### PR TITLE
[RST-1121] Moved the Variable class into the public fuse repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2018, Locus Robotics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # fuse
-The fuse stack provides a general architecture for performing sensor fusion live on a robot. Some possible applications include state estimation, localization, mapping, and calibration.
+The fuse stack provides a general architecture for performing sensor fusion live on a robot. Some possible applications
+include state estimation, localization, mapping, and calibration.

--- a/fuse/CMakeLists.txt
+++ b/fuse/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/fuse/LICENSE
+++ b/fuse/LICENSE
@@ -1,0 +1,31 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2018, Locus Robotics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/fuse/README.md
+++ b/fuse/README.md
@@ -1,0 +1,2 @@
+# fuse
+This is the metapackage for the entire fuse stack.

--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse</name>
+  <version>0.0.0</version>
+  <description>
+    The fuse metapackage
+  </description>
+
+  <maintainer email="swilliams@locusrobotics.com">Stephen Williams</maintainer>
+  <author email="swilliams@locusrobotics.com">Stephen Williams</author>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>fuse_core</exec_depend>
+
+  <export>
+    <metapackage />
+  </export>
+</package>

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -67,9 +67,35 @@ install(
 #############
 
 if(CATKIN_ENABLE_TESTING)
-  # Lint tests
   find_package(roslint REQUIRED)
+  find_package(rostest REQUIRED)
+
+  # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
   roslint_cpp()
   roslint_add_test()
+
+  # Constraint tests
+  catkin_add_gtest(test_constraint
+    test/test_constraint.cpp
+  )
+  add_dependencies(test_constraint
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_link_libraries(test_constraint
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+
+  # Variable tests
+  catkin_add_gtest(test_variable
+    test/test_variable.cpp
+  )
+  add_dependencies(test_variable
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_link_libraries(test_variable
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(
 
 ## fuse_core library
 add_library(${PROJECT_NAME}
+  src/constraint.cpp
   src/variable.cpp
 )
 add_dependencies(${PROJECT_NAME}

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse_core)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
+find_package(Boost REQUIRED)
+find_package(Ceres REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS
+    include
+    ${CERES_INCLUDE_DIRS}
+  LIBRARIES
+    ${PROJECT_NAME}
+    ${CERES_LIBRARIES}
+  CATKIN_DEPENDS
+    roscpp
+  DEPENDS
+    Boost
+)
+
+###########
+## Build ##
+###########
+
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+
+include_directories(
+  include
+  ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${CERES_INCLUDE_DIRS}
+)
+
+## fuse_core library
+add_library(${PROJECT_NAME}
+  src/variable.cpp
+)
+add_dependencies(${PROJECT_NAME}
+  ${catkin_EXPORTED_TARGETS}
+)
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${CERES_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(
+  DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  # Lint tests
+  find_package(roslint REQUIRED)
+  set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
+  roslint_cpp()
+  roslint_add_test()
+endif()

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -84,6 +84,17 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(test_constraint
     ${PROJECT_NAME}
+  )
+
+  # UUID tests
+  catkin_add_gtest(test_uuid
+    test/test_uuid.cpp
+  )
+  add_dependencies(test_uuid
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_link_libraries(test_uuid
+    ${PROJECT_NAME}
     ${catkin_LIBRARIES}
   )
 
@@ -96,6 +107,5 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(test_variable
     ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
   )
 endif()

--- a/fuse_core/LICENSE
+++ b/fuse_core/LICENSE
@@ -1,0 +1,31 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2018, Locus Robotics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/fuse_core/README.md
+++ b/fuse_core/README.md
@@ -1,0 +1,25 @@
+# fuse_core
+This package provides the base class interfaces for the various fuse components. Concrete implementations of these
+interfaces are provided in other packages.
+
+## Variable
+Within the fuse system, a "variable" is a convenient group of one or more related scalar values. These scalars are
+treated as a block within the optimizer. If the variable is modeling a time-varying quatity, the an instance of the
+variable represents value of the state at one specific point in time. The fuse system maintains a history of variable
+instances, allowing measurements to involve previous states as well as the current state.
+
+When defining a new variable type, there is a balance that must be struct between reusability and convenience. If you
+define a complex composite state, it is unlikely that any other available components will use that same state
+definition. If you make the state too granular, then more book-keeping and value lookups will be required to piece
+together a useful concept from many smallar scalar components.
+
+As an example, let's consider a 3D pose consisting of a 3D position (x, y, z) and a quaternion orientation
+(qx, qy, qx, qw). We could define a single state for the 3D pose consisting of all 7 scalar components. Alternatively,
+we could define two variables types, a 3 dimension position vector and a 4 dimension quaternion. Or we could even
+define seven variable types, one for each dimension.
+
+Within the `fuse_core` package, no concrete variables are actually created. We only define the common interface to which
+all types must adhere. A set of common variable types are provided in the [`fuse_variables`](../fuse_variables)
+package. And new variable types can be created outside the fuse stack completely. However, similar to how using common
+ROS messages across nodes allow for code reuse, using common variable types will allow sensor models and motion models
+to be shared across the community.

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -1,0 +1,199 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_CONSTRAINT_H
+#define FUSE_CORE_CONSTRAINT_H
+
+#include <fuse_core/uuid.h>
+#include <fuse_core/macros.h>
+
+#include <boost/core/demangle.hpp>
+#include <ceres/cost_function.h>
+#include <ceres/loss_function.h>
+
+#include <initializer_list>
+#include <ostream>
+#include <string>
+#include <vector>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief The Constraint interface definition.
+ *
+ * A Constraint defines a cost function that is connected to one or more variables. This base class defines the
+ * required interface of all Constraint objects, and holds the ordered list of involved variable UUIDs. All other
+ * functionality is left to the derived classes to implement.
+ *
+ * Most importantly, the implementation of the cost function is left to the derived classes, allowing arbitrarily
+ * complex sensor models to be implemented outside of the core fuse packages. The cost function must be a valid
+ * ceres::CostFunction object. Ceres provides many nice features to make implementing the cost function easier,
+ * including an automatic differentiation system. Please see the Ceres documentation for details on creating valid
+ * ceres::CostFunction objects (http://ceres-solver.org/nnls_modeling.html). In addition to the cost function itself,
+ * an optional loss function may be provided. Loss functions provide a mechanism for reducing the impact of outlier
+ * measurements on the final optimization results. Again, see the Ceres documentation for details
+ * (http://ceres-solver.org/nnls_modeling.html#lossfunction).
+ */
+class Constraint
+{
+public:
+  SMART_PTR_ALIASES_ONLY(Constraint);
+
+  /**
+   * @brief Constructor
+   *
+   * Accepts an arbitrary number of variable UUIDs directly. It can be called like:
+   * @code{.cpp}
+   * Constraint{uuid1, uuid2, uuid3};
+   * @endcode
+   *
+   * @param[in] variable_uuid_list The list of involved variable UUIDs
+   */
+  Constraint(std::initializer_list<UUID> variable_uuid_list);
+
+  /**
+   * @brief Constructor
+   *
+   * Accepts an arbitrary number of variable UUIDs stored in a container using iterators.
+   */
+  template<typename VariableUuidIterator>
+  Constraint(VariableUuidIterator first, VariableUuidIterator last);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~Constraint() = default;
+
+  /**
+   * @brief Returns a unique name for this constraint type.
+   *
+   * The constraint type string must be unique for each class. As such, the fully-qualified class name is an excellent
+   * choice for the type string.
+   */
+  virtual std::string type() const { return boost::core::demangle(typeid(*this).name()); }
+
+  /**
+   * @brief Returns the UUID for this constraint.
+   *
+   * Each constraint will generate a unique, random UUID during construction.
+   */
+  UUID uuid() const { return uuid_; }
+
+  /**
+   * @brief Print a human-readable description of the constraint to the provided stream.
+   *
+   * @param  stream The stream to write to. Defaults to stdout.
+   */
+  virtual void print(std::ostream& stream = std::cout) const = 0;
+
+  /**
+   * @brief Create a new Ceres cost function and return a raw pointer to it.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
+   * delete the cost function when it is done. Additionally, fuse promises that the Constraint object will outlive any
+   * generated cost functions (i.e. the Ceres objects will be destroyed before the Constraint objects). This guarantee
+   * may allow optimizations for the creation of the cost function objects.
+   *
+   * @return A base pointer to an instance of a derived ceres::CostFunction.
+   */
+  virtual ceres::CostFunction* costFunction() const = 0;
+
+  /**
+   * @brief Create a new Ceres loss function and return a raw pointer to it.
+   *
+   * See http://ceres-solver.org/nnls_modeling.html#lossfunction for a detailed description about loss functions.
+   * Basically, a loss function defines the penalty associated with a specific amount error. By default, or if a NULL
+   * pointer is provided as the loss function, the penalty will be quadratic. This is the loss function associated
+   * with standard least-squares optimization. By providing a different loss function, the penalty for the constraint's
+   * error can be altered.
+   *
+   * This is generally done to reduce the effect of outlier measurements that made it into the optimization problem.
+   * It is always better to remove outliers before they make it into the optimization problem, but no method is perfect.
+   * Using robust loss functions can significantly improve the results and stability of the solution in the presence
+   * of outlier measurements.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
+   * delete the loss function when it is done. Additionally, Fuse promises that the Constraint object will outlive any
+   * generated loss functions (i.e. the Ceres objects will be destroyed before the Constraint objects). This guarantee
+   * may allow optimizations for the creation of the loss function objects.
+   *
+   * @return A base pointer to an instance of a derived ceres::LostFunction.
+   */
+  virtual ceres::LossFunction* lossFunction() const
+  {
+    return nullptr;
+  }
+
+  /**
+   * @brief Perform a deep copy of the Constraint and return a unique pointer to the copy
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * return Derived::make_unique(*this);
+   * @endcode
+   *
+   * @return A unique pointer to a new instance of the most-derived Constraint
+   */
+  virtual Constraint::UniquePtr clone() const = 0;
+
+  /**
+   * @brief Read-only access to the ordered list of variable UUIDs involved in this constraint
+   */
+  const std::vector<UUID>& variables() const { return variables_; }
+
+protected:
+  fuse_core::UUID uuid_;  //!< The unique ID associated with this constraint
+  std::vector<UUID> variables_;  //!< The ordered set of variables involved with this constraint
+};
+
+/**
+ * Stream operator implementation used for all derived Constraint classes.
+ */
+std::ostream& operator <<(std::ostream& stream, const Constraint& constraint);
+
+
+template<typename VariableUuidIterator>
+Constraint::Constraint(VariableUuidIterator first, VariableUuidIterator last) :
+  uuid_(fuse_core::uuid::generate())
+{
+  while (first != last)
+  {
+    variables_.push_back(*first++);
+  }
+}
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_CONSTRAINT_H

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -109,7 +109,7 @@ public:
    *
    * Each constraint will generate a unique, random UUID during construction.
    */
-  UUID uuid() const { return uuid_; }
+  const UUID& uuid() const { return uuid_; }
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -174,7 +174,7 @@ public:
   const std::vector<UUID>& variables() const { return variables_; }
 
 protected:
-  fuse_core::UUID uuid_;  //!< The unique ID associated with this constraint
+  UUID uuid_;  //!< The unique ID associated with this constraint
   std::vector<UUID> variables_;  //!< The ordered set of variables involved with this constraint
 };
 
@@ -186,7 +186,7 @@ std::ostream& operator <<(std::ostream& stream, const Constraint& constraint);
 
 template<typename VariableUuidIterator>
 Constraint::Constraint(VariableUuidIterator first, VariableUuidIterator last) :
-  uuid_(fuse_core::uuid::generate())
+  uuid_(uuid::generate())
 {
   while (first != last)
   {

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -1,0 +1,135 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/***************************************************************************
+ * This file has been modified from its original published source.
+ * https://raw.githubusercontent.com/ros2/rclcpp/master/rclcpp/include/rclcpp/macros.hpp
+ * Modifications are provided under the BSD license.
+ ***************************************************************************/
+
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_CORE_MACROS_H
+#define FUSE_CORE_MACROS_H
+
+#include <memory>
+
+/**
+ * Defines aliases and static functions for using the Class with smart pointers.
+ *
+ * Use in the public section of the class.
+ */
+#define SMART_PTR_DEFINITIONS(...) \
+  SHARED_PTR_DEFINITIONS(__VA_ARGS__) \
+  WEAK_PTR_DEFINITIONS(__VA_ARGS__) \
+  UNIQUE_PTR_DEFINITIONS(__VA_ARGS__)
+
+/**
+ * Defines aliases only for using the Class with smart pointers.
+ *
+ * Same as SMART_PTR_DEFINITIONS except it excludes the static
+ * method definitions which do not work on pure virtual classes and classes
+ * which are not CopyConstructable.
+ *
+ * Use in the public section of the class.
+ */
+#define SMART_PTR_ALIASES_ONLY(...) \
+  __SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __WEAK_PTR_ALIAS(__VA_ARGS__) \
+  __UNIQUE_PTR_ALIAS(__VA_ARGS__)
+
+/// Defines aliases and static functions for using the Class with shared_ptrs.
+#define SHARED_PTR_DEFINITIONS(...) \
+  __SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __MAKE_SHARED_DEFINITION(__VA_ARGS__)
+
+#define __SHARED_PTR_ALIAS(...) \
+  using SharedPtr = std::shared_ptr<__VA_ARGS__>; \
+  using ConstSharedPtr = std::shared_ptr<const __VA_ARGS__>;
+
+#define __MAKE_SHARED_DEFINITION(...) \
+  template<typename ... Args> \
+  static std::shared_ptr<__VA_ARGS__> \
+  make_shared(Args && ... args) \
+  { \
+    return std::make_shared<__VA_ARGS__>(std::forward<Args>(args) ...); \
+  }
+
+/// Defines aliases and static functions for using the Class with weak_ptrs.
+#define WEAK_PTR_DEFINITIONS(...) \
+  __WEAK_PTR_ALIAS(__VA_ARGS__)
+
+#define __WEAK_PTR_ALIAS(...) \
+  using WeakPtr = std::weak_ptr<__VA_ARGS__>; \
+  using ConstWeakPtr = std::weak_ptr<const __VA_ARGS__>;
+
+/// Defines aliases and static functions for using the Class with unique_ptrs.
+#define UNIQUE_PTR_DEFINITIONS(...) \
+  __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+  __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
+
+#define __UNIQUE_PTR_ALIAS(...) \
+  using UniquePtr = std::unique_ptr<__VA_ARGS__>;
+
+#if __cplusplus >= 201402L
+  #define __MAKE_UNIQUE_DEFINITION(...) \
+  template<typename ... Args> \
+  static std::unique_ptr<__VA_ARGS__> \
+  make_unique(Args && ... args) \
+  { \
+    return std::make_unique<__VA_ARGS__>(std::forward<Args>(args) ...); \
+  }
+#else
+  #define __MAKE_UNIQUE_DEFINITION(...) \
+  template<typename ... Args> \
+  static std::unique_ptr<__VA_ARGS__> \
+  make_unique(Args && ... args) \
+  { \
+    return std::unique_ptr<__VA_ARGS__>(new __VA_ARGS__(std::forward<Args>(args) ...)); \
+  }
+#endif
+
+#endif  // FUSE_CORE_MACROS_H

--- a/fuse_core/include/fuse_core/uuid.h
+++ b/fuse_core/include/fuse_core/uuid.h
@@ -1,0 +1,192 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_UUID_H
+#define FUSE_CORE_UUID_H
+
+#include <ros/time.h>
+
+#include <boost/functional/hash.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+
+namespace fuse_core
+{
+
+using UUID = boost::uuids::uuid;
+
+namespace uuid
+{
+  using boost::uuids::to_string;
+  using hash = boost::hash<UUID>;
+  constexpr UUID NIL = {{0}};
+
+  /**
+   * @brief Generate a random UUID
+   */
+  inline UUID generate()
+  {
+    return boost::uuids::random_generator()();
+  }
+
+  /**
+   * @brief Generate a UUID from a raw data buffer
+   *
+   * @param[in] data       A data buffer containing information that makes this item unique
+   * @param[in] byte_count The number of bytes in the data buffer
+   * @return               A repeatable UUID specific to the provided data
+   */
+  inline UUID generate(const void* data, size_t byte_count)
+  {
+    return boost::uuids::name_generator(NIL)(data, byte_count);
+  }
+
+  /**
+   * @brief Generate a UUID from a C-style string
+   *
+   * @param[in] data A data buffer held in a C-style string
+   * @return         A repeatable UUID specific to the provided data
+   */
+  inline UUID generate(const char* data)
+  {
+    return generate(data, std::strlen(data));
+  }
+
+  /**
+   * @brief Generate a UUID from a C++ string
+   *
+   * @param[in] data A data buffer held in a C++-style string
+   * @return         A repeatable UUID specific to the provided namespace and data
+   */
+  inline UUID generate(const std::string& data)
+  {
+    return generate(data.c_str(), data.length());
+  }
+
+  /**
+   * @brief Generate a UUID from a namespace string and a raw data buffer
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] data             A data buffer containing information that makes this item unique
+   * @param[in] byte_count       The number of bytes in the data buffer
+   * @return                     A repeatable UUID specific to the provided namespace and data
+   */
+  inline UUID generate(const std::string& namespace_string, const void* data, size_t byte_count)
+  {
+    return boost::uuids::name_generator(generate(namespace_string))(data, byte_count);
+  }
+
+  /**
+   * @brief Generate a UUID from a namespace string and C-style string
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] data             A data buffer held in a C-style string
+   * @return                     A repeatable UUID specific to the provided namespace and data
+   */
+  inline UUID generate(const std::string& namespace_string, const char* data)
+  {
+    return generate(namespace_string, data, std::strlen(data));
+  }
+
+  /**
+   * @brief Generate a UUID from a namespace string and a C++ string
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] data             A data buffer held in a C++-style string
+   * @return                     A repeatable UUID specific to the provided namespace and data
+   */
+  inline UUID generate(const std::string& namespace_string, const std::string& data)
+  {
+    return generate(namespace_string, data.c_str(), data.length());
+  }
+
+  /**
+   * @brief Generate a UUID from a namespace string and a ros timestamp
+   *
+   * Every unique timestamp will generate a unique UUID
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] stamp            A ROS::Time timestamp
+   * @return                     A repeatable UUID specific to the provided namespace and timestamp
+   */
+  inline UUID generate(const std::string& namespace_string, const ros::Time& stamp)
+  {
+    constexpr size_t buffer_size = sizeof(stamp.sec) + sizeof(stamp.nsec);
+    std::array<unsigned char, buffer_size> buffer;
+    auto iter = buffer.begin();
+    iter = std::copy(reinterpret_cast<const unsigned char*>(&stamp.sec),
+                     reinterpret_cast<const unsigned char*>(&stamp.sec) + sizeof(stamp.sec),
+                     iter);
+    iter = std::copy(reinterpret_cast<const unsigned char*>(&stamp.nsec),
+                     reinterpret_cast<const unsigned char*>(&stamp.nsec) + sizeof(stamp.nsec),
+                     iter);
+    return generate(namespace_string, buffer.data(), buffer.size());
+  }
+
+  /**
+   * @brief Generate a UUID from a namespace string, a ros timestamp, and an additional id
+   *
+   * Every unique timestamp and id pair will generate a unique UUID
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] stamp            A ROS::Time timestamp
+   * @param[in] id               A UUID
+   * @return                     A repeatable UUID specific to the provided namespace and timestamp
+   */
+  inline UUID generate(const std::string& namespace_string, const ros::Time& stamp, const UUID& id)
+  {
+    constexpr size_t buffer_size = sizeof(stamp.sec) + sizeof(stamp.nsec) + UUID::static_size();
+    std::array<unsigned char, buffer_size> buffer;
+    auto iter = buffer.begin();
+    iter = std::copy(reinterpret_cast<const unsigned char*>(&stamp.sec),
+                     reinterpret_cast<const unsigned char*>(&stamp.sec) + sizeof(stamp.sec),
+                     iter);
+    iter = std::copy(reinterpret_cast<const unsigned char*>(&stamp.nsec),
+                     reinterpret_cast<const unsigned char*>(&stamp.nsec) + sizeof(stamp.nsec),
+                     iter);
+    iter = std::copy(id.begin(),
+                     id.end(),
+                     iter);
+    return generate(namespace_string, buffer.data(), buffer.size());
+  }
+}  // namespace uuid
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_UUID_H

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -1,0 +1,180 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_VARIABLE_H
+#define FUSE_CORE_VARIABLE_H
+
+#include <fuse_core/uuid.h>
+#include <fuse_core/macros.h>
+
+#include <boost/core/demangle.hpp>
+#include <ceres/local_parameterization.h>
+
+#include <ostream>
+#include <string>
+#include <typeinfo>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief The Variable interface definition.
+ *
+ * A Variable defines some semantically meaningful group of one or more individual scale values. Each variable is
+ * treated as a block by the optimization engine, as the values of all of its dimensions are likely to be involved
+ * in the same constraints. Some common examples of variable groupings are a 2D point (x, y), 3D point (x, y, z), or
+ * camera calibration parameters (fx, fy, cx, cy).
+ *
+ * To support the Ceres optimization engine, the Variable must hold the scalar values of each dimension in a
+ * _contiguous_ memory space, and must provide access to that memory location via the Variable::data() methods.
+ *
+ * Some Variables may require special update rules, either because they are over-parameterized, as is the case with
+ * 3D rotations represented as quaternions, or because the update of the individual dimensions exhibit some nonlinear
+ * properties, as is the case with rotations in general (e.g. 2D rotations have a discontinuity around &pi;). To
+ * support these situations, Ceres uses an optional "local parameterization". See the Ceres documentation for more
+ * details. http://ceres-solver.org/nnls_modeling.html#localparameterization
+ */
+class Variable
+{
+public:
+  SMART_PTR_ALIASES_ONLY(Variable);
+
+  /**
+   * @brief Constructor
+   */
+  Variable() = default;
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~Variable() = default;
+
+  /**
+   * @brief Returns a unique name for this variable type.
+   *
+   * The variable type string must be unique for each class. As such, the fully-qualified class name is an excellent
+   * choice for the type string.
+   */
+  virtual std::string type() const { return boost::core::demangle(typeid(*this).name()); }
+
+  /**
+   * @brief Returns a UUID for this variable.
+   *
+   * The implemented UUID generation should be deterministic such that a variable with the same metadata will always
+   * return the same UUID. Identical UUIDs produced by sensors will be treated as the same variable by the optimizer,
+   * and different UUIDs will be treated as different variables. So, two derived variables representing robot poses with
+   * the same timestamp but different UUIDs will incorrectly be treated as different variables, and two robot poses with
+   * different timestamps but the same UUID will be incorrectly treated as the same variable.
+   *
+   * One method of producing UUIDs that adhere to this requirement is to use the boost::uuid::name_generator() function.
+   * The type() string can be used to generate a UUID namespace for all variables of a given derived type, and the
+   * variable metadata of consequence can be converted into a carefully-formatted string or byte array and provided to
+   * the generator to create the UUID for a specific variable instance.
+   */
+  virtual UUID uuid() const = 0;
+
+  /**
+   * @brief Returns the number of elements of this variable.
+   *
+   * In most cases, this will be the number of degrees of freedom this variable represents. For example, a 2D pose has
+   * an x, y, and theta value, so the size will be 3. A notable exception is a 3D rotation represented as a quaternion.
+   * It only has 3 degrees of freedom, but it is represented as four elements, (w, x, y, z), so it's size will be 4.
+   */
+  virtual size_t size() const = 0;
+
+  /**
+   * @brief Read-only access to the variable data
+   *
+   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
+   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * interface is provided for integration with Ceres, which uses raw pointers.
+   */
+  virtual const double* data() const = 0;
+
+  /**
+   * @brief Read-write access to the variable data
+   *
+   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
+   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * interface is provided for integration with Ceres, which uses raw pointers.
+   */
+  virtual double* data() = 0;
+
+  /**
+   * @brief Print a human-readable description of the variable to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  virtual void print(std::ostream& stream = std::cout) const = 0;
+
+  /**
+   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
+   *
+   * Unique pointers can be implicitly upgraded to shared pointers if needed.
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * return Derived::make_unique(*this);
+   * @endcode
+   *
+   * @return A unique pointer to a new instance of the most-derived Variable
+   */
+  virtual Variable::UniquePtr clone() const = 0;
+
+  /**
+   * @brief Create a new Ceres local parameterization object to apply to updates of this variable
+   *
+   * If a local parameterization is not needed, a null pointer should be returned.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
+   * delete the local parameterization when it is done. Additionally, fuse promises that the Variable object will
+   * outlive any generated local parameterization (i.e. the Ceres objects will be destroyed before the Variable
+   * objects). This guarantee may allow optimizations for the creation of the local parameterization objects.
+   *
+   * @return A base pointer to an instance of a derived LocalParameterization
+   */
+  virtual ceres::LocalParameterization* localParameterization() const
+  {
+    return nullptr;
+  }
+};
+
+/**
+ * Stream operator implementation used for all derived Constraint classes.
+ */
+std::ostream& operator <<(std::ostream& stream, const Variable& variable);
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_VARIABLE_H

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse_core</name>
+  <version>0.0.0</version>
+  <description>
+    The fuse_core package provides the base class interfaces for the various fuse components. Concrete implementations of these
+    interfaces are provided in other packages.
+  </description>
+
+  <maintainer email="swilliams@locusrobotics.com">Stephen Williams</maintainer>
+  <author email="swilliams@locusrobotics.com">Stephen Williams</author>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>ceres-solver</depend>
+  <depend>roscpp</depend>
+  <test_depend>roslint</test_depend>
+</package>

--- a/fuse_core/src/constraint.cpp
+++ b/fuse_core/src/constraint.cpp
@@ -1,0 +1,52 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/constraint.h>
+
+
+namespace fuse_core
+{
+
+Constraint::Constraint(std::initializer_list<UUID> variable_uuid_list) :
+  uuid_(fuse_core::uuid::generate()),
+  variables_(variable_uuid_list)
+{
+}
+
+std::ostream& operator <<(std::ostream& stream, const Constraint& constraint)
+{
+  constraint.print(stream);
+  return stream;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/constraint.cpp
+++ b/fuse_core/src/constraint.cpp
@@ -38,7 +38,7 @@ namespace fuse_core
 {
 
 Constraint::Constraint(std::initializer_list<UUID> variable_uuid_list) :
-  uuid_(fuse_core::uuid::generate()),
+  uuid_(uuid::generate()),
   variables_(variable_uuid_list)
 {
 }

--- a/fuse_core/src/variable.cpp
+++ b/fuse_core/src/variable.cpp
@@ -1,0 +1,46 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/variable.h>
+
+
+namespace fuse_core
+{
+
+std::ostream& operator <<(std::ostream& stream, const Variable& variable)
+{
+  variable.print(stream);
+  return stream;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/test/example_constraint.h
+++ b/fuse_core/test/example_constraint.h
@@ -31,19 +31,38 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include "example_variable.h"
+#ifndef FUSE_CORE_TEST_EXAMPLE_CONSTRAINT_H
+#define FUSE_CORE_TEST_EXAMPLE_CONSTRAINT_H
 
-#include <gtest/gtest.h>
+#include <fuse_core/constraint.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/uuid.h>
+
+#include <initializer_list>
 
 
-TEST(Variable, Type)
+/**
+ * @brief Dummy constraint implementation for testing
+ */
+class ExampleConstraint : public fuse_core::Constraint
 {
-  ExampleVariable variable;
-  ASSERT_EQ("ExampleVariable", variable.type());
-}
+public:
+  SMART_PTR_DEFINITIONS(ExampleConstraint);
 
-int main(int argc, char **argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+  ExampleConstraint(std::initializer_list<fuse_core::UUID> variable_uuid_list) :
+    fuse_core::Constraint(variable_uuid_list)
+  {
+  }
+
+  template<typename VariableUuidIterator>
+  ExampleConstraint(VariableUuidIterator first, VariableUuidIterator last) :
+    fuse_core::Constraint(first, last)
+  {
+  }
+
+  void print(std::ostream& stream = std::cout) const override {}
+  ceres::CostFunction* costFunction() const override { return nullptr; }
+  fuse_core::Constraint::UniquePtr clone() const override { return ExampleConstraint::make_unique(*this); }
+};
+
+#endif  // FUSE_CORE_TEST_EXAMPLE_CONSTRAINT_H

--- a/fuse_core/test/example_variable.h
+++ b/fuse_core/test/example_variable.h
@@ -31,19 +31,38 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include "example_variable.h"
+#ifndef FUSE_CORE_TEST_EXAMPLE_VARIABLE_H
+#define FUSE_CORE_TEST_EXAMPLE_VARIABLE_H
 
-#include <gtest/gtest.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 
 
-TEST(Variable, Type)
+/**
+ * @brief Dummy variable implementation for testing
+ */
+class ExampleVariable : public fuse_core::Variable
 {
-  ExampleVariable variable;
-  ASSERT_EQ("ExampleVariable", variable.type());
-}
+public:
+  SMART_PTR_DEFINITIONS(ExampleVariable);
 
-int main(int argc, char **argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+  ExampleVariable() :
+    data_(0.0),
+    uuid_(fuse_core::uuid::generate())
+  {
+  }
+
+  fuse_core::UUID uuid() const override { return uuid_; }
+  size_t size() const override { return 1; }
+  const double* data() const override { return &data_; };
+  double* data() override { return &data_; };
+  void print(std::ostream& stream = std::cout) const override {}
+  fuse_core::Variable::UniquePtr clone() const override { return ExampleVariable::make_unique(*this); }
+
+private:
+  double data_;
+  fuse_core::UUID uuid_;
+};
+
+#endif  // FUSE_CORE_TEST_EXAMPLE_VARIABLE_H

--- a/fuse_core/test/test_constraint.cpp
+++ b/fuse_core/test/test_constraint.cpp
@@ -1,0 +1,116 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/constraint.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/uuid.h>
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <vector>
+
+
+/**
+ * @brief Dummy constraint implementation for testing
+ */
+class TestConstraint : public fuse_core::Constraint
+{
+public:
+  SMART_PTR_DEFINITIONS(TestConstraint);
+
+  TestConstraint(std::initializer_list<fuse_core::UUID> variable_uuid_list) :
+    fuse_core::Constraint(variable_uuid_list)
+  {
+  }
+
+  template<typename VariableUuidIterator>
+  TestConstraint(VariableUuidIterator first, VariableUuidIterator last) :
+    fuse_core::Constraint(first, last)
+  {
+  }
+
+  void print(std::ostream& stream = std::cout) const override {}
+  ceres::CostFunction* costFunction() const override { return nullptr; }
+  fuse_core::Constraint::UniquePtr clone() const override { return TestConstraint::make_unique(*this); }
+};
+
+
+TEST(Constraint, Constructor)
+{
+  // Create a constraint with a single UUID
+  {
+    fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
+    TestConstraint constraint{variable_uuid1};
+    ASSERT_EQ(1, constraint.variables().size());
+    ASSERT_EQ(variable_uuid1, constraint.variables().at(0));
+  }
+  // Create a constraint with multiple UUIDs
+  {
+    fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
+    fuse_core::UUID variable_uuid2 = fuse_core::uuid::generate();
+    fuse_core::UUID variable_uuid3 = fuse_core::uuid::generate();
+    TestConstraint constraint{variable_uuid1, variable_uuid2, variable_uuid3};
+    ASSERT_EQ(3, constraint.variables().size());
+    ASSERT_EQ(variable_uuid1, constraint.variables().at(0));
+    ASSERT_EQ(variable_uuid2, constraint.variables().at(1));
+    ASSERT_EQ(variable_uuid3, constraint.variables().at(2));
+  }
+  // Create a constraint using the iterator constructor
+  {
+    std::vector<fuse_core::UUID> variable_uuids;
+    variable_uuids.push_back(fuse_core::uuid::generate());
+    variable_uuids.push_back(fuse_core::uuid::generate());
+    variable_uuids.push_back(fuse_core::uuid::generate());
+    variable_uuids.push_back(fuse_core::uuid::generate());
+    TestConstraint constraint(variable_uuids.begin(), variable_uuids.end());
+    ASSERT_EQ(variable_uuids.size(), constraint.variables().size());
+    for (size_t i = 0; i < variable_uuids.size(); ++i)
+    {
+      ASSERT_EQ(variable_uuids.at(i), constraint.variables().at(i));
+    }
+  }
+}
+
+TEST(Constraint, Type)
+{
+  fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
+  TestConstraint constraint{variable_uuid1};
+  ASSERT_EQ("TestConstraint", constraint.type());
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_core/test/test_constraint.cpp
+++ b/fuse_core/test/test_constraint.cpp
@@ -31,39 +31,12 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include "example_constraint.h"
 #include <fuse_core/uuid.h>
 
 #include <gtest/gtest.h>
 
-#include <initializer_list>
 #include <vector>
-
-
-/**
- * @brief Dummy constraint implementation for testing
- */
-class TestConstraint : public fuse_core::Constraint
-{
-public:
-  SMART_PTR_DEFINITIONS(TestConstraint);
-
-  TestConstraint(std::initializer_list<fuse_core::UUID> variable_uuid_list) :
-    fuse_core::Constraint(variable_uuid_list)
-  {
-  }
-
-  template<typename VariableUuidIterator>
-  TestConstraint(VariableUuidIterator first, VariableUuidIterator last) :
-    fuse_core::Constraint(first, last)
-  {
-  }
-
-  void print(std::ostream& stream = std::cout) const override {}
-  ceres::CostFunction* costFunction() const override { return nullptr; }
-  fuse_core::Constraint::UniquePtr clone() const override { return TestConstraint::make_unique(*this); }
-};
 
 
 TEST(Constraint, Constructor)
@@ -71,7 +44,7 @@ TEST(Constraint, Constructor)
   // Create a constraint with a single UUID
   {
     fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
-    TestConstraint constraint{variable_uuid1};
+    ExampleConstraint constraint{variable_uuid1};
     ASSERT_EQ(1, constraint.variables().size());
     ASSERT_EQ(variable_uuid1, constraint.variables().at(0));
   }
@@ -80,7 +53,7 @@ TEST(Constraint, Constructor)
     fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
     fuse_core::UUID variable_uuid2 = fuse_core::uuid::generate();
     fuse_core::UUID variable_uuid3 = fuse_core::uuid::generate();
-    TestConstraint constraint{variable_uuid1, variable_uuid2, variable_uuid3};
+    ExampleConstraint constraint{variable_uuid1, variable_uuid2, variable_uuid3};
     ASSERT_EQ(3, constraint.variables().size());
     ASSERT_EQ(variable_uuid1, constraint.variables().at(0));
     ASSERT_EQ(variable_uuid2, constraint.variables().at(1));
@@ -93,11 +66,26 @@ TEST(Constraint, Constructor)
     variable_uuids.push_back(fuse_core::uuid::generate());
     variable_uuids.push_back(fuse_core::uuid::generate());
     variable_uuids.push_back(fuse_core::uuid::generate());
-    TestConstraint constraint(variable_uuids.begin(), variable_uuids.end());
+    ExampleConstraint constraint(variable_uuids.begin(), variable_uuids.end());
     ASSERT_EQ(variable_uuids.size(), constraint.variables().size());
     for (size_t i = 0; i < variable_uuids.size(); ++i)
     {
       ASSERT_EQ(variable_uuids.at(i), constraint.variables().at(i));
+    }
+  }
+  // Copy constructor
+  {
+    fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
+    fuse_core::UUID variable_uuid2 = fuse_core::uuid::generate();
+    fuse_core::UUID variable_uuid3 = fuse_core::uuid::generate();
+    ExampleConstraint constraint1{variable_uuid1, variable_uuid2, variable_uuid3};
+    ExampleConstraint constraint2(constraint1);
+
+    ASSERT_EQ(constraint1.uuid(), constraint2.uuid());
+    ASSERT_EQ(constraint1.variables().size(), constraint2.variables().size());
+    for (size_t i = 0; i < constraint1.variables().size(); ++i)
+    {
+      ASSERT_EQ(constraint1.variables().at(i), constraint2.variables().at(i));
     }
   }
 }
@@ -105,8 +93,8 @@ TEST(Constraint, Constructor)
 TEST(Constraint, Type)
 {
   fuse_core::UUID variable_uuid1 = fuse_core::uuid::generate();
-  TestConstraint constraint{variable_uuid1};
-  ASSERT_EQ("TestConstraint", constraint.type());
+  ExampleConstraint constraint{variable_uuid1};
+  ASSERT_EQ("ExampleConstraint", constraint.type());
 }
 
 int main(int argc, char **argv)

--- a/fuse_core/test/test_uuid.cpp
+++ b/fuse_core/test/test_uuid.cpp
@@ -1,0 +1,153 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/uuid.h>
+#include <ros/time.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+
+using fuse_core::UUID;
+
+
+TEST(UUID, Generate)
+{
+  // These tests are mostly just calling the different generate() signatures to verify they compile and work.
+  // It's hard to validate that the "correct" random number has been generated. :)
+
+  // Just get a random number
+  {
+    UUID id1 = fuse_core::uuid::generate();
+    UUID id2 = fuse_core::uuid::generate();
+    ASSERT_NE(id1, id2);
+  }
+  // Generate a UUID from a data buffer. The same buffer contents should always generate the same UUID.
+  {
+    std::string buffer1 = "Curse your sudden but inevitable betrayal!";
+    std::string buffer2 = "Man walks down the street in a hat like that, you know he's not afraid of anything.";
+    UUID id1 = fuse_core::uuid::generate(buffer1.data(), buffer1.size());
+    UUID id2 = fuse_core::uuid::generate(buffer1.data(), buffer1.size());
+    UUID id3 = fuse_core::uuid::generate(buffer2.data(), buffer2.size());
+    ASSERT_EQ(id1, id2);
+    ASSERT_NE(id1, id3);
+
+    UUID id4 = fuse_core::uuid::generate(buffer1.c_str());
+    UUID id5 = fuse_core::uuid::generate(buffer1.c_str());
+    UUID id6 = fuse_core::uuid::generate(buffer2.c_str());
+    ASSERT_EQ(id4, id1);
+    ASSERT_EQ(id4, id5);
+    ASSERT_NE(id4, id6);
+
+    UUID id7 = fuse_core::uuid::generate(buffer1);
+    UUID id8 = fuse_core::uuid::generate(buffer1);
+    UUID id9 = fuse_core::uuid::generate(buffer2);
+    ASSERT_EQ(id7, id1);
+    ASSERT_EQ(id7, id8);
+    ASSERT_NE(id7, id9);
+  }
+  // Generate a UUID from a namespace and a data buffer. The same name and buffer should always generate the same UUID.
+  {
+    std::string name1 = "Jayne";
+    std::string name2 = "Hoban";
+    std::string buffer1 = "Ten percent of nothing is, let me do the math here. Nothing into nothin'. Carry the nothin'";
+    std::string buffer2 = "Some people juggle geese.";
+
+    UUID id1 = fuse_core::uuid::generate(name1, buffer1.data(), buffer1.size());
+    UUID id2 = fuse_core::uuid::generate(name1, buffer1.data(), buffer1.size());
+    UUID id3 = fuse_core::uuid::generate(name1, buffer2.data(), buffer2.size());
+    UUID id4 = fuse_core::uuid::generate(name2, buffer2.data(), buffer2.size());
+    ASSERT_EQ(id1, id2);
+    ASSERT_NE(id1, id3);
+    ASSERT_NE(id1, id4);
+
+    UUID id5 = fuse_core::uuid::generate(name1, buffer1.c_str());
+    UUID id6 = fuse_core::uuid::generate(name1, buffer1.c_str());
+    UUID id7 = fuse_core::uuid::generate(name1, buffer2.c_str());
+    UUID id8 = fuse_core::uuid::generate(name2, buffer2.c_str());
+    ASSERT_EQ(id5, id1);
+    ASSERT_EQ(id5, id6);
+    ASSERT_NE(id5, id7);
+    ASSERT_NE(id5, id8);
+
+    UUID id9 = fuse_core::uuid::generate(name1, buffer1);
+    UUID id10 = fuse_core::uuid::generate(name1, buffer1);
+    UUID id11 = fuse_core::uuid::generate(name1, buffer2);
+    UUID id12 = fuse_core::uuid::generate(name2, buffer2);
+    ASSERT_EQ(id9, id1);
+    ASSERT_EQ(id9, id10);
+    ASSERT_NE(id9, id11);
+    ASSERT_NE(id9, id12);
+  }
+  // Generate a UUID from a namespace and a ros::Time
+  {
+    std::string name1 = "Cobb";
+    std::string name2 = "Frye";
+    ros::Time stamp1(1234, 5678);
+    ros::Time stamp2(1235, 5678);
+
+    UUID id1 = fuse_core::uuid::generate(name1, stamp1);
+    UUID id2 = fuse_core::uuid::generate(name1, stamp1);
+    UUID id3 = fuse_core::uuid::generate(name1, stamp2);
+    UUID id4 = fuse_core::uuid::generate(name2, stamp2);
+    ASSERT_EQ(id1, id2);
+    ASSERT_NE(id1, id3);
+    ASSERT_NE(id1, id4);
+  }
+  // Generate a UUID from a namespace, a ros::Time, and another UUID
+  {
+    std::string name1 = "Book";
+    std::string name2 = "Tam";
+    ros::Time stamp1(1234, 5678);
+    ros::Time stamp2(1235, 5678);
+    UUID uuid1 = fuse_core::uuid::generate();
+    UUID uuid2 = fuse_core::uuid::generate();
+
+    UUID id1 = fuse_core::uuid::generate(name1, stamp1, uuid1);
+    UUID id2 = fuse_core::uuid::generate(name1, stamp1, uuid1);
+    UUID id3 = fuse_core::uuid::generate(name2, stamp1, uuid1);
+    UUID id4 = fuse_core::uuid::generate(name1, stamp2, uuid1);
+    UUID id5 = fuse_core::uuid::generate(name1, stamp1, uuid2);
+    ASSERT_EQ(id1, id2);
+    ASSERT_NE(id1, id3);
+    ASSERT_NE(id1, id4);
+    ASSERT_NE(id1, id5);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_core/test/test_variable.cpp
+++ b/fuse_core/test/test_variable.cpp
@@ -1,0 +1,78 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/macros.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
+
+#include <gtest/gtest.h>
+
+
+/**
+ * @brief Dummy variable implementation for testing
+ */
+class TestVariable : public fuse_core::Variable
+{
+public:
+  SMART_PTR_DEFINITIONS(TestVariable);
+
+  TestVariable() :
+    data_(0.0),
+    uuid_(fuse_core::uuid::NIL)
+  {
+  }
+
+  fuse_core::UUID uuid() const override { return uuid_; }
+  size_t size() const override { return 1; }
+  const double* data() const override { return &data_; };
+  double* data() override { return &data_; };
+  void print(std::ostream& stream = std::cout) const override {}
+  fuse_core::Variable::UniquePtr clone() const override { return TestVariable::make_unique(*this); }
+
+private:
+  double data_;
+  fuse_core::UUID uuid_;
+};
+
+
+TEST(Variable, Type)
+{
+  TestVariable variable;
+  ASSERT_EQ("TestVariable", variable.type());
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is the first of many PRs to move core fuse components into the public `fuse` repo