### PR TITLE
[RST-1121] Removed fuse_variables default constructors

### DIFF
--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -5,12 +5,15 @@ find_package(catkin REQUIRED COMPONENTS
   fuse_core
   roscpp
 )
+find_package(Ceres REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
     include
+    ${CERES_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
+    ${CERES_LIBRARIES}
   CATKIN_DEPENDS
     fuse_core
     roscpp
@@ -25,6 +28,7 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${CERES_INCLUDE_DIRS}
 )
 
 ## fuse_variables library
@@ -42,6 +46,7 @@ add_dependencies(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  ${CERES_LIBRARIES}
 )
 
 #############
@@ -64,10 +69,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(Ceres REQUIRED)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
-  include_directories(${CERES_INCLUDE_DIRS})
 
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")

--- a/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
@@ -57,13 +57,6 @@ public:
   SMART_PTR_DEFINITIONS(AccelerationAngular2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  AccelerationAngular2DStamped();
-
-  /**
    * @brief Construct a 2D acceleration at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this velocity.

--- a/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
@@ -58,13 +58,6 @@ public:
   SMART_PTR_DEFINITIONS(AccelerationLinear2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  AccelerationLinear2DStamped();
-
-  /**
    * @brief Construct a 2D acceleration at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this velocity.

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -61,13 +61,6 @@ public:
   SMART_PTR_DEFINITIONS(Orientation2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  Orientation2DStamped();
-
-  /**
    * @brief Construct a 2D orientation at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this orientation.

--- a/fuse_variables/include/fuse_variables/position_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_2d_stamped.h
@@ -58,13 +58,6 @@ public:
   SMART_PTR_DEFINITIONS(Position2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  Position2DStamped();
-
-  /**
    * @brief Construct a 2D position at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this position.

--- a/fuse_variables/include/fuse_variables/position_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_3d_stamped.h
@@ -59,13 +59,6 @@ public:
   SMART_PTR_DEFINITIONS(Position3DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  Position3DStamped();
-
-  /**
    * @brief Construct a 3D position at a specific point in time.
    *
    * @param[IN]  stamp  The timestamp attached to this popositionse.

--- a/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
@@ -58,13 +58,6 @@ public:
   SMART_PTR_DEFINITIONS(VelocityAngular2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  VelocityAngular2DStamped();
-
-  /**
    * @brief Construct a 2D velocity at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this velocity.

--- a/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
@@ -58,13 +58,6 @@ public:
   SMART_PTR_DEFINITIONS(VelocityLinear2DStamped);
 
   /**
-   * @brief Default constructor
-   *
-   * This is needed for the ROS plugin system and the deserializeMessage() method. It should not be used directly.
-   */
-  VelocityLinear2DStamped();
-
-  /**
    * @brief Construct a 2D velocity at a specific point in time.
    *
    * @param[in] stamp       The timestamp attached to this velocity.

--- a/fuse_variables/package.xml
+++ b/fuse_variables/package.xml
@@ -12,9 +12,9 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>ceres-solver</depend>
   <depend>fuse_core</depend>
   <depend>roscpp</depend>
-  <test_depend>ceres-solver</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 </package>

--- a/fuse_variables/src/acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_2d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-AccelerationAngular2DStamped::AccelerationAngular2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 AccelerationAngular2DStamped::AccelerationAngular2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_2d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-AccelerationLinear2DStamped::AccelerationLinear2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 AccelerationLinear2DStamped::AccelerationLinear2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -40,13 +40,6 @@
 namespace fuse_variables
 {
 
-Orientation2DStamped::Orientation2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 Orientation2DStamped::Orientation2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/position_2d_stamped.cpp
+++ b/fuse_variables/src/position_2d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-Position2DStamped::Position2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 Position2DStamped::Position2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/position_3d_stamped.cpp
+++ b/fuse_variables/src/position_3d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-Position3DStamped::Position3DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 Position3DStamped::Position3DStamped(const ros::Time& stamp, const fuse_core::UUID &hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_2d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-VelocityAngular2DStamped::VelocityAngular2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 VelocityAngular2DStamped::VelocityAngular2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),

--- a/fuse_variables/src/velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_2d_stamped.cpp
@@ -38,13 +38,6 @@
 namespace fuse_variables
 {
 
-VelocityLinear2DStamped::VelocityLinear2DStamped() :
-  hardware_id_(fuse_core::uuid::NIL),
-  stamp_(0, 0),
-  uuid_(fuse_core::uuid::NIL)
-{
-}
-
 VelocityLinear2DStamped::VelocityLinear2DStamped(const ros::Time& stamp, const fuse_core::UUID& hardware_id) :
   hardware_id_(hardware_id),
   stamp_(stamp),


### PR DESCRIPTION
Removed fuse_variables default constructors. These were basically useless since you could not update the UUID. (Also added a missing ceres dependency)