### PR TITLE
Fix 2D pose constraint tests

### DIFF
--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -138,7 +138,7 @@ TEST(AbsolutePose2DStampedConstraint, Optimization)
   covariance.GetCovarianceBlock(position_variable->data(), position_variable->data(), covariance_vector1.data());
   std::vector<double> covariance_vector2(position_variable->size() * orientation_variable->size());
   covariance.GetCovarianceBlock(position_variable->data(), orientation_variable->data(), covariance_vector2.data());
-  std::vector<double> covariance_vector3(position_variable->size() * orientation_variable->size());
+  std::vector<double> covariance_vector3(orientation_variable->size() * orientation_variable->size());
   covariance.GetCovarianceBlock(orientation_variable->data(), orientation_variable->data(), covariance_vector3.data());
   // Assemble the full covariance from the covariance blocks
   Eigen::Matrix3d actual_covariance;

--- a/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
@@ -192,7 +192,7 @@ TEST(RelativePose2DStampedConstraint, Optimization)
     covariance.GetCovarianceBlock(position1->data(), position1->data(), covariance_vector1.data());
     std::vector<double> covariance_vector2(position1->size() * orientation1->size());
     covariance.GetCovarianceBlock(position1->data(), orientation1->data(), covariance_vector2.data());
-    std::vector<double> covariance_vector3(position1->size() * orientation1->size());
+    std::vector<double> covariance_vector3(orientation1->size() * orientation1->size());
     covariance.GetCovarianceBlock(orientation1->data(), orientation1->data(), covariance_vector3.data());
     // Assemble the full covariance from the covariance blocks
     Eigen::Matrix3d actual_covariance;
@@ -221,7 +221,7 @@ TEST(RelativePose2DStampedConstraint, Optimization)
     covariance.GetCovarianceBlock(position2->data(), position2->data(), covariance_vector1.data());
     std::vector<double> covariance_vector2(position2->size() * orientation2->size());
     covariance.GetCovarianceBlock(position2->data(), orientation2->data(), covariance_vector2.data());
-    std::vector<double> covariance_vector3(position2->size() * orientation2->size());
+    std::vector<double> covariance_vector3(orientation2->size() * orientation2->size());
     covariance.GetCovarianceBlock(orientation2->data(), orientation2->data(), covariance_vector3.data());
     // Assemble the full covariance from the covariance blocks
     Eigen::Matrix3d actual_covariance;


### PR DESCRIPTION
Fixed covariance matrix size in the unit tests. The blocks of interest are: `position x position`, `position x orientation`, and `orientation x orientation`.

Got away with the typo before because position.size() > orientation.size() for 2D objects.