### PR TITLE
[RST-1226] Convert all Eigen objects to use row-major order

### DIFF
--- a/fuse_constraints/include/fuse_constraints/absolute_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_ABSOLUTE_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
@@ -46,7 +47,6 @@
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 
 #include <ceres/cost_function.h>
-#include <Eigen/Core>
 
 #include <ostream>
 #include <vector>
@@ -78,8 +78,8 @@ public:
    */
   AbsoluteConstraint(
     const Variable& variable,
-    const Eigen::VectorXd& mean,
-    const Eigen::MatrixXd& covariance);
+    const fuse_core::VectorXd& mean,
+    const fuse_core::MatrixXd& covariance);
 
   /**
    * @brief Create a constraint using a measurement/prior of only a partial set of dimensions of the target variable
@@ -91,8 +91,8 @@ public:
    */
   AbsoluteConstraint(
     const Variable& variable,
-    const Eigen::VectorXd& partial_mean,
-    const Eigen::MatrixXd& partial_covariance,
+    const fuse_core::VectorXd& partial_mean,
+    const fuse_core::MatrixXd& partial_covariance,
     const std::vector<size_t>& indices);
 
   /**
@@ -107,7 +107,7 @@ public:
    * defined by the variable, not the order defined by the \p indices parameter. All unmeasured variable dimensions
    * are set to zero.
    */
-  const Eigen::VectorXd& mean() const { return mean_; }
+  const fuse_core::VectorXd& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
@@ -116,7 +116,7 @@ public:
    * square root information matrix will have size measured_dimensions X variable_dimensions. If only a partial set
    * of dimensions are measured, then this matrix will not be square.
    */
-  const Eigen::MatrixXd& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::MatrixXd& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
@@ -126,7 +126,7 @@ public:
    * subset of dimensions are measured, then some rows/columns will be zero. This will result in a rank-deficient
    * covariance matrix. You have been warned.
    */
-  Eigen::MatrixXd covariance() const;
+  fuse_core::MatrixXd covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -156,8 +156,8 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  Eigen::VectorXd mean_;  //!< The measured/prior mean vector for this variable
-  Eigen::MatrixXd sqrt_information_;  //!< The square root information matrix
+  fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
+  fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
 };
 
 // Define unique names for the different variations of the absolute constraint

--- a/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
@@ -48,8 +48,8 @@ namespace fuse_constraints
 template<class Variable>
 AbsoluteConstraint<Variable>::AbsoluteConstraint(
   const Variable& variable,
-  const Eigen::VectorXd& mean,
-  const Eigen::MatrixXd& covariance) :
+  const fuse_core::VectorXd& mean,
+  const fuse_core::MatrixXd& covariance) :
     fuse_core::Constraint{variable.uuid()},
     mean_(mean),
     sqrt_information_(covariance.inverse().llt().matrixU())
@@ -62,8 +62,8 @@ AbsoluteConstraint<Variable>::AbsoluteConstraint(
 template<class Variable>
 AbsoluteConstraint<Variable>::AbsoluteConstraint(
   const Variable& variable,
-  const Eigen::VectorXd& partial_mean,
-  const Eigen::MatrixXd& partial_covariance,
+  const fuse_core::VectorXd& partial_mean,
+  const fuse_core::MatrixXd& partial_covariance,
   const std::vector<size_t>& indices) :
     fuse_core::Constraint{variable.uuid()}
 {
@@ -71,7 +71,7 @@ AbsoluteConstraint<Variable>::AbsoluteConstraint(
   assert(partial_covariance.rows() == static_cast<int>(indices.size()));
   assert(partial_covariance.cols() == static_cast<int>(indices.size()));
   // Compute the sqrt information of the provided cov matrix
-  Eigen::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
+  fuse_core::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
   // Assemble a mean vector and sqrt information matrix from the provided values, but in proper Variable order
   // What are we doing here?
   // The constraint equation is defined as: cost(x) = ||A * (x - b)||^2
@@ -79,8 +79,8 @@ AbsoluteConstraint<Variable>::AbsoluteConstraint(
   // But the variable vectors will be full sized. We can make this all work out by creating a non-square A
   // matrix, where each row computes a cost for one measured dimensions, and the columns are in the order
   // defined by the variable.
-  mean_ = Eigen::VectorXd::Zero(variable.size());
-  sqrt_information_ = Eigen::MatrixXd::Zero(indices.size(), variable.size());
+  mean_ = fuse_core::VectorXd::Zero(variable.size());
+  sqrt_information_ = fuse_core::MatrixXd::Zero(indices.size(), variable.size());
   for (size_t i = 0; i < indices.size(); ++i)
   {
     mean_(indices[i]) = partial_mean(i);
@@ -89,7 +89,7 @@ AbsoluteConstraint<Variable>::AbsoluteConstraint(
 }
 
 template<class Variable>
-Eigen::MatrixXd AbsoluteConstraint<Variable>::covariance() const
+fuse_core::MatrixXd AbsoluteConstraint<Variable>::covariance() const
 {
   // We want to compute:
   // cov = (sqrt_info' * sqrt_info)^-1
@@ -98,8 +98,8 @@ Eigen::MatrixXd AbsoluteConstraint<Variable>::covariance() const
   // But sqrt_info _may_ not be square. So we need to compute the pseudoinverse instead.
   // Eigen doesn't have a pseudoinverse function (for probably very legitimate reasons).
   // So we set the right hand side to identity, then solve using one of Eigen's many decompositions.
-  auto I = Eigen::MatrixXd::Identity(sqrt_information_.rows(), sqrt_information_.cols());
-  Eigen::MatrixXd pinv = sqrt_information_.colPivHouseholderQr().solve(I);
+  auto I = fuse_core::MatrixXd::Identity(sqrt_information_.rows(), sqrt_information_.cols());
+  fuse_core::MatrixXd pinv = sqrt_information_.colPivHouseholderQr().solve(I);
   return pinv * pinv.transpose();
 }
 

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_ABSOLUTE_ORIENTATION_3D_STAMPED_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
@@ -71,8 +72,8 @@ public:
    */
   AbsoluteOrientation3DStampedConstraint(
     const fuse_variables::Orientation3DStamped& orientation,
-    const Eigen::Vector4d& mean,
-    const Eigen::Matrix3d& covariance);
+    const fuse_core::Vector4d& mean,
+    const fuse_core::Matrix3d& covariance);
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -84,7 +85,7 @@ public:
   AbsoluteOrientation3DStampedConstraint(
     const fuse_variables::Orientation3DStamped& orientation,
     const Eigen::Quaterniond& mean,
-    const Eigen::Matrix3d& covariance);
+    const fuse_core::Matrix3d& covariance);
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -108,21 +109,21 @@ public:
    *
    * Order is (w, x, y, z)
    */
-  const Eigen::Vector4d& mean() const { return mean_; }
+  const fuse_core::Vector4d& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
    *
    * Order is (qx, qy, qz)
    */
-  const Eigen::Matrix3d& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::Matrix3d& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
    *
    * Order is (qx, qy, qz)
    */
-  Eigen::Matrix3d covariance() const;
+  fuse_core::Matrix3d covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -157,24 +158,24 @@ protected:
    * @param[in] quaternion - The input Eigen quaternion
    * @return The \p quaternion, converted to an Eigen Vector4d
    */
-  static Eigen::Vector4d toEigen(const Eigen::Quaterniond& quaternion);
+  static fuse_core::Vector4d toEigen(const Eigen::Quaterniond& quaternion);
 
   /**
    * @brief Utility method to convert an ROS quaternion message to an Eigen Vector4d
    * @param[in] quaternion - The input ROS quaternion message
    * @return The \p quaternion, converted to an Eigen Vector4d
    */
-  static Eigen::Vector4d toEigen(const geometry_msgs::Quaternion& quaternion);
+  static fuse_core::Vector4d toEigen(const geometry_msgs::Quaternion& quaternion);
 
   /**
    * @brief Utility method to convert a flat 1D array to a 3x3 Eigen matrix
    * @param[in] covariance - The input covariance array
    * @return The \p covariance, converted to an Eigen Matrix3d
    */
-  static Eigen::Matrix3d toEigen(const std::array<double, 9>& covariance);
+  static fuse_core::Matrix3d toEigen(const std::array<double, 9>& covariance);
 
-  Eigen::Vector4d mean_;  //!< The measured/prior mean vector for this variable
-  Eigen::Matrix3d sqrt_information_;  //!< The square root information matrix
+  fuse_core::Vector4d mean_;  //!< The measured/prior mean vector for this variable
+  fuse_core::Matrix3d sqrt_information_;  //!< The square root information matrix
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_ABSOLUTE_ORIENTATION_3D_STAMPED_EULER_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
@@ -78,8 +79,8 @@ public:
    */
   AbsoluteOrientation3DStampedEulerConstraint(
     const fuse_variables::Orientation3DStamped& orientation,
-    const Eigen::VectorXd& mean,
-    const Eigen::MatrixXd& covariance,
+    const fuse_core::VectorXd& mean,
+    const fuse_core::MatrixXd& covariance,
     const std::vector<Euler> &axes);
 
   /**
@@ -99,7 +100,7 @@ public:
    * Order is defined by the provided \p axes parameter. This mean() function deviates from all other
    * currently implemented constraints in that the order does _not_ match the order defined in the variable.
    */
-  const Eigen::VectorXd& mean() const { return mean_; }
+  const fuse_core::VectorXd& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
@@ -107,7 +108,7 @@ public:
    * Order is defined by the provided \p axes parameter. This sqrtInformation() function deviates from all other
    * currently implemented constraints in that the order does _not_ match the order defined in the variable.
    */
-  const Eigen::MatrixXd& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::MatrixXd& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
@@ -115,7 +116,7 @@ public:
    * Order is defined by the provided \p axes parameter. This covariance() function deviates from all other
    * currently implemented constraints in that the order does _not_ match the order defined in the variable.
    */
-  Eigen::MatrixXd covariance() const;
+  fuse_core::MatrixXd covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -145,8 +146,8 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  Eigen::VectorXd mean_;  //!< The measured/prior mean vector for this variable
-  Eigen::MatrixXd sqrt_information_;  //!< The square root information matrix
+  fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
+  fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
   std::vector<Euler> axes_;  //!< Which Euler angle axes we want to measure
 };
 

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_ABSOLUTE_POSE_2D_STAMPED_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -74,8 +75,8 @@ public:
   AbsolutePose2DStampedConstraint(
     const fuse_variables::Position2DStamped& position,
     const fuse_variables::Orientation2DStamped& orientation,
-    const Eigen::Vector3d& mean,
-    const Eigen::Matrix3d& covariance);
+    const fuse_core::Vector3d& mean,
+    const fuse_core::Matrix3d& covariance);
 
   /**
    * @brief Destructor
@@ -87,21 +88,21 @@ public:
    *
    * Order is (x, y, yaw)
    */
-  const Eigen::Vector3d& mean() const { return mean_; }
+  const fuse_core::Vector3d& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
    *
    * Order is (x, y, yaw)
    */
-  const Eigen::Matrix3d& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::Matrix3d& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
    *
    * Order is (x, y, yaw)
    */
-  Eigen::Matrix3d covariance() const { return (sqrt_information_.transpose() * sqrt_information_).inverse(); }
+  fuse_core::Matrix3d covariance() const { return (sqrt_information_.transpose() * sqrt_information_).inverse(); }
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -131,8 +132,8 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  Eigen::Vector3d mean_;  //!< The measured/prior mean vector for this variable
-  Eigen::Matrix3d sqrt_information_;  //!< The square root information matrix
+  fuse_core::Vector3d mean_;  //!< The measured/prior mean vector for this variable
+  fuse_core::Matrix3d sqrt_information_;  //!< The square root information matrix
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/normal_delta.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta.h
@@ -34,8 +34,9 @@
 #ifndef FUSE_CONSTRAINTS_NORMAL_DELTA_H
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_H
 
+#include <fuse_core/eigen.h>
+
 #include <ceres/cost_function.h>
-#include <ceres/internal/eigen.h>
 #include <ceres/internal/disable_warnings.h>
 
 
@@ -72,7 +73,7 @@ public:
    *              type of variable. At a minimum, they must have the same dimensions and the per-element subtraction
    *              operator must be valid.
    */
-  NormalDelta(const ceres::Matrix& A, const ceres::Vector& b);
+  NormalDelta(const fuse_core::MatrixXd& A, const fuse_core::VectorXd& b);
 
   /**
    * @brief Destructor
@@ -89,8 +90,8 @@ public:
     double** jacobians) const;
 
 private:
-  ceres::Matrix A_;  //!< The residual weighting matrix, most likely the square root information matrix
-  ceres::Vector b_;  //!< The measured difference between variable x0 and variable x1
+  fuse_core::MatrixXd A_;  //!< The residual weighting matrix, most likely the square root information matrix
+  fuse_core::VectorXd b_;  //!< The measured difference between variable x0 and variable x1
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
@@ -35,10 +35,10 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_POSE_2D_COST_FUNCTOR_H
 
 #include <fuse_constraints/util.h>
+#include <fuse_core/eigen.h>
 
 #include <ceres/internal/disable_warnings.h>
 #include <ceres/internal/eigen.h>
-#include <Eigen/Core>
 
 
 namespace fuse_constraints
@@ -78,7 +78,7 @@ public:
    * @param[in] A The residual weighting matrix, most likely the square root information matrix in order (x, y, yaw)
    * @param[in] b The exposed pose difference in order (x, y, yaw)
    */
-  NormalDeltaPose2DCostFunctor(const Eigen::Matrix3d& A, const Eigen::Vector3d& b);
+  NormalDeltaPose2DCostFunctor(const fuse_core::Matrix3d& A, const fuse_core::Vector3d& b);
 
   /**
    * @brief Compute the cost values/residuals using the provided variable/parameter values
@@ -92,11 +92,11 @@ public:
     T* residual) const;
 
 private:
-  Eigen::Matrix3d A_;  //!< The residual weighting matrix, most likely the square root information matrix
-  Eigen::Vector3d b_;  //!< The measured difference between variable x0 and variable x1
+  fuse_core::Matrix3d A_;  //!< The residual weighting matrix, most likely the square root information matrix
+  fuse_core::Vector3d b_;  //!< The measured difference between variable x0 and variable x1
 };
 
-NormalDeltaPose2DCostFunctor::NormalDeltaPose2DCostFunctor(const Eigen::Matrix3d& A, const Eigen::Vector3d& b) :
+NormalDeltaPose2DCostFunctor::NormalDeltaPose2DCostFunctor(const fuse_core::Matrix3d& A, const fuse_core::Vector3d& b) :
   A_(A),
   b_(b)
 {
@@ -110,9 +110,9 @@ bool NormalDeltaPose2DCostFunctor::operator()(
   const T* const orientation2,
   T* residual) const
 {
-  Eigen::Map<const Eigen::Matrix<T, 2, 1> > position1_vector(position1);
-  Eigen::Map<const Eigen::Matrix<T, 2, 1> > position2_vector(position2);
-  Eigen::Map<Eigen::Matrix<T, 3, 1> > residuals_matrix(residual);
+  Eigen::Map<const Eigen::Matrix<T, 2, 1>> position1_vector(position1);
+  Eigen::Map<const Eigen::Matrix<T, 2, 1>> position2_vector(position2);
+  Eigen::Map<Eigen::Matrix<T, 3, 1>> residuals_matrix(residual);
   residuals_matrix.template head<2>() =
     RotationMatrix2D(orientation1[0]).transpose() * (position2_vector - position1_vector) -
     b_.head<2>().template cast<T>();
@@ -120,7 +120,7 @@ bool NormalDeltaPose2DCostFunctor::operator()(
   wrapAngle2D(residuals_matrix(2));
   // Scale the residuals by the square root information matrix to account for
   // the measurement uncertainty.
-  residuals_matrix = A_.template cast<T>() * residuals_matrix;
+  residuals_matrix.applyOnTheLeft(A_.template cast<T>());
   return true;
 }
 

--- a/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
@@ -35,10 +35,10 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_ORIENTATION_3D_COST_FUNCTOR_H
 
 #include <fuse_constraints/util.h>
+#include <fuse_core/eigen.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
 #include <ceres/internal/disable_warnings.h>
-#include <ceres/internal/eigen.h>
 #include <ceres/rotation.h>
 #include <Eigen/Core>
 
@@ -77,8 +77,8 @@ public:
    * @param[in] b The orientation measurement or prior in order (w, x, y, z)
    */
   NormalPriorOrientation3DCostFunctor(
-    const Eigen::Matrix3d& A,
-    const Eigen::Vector4d& b) :
+    const fuse_core::Matrix3d& A,
+    const fuse_core::Vector4d& b) :
       A_(A),
       b_(b)
   {
@@ -119,15 +119,15 @@ public:
     residuals[2] = output[3];
 
     // 3. Scale the residuals by the square root information matrix to account for the measurement uncertainty.
-    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > residuals_map(residuals, A_.rows(), 1);
-    residuals_map = A_.template cast<T>() * residuals_map;
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> residuals_map(residuals, A_.rows());
+    residuals_map.applyOnTheLeft(A_.template cast<T>());
 
     return true;
   }
 
 private:
-  Eigen::Matrix3d A_;  //!< The residual weighting matrix, most likely the square root information matrix
-  Eigen::Vector4d b_;  //!< The measured 3D orientation (quaternion) value
+  fuse_core::Matrix3d A_;  //!< The residual weighting matrix, most likely the square root information matrix
+  fuse_core::Vector4d b_;  //!< The measured 3D orientation (quaternion) value
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_euler_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_euler_cost_functor.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_ORIENTATION_3D_EULER_COST_FUNCTOR_H
 
 #include <fuse_constraints/util.h>
+#include <fuse_core/eigen.h>
 #include <fuse_variables/util.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
@@ -88,8 +89,8 @@ public:
    * @param[in] axes The Euler angle axes for which we want to compute errors. Defaults to all axes. 
    */
   NormalPriorOrientation3DEulerCostFunctor(
-    const Eigen::MatrixXd& A,
-    const Eigen::VectorXd& b,
+    const fuse_core::MatrixXd& A,
+    const fuse_core::VectorXd& b,
     const std::vector<Euler> &axes = {Euler::ROLL, Euler::PITCH, Euler::YAW}) :  //NOLINT
       A_(A),
       b_(b),
@@ -134,15 +135,15 @@ public:
       residuals[i] = angle - T(b_[i]);
     }
 
-    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > residuals_map(residuals, A_.rows(), 1);
-    residuals_map = A_.template cast<T>() * residuals_map;
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> residuals_map(residuals, A_.rows());
+    residuals_map.applyOnTheLeft(A_.template cast<T>());
 
     return true;
   }
 
 private:
-  Eigen::MatrixXd A_;  //!< The residual weighting matrix, most likely the square root information matrix
-  Eigen::VectorXd b_;  //!< The measured 3D orientation (quaternion) value
+  fuse_core::MatrixXd A_;  //!< The residual weighting matrix, most likely the square root information matrix
+  fuse_core::VectorXd b_;  //!< The measured 3D orientation (quaternion) value
   std::vector<Euler> axes_;  //!< The Euler angle axes that we're measuring
 };
 

--- a/fuse_constraints/include/fuse_constraints/relative_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_RELATIVE_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
@@ -83,8 +84,8 @@ public:
   RelativeConstraint(
     const Variable& variable1,
     const Variable& variable2,
-    const Eigen::VectorXd& delta,
-    const Eigen::MatrixXd& covariance);
+    const fuse_core::VectorXd& delta,
+    const fuse_core::MatrixXd& covariance);
 
   /**
    * @brief Constructor
@@ -100,8 +101,8 @@ public:
   RelativeConstraint(
     const Variable& variable1,
     const Variable& variable2,
-    const Eigen::VectorXd& delta,
-    const Eigen::MatrixXd& covariance,
+    const fuse_core::VectorXd& delta,
+    const fuse_core::MatrixXd& covariance,
     const std::vector<size_t>& indices);
 
   /**
@@ -116,7 +117,7 @@ public:
    * defined by the variable, not the order defined by the \p indices parameter. All unmeasured variable dimensions
    * are set to zero.
    */
-  const Eigen::VectorXd& delta() const { return delta_; }
+  const fuse_core::VectorXd& delta() const { return delta_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
@@ -125,7 +126,7 @@ public:
    * square root information matrix will have size measured_dimensions X variable_dimensions. If only a partial set
    * of dimensions are measured, then this matrix will not be square.
    */
-  const Eigen::MatrixXd& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::MatrixXd& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
@@ -135,7 +136,7 @@ public:
    * subset of dimensions are measured, then some rows/columns will be zero. This will result in a rank-deficient
    * covariance matrix. You have been warned.
    */
-  Eigen::MatrixXd covariance() const;
+  fuse_core::MatrixXd covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -165,8 +166,8 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  Eigen::VectorXd delta_;  //!< The measured change between the two variables
-  Eigen::MatrixXd sqrt_information_;  //!< The square root information matrix
+  fuse_core::VectorXd delta_;  //!< The measured change between the two variables
+  fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
 };
 
 // Define unique names for the different variations of the absolute constraint

--- a/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
@@ -49,8 +49,8 @@ template<class Variable>
 RelativeConstraint<Variable>::RelativeConstraint(
   const Variable& variable1,
   const Variable& variable2,
-  const Eigen::VectorXd& delta,
-  const Eigen::MatrixXd& covariance) :
+  const fuse_core::VectorXd& delta,
+  const fuse_core::MatrixXd& covariance) :
     fuse_core::Constraint{variable1.uuid(), variable2.uuid()},
     delta_(delta),
     sqrt_information_(covariance.inverse().llt().matrixU())
@@ -65,8 +65,8 @@ template<class Variable>
 RelativeConstraint<Variable>::RelativeConstraint(
   const Variable& variable1,
   const Variable& variable2,
-  const Eigen::VectorXd& partial_delta,
-  const Eigen::MatrixXd& partial_covariance,
+  const fuse_core::VectorXd& partial_delta,
+  const fuse_core::MatrixXd& partial_covariance,
   const std::vector<size_t>& indices) :
     fuse_core::Constraint{variable1.uuid(), variable2.uuid()}
 {
@@ -75,7 +75,7 @@ RelativeConstraint<Variable>::RelativeConstraint(
   assert(partial_covariance.rows() == static_cast<int>(indices.size()));
   assert(partial_covariance.cols() == static_cast<int>(indices.size()));
   // Compute the sqrt information of the provided cov matrix
-  Eigen::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
+  fuse_core::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
   // Assemble a mean vector and sqrt information matrix from the provided values, but in proper Variable order
   // What are we doing here?
   // The constraint equation is defined as: cost(x) = ||A * (x1 - x0 - b)||^2
@@ -83,8 +83,8 @@ RelativeConstraint<Variable>::RelativeConstraint(
   // But the variable vectors will be full sized. We can make this all work out by creating a non-square A
   // matrix, where each row computes a cost for one measured dimensions, and the columns are in the order
   // defined by the variable.
-  delta_ = Eigen::VectorXd::Zero(variable1.size());
-  sqrt_information_ = Eigen::MatrixXd::Zero(indices.size(), variable1.size());
+  delta_ = fuse_core::VectorXd::Zero(variable1.size());
+  sqrt_information_ = fuse_core::MatrixXd::Zero(indices.size(), variable1.size());
   for (size_t i = 0; i < indices.size(); ++i)
   {
     delta_(indices[i]) = partial_delta(i);
@@ -93,7 +93,7 @@ RelativeConstraint<Variable>::RelativeConstraint(
 }
 
 template<class Variable>
-Eigen::MatrixXd RelativeConstraint<Variable>::covariance() const
+fuse_core::MatrixXd RelativeConstraint<Variable>::covariance() const
 {
   // We want to compute:
   // cov = (sqrt_info' * sqrt_info)^-1
@@ -102,8 +102,8 @@ Eigen::MatrixXd RelativeConstraint<Variable>::covariance() const
   // But sqrt_info _may_ not be square. So we need to compute the pseudoinverse instead.
   // Eigen doesn't have a pseudoinverse function (for probably very legitimate reasons).
   // So we set the right hand side to identity, then solve using one of Eigen's many decompositions.
-  auto I = Eigen::MatrixXd::Identity(sqrt_information_.rows(), sqrt_information_.cols());
-  Eigen::MatrixXd pinv = sqrt_information_.colPivHouseholderQr().solve(I);
+  auto I = fuse_core::MatrixXd::Identity(sqrt_information_.rows(), sqrt_information_.cols());
+  fuse_core::MatrixXd pinv = sqrt_information_.colPivHouseholderQr().solve(I);
   return pinv * pinv.transpose();
 }
 

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_RELATIVE_POSE_2D_STAMPED_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -76,8 +77,8 @@ public:
     const fuse_variables::Orientation2DStamped& orientation1,
     const fuse_variables::Position2DStamped& position2,
     const fuse_variables::Orientation2DStamped& orientation2,
-    const Eigen::Vector3d& delta,
-    const Eigen::Matrix3d& covariance);
+    const fuse_core::Vector3d& delta,
+    const fuse_core::Matrix3d& covariance);
 
   /**
    * @brief Destructor
@@ -87,17 +88,17 @@ public:
   /**
    * @brief Read-only access to the measured pose change.
    */
-  const Eigen::Vector3d& delta() const { return delta_; }
+  const fuse_core::Vector3d& delta() const { return delta_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
    */
-  const Eigen::Matrix3d& sqrtInformation() const { return sqrt_information_; }
+  const fuse_core::Matrix3d& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
    */
-  Eigen::Matrix3d covariance() const { return (sqrt_information_.transpose() * sqrt_information_).inverse(); }
+  fuse_core::Matrix3d covariance() const { return (sqrt_information_.transpose() * sqrt_information_).inverse(); }
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -127,8 +128,8 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  Eigen::Vector3d delta_;  //!< The measured pose change (dx, dy, dyaw)
-  Eigen::Matrix3d sqrt_information_;  //!< The square root information matrix (derived from the covariance matrix)
+  fuse_core::Vector3d delta_;  //!< The measured pose change (dx, dy, dyaw)
+  fuse_core::Matrix3d sqrt_information_;  //!< The square root information matrix (derived from the covariance matrix)
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/util.h
+++ b/fuse_constraints/include/fuse_constraints/util.h
@@ -135,11 +135,11 @@ T wrapAngle2D(const T& angle)
  * @return          The equivalent 2x2 rotation matrix
  */
 template <typename T>
-Eigen::Matrix<T, 2, 2> RotationMatrix2D(const T angle)
+Eigen::Matrix<T, 2, 2, Eigen::RowMajor> RotationMatrix2D(const T angle)
 {
   const T cos_angle = ceres::cos(angle);
   const T sin_angle = ceres::sin(angle);
-  Eigen::Matrix<T, 2, 2> rotation;
+  Eigen::Matrix<T, 2, 2, Eigen::RowMajor> rotation;
   rotation << cos_angle, -sin_angle, sin_angle, cos_angle;
   return rotation;
 }

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
@@ -42,8 +42,8 @@ namespace fuse_constraints
 
 AbsoluteOrientation3DStampedConstraint::AbsoluteOrientation3DStampedConstraint(
   const fuse_variables::Orientation3DStamped& orientation,
-  const Eigen::Vector4d& mean,
-  const Eigen::Matrix3d& covariance) :
+  const fuse_core::Vector4d& mean,
+  const fuse_core::Matrix3d& covariance) :
     fuse_core::Constraint{orientation.uuid()},
     mean_(mean),
     sqrt_information_(covariance.inverse().llt().matrixU())
@@ -53,7 +53,7 @@ AbsoluteOrientation3DStampedConstraint::AbsoluteOrientation3DStampedConstraint(
 AbsoluteOrientation3DStampedConstraint::AbsoluteOrientation3DStampedConstraint(
   const fuse_variables::Orientation3DStamped& orientation,
   const Eigen::Quaterniond& mean,
-  const Eigen::Matrix3d& covariance) :
+  const fuse_core::Matrix3d& covariance) :
     AbsoluteOrientation3DStampedConstraint(orientation, toEigen(mean), covariance)
 {
 }
@@ -66,7 +66,7 @@ AbsoluteOrientation3DStampedConstraint::AbsoluteOrientation3DStampedConstraint(
 {
 }
 
-Eigen::Matrix3d AbsoluteOrientation3DStampedConstraint::covariance() const
+fuse_core::Matrix3d AbsoluteOrientation3DStampedConstraint::covariance() const
 {
   return (sqrt_information_.transpose() * sqrt_information_).inverse();
 }
@@ -91,23 +91,23 @@ ceres::CostFunction* AbsoluteOrientation3DStampedConstraint::costFunction() cons
     new NormalPriorOrientation3DCostFunctor(sqrt_information_, mean_));
 }
 
-Eigen::Vector4d AbsoluteOrientation3DStampedConstraint::toEigen(const Eigen::Quaterniond& quaternion)
+fuse_core::Vector4d AbsoluteOrientation3DStampedConstraint::toEigen(const Eigen::Quaterniond& quaternion)
 {
-  Eigen::Vector4d eigen_quaternion_vector;
+  fuse_core::Vector4d eigen_quaternion_vector;
   eigen_quaternion_vector << quaternion.w(), quaternion.x(), quaternion.y(), quaternion.z();
   return eigen_quaternion_vector;
 }
 
-Eigen::Vector4d AbsoluteOrientation3DStampedConstraint::toEigen(const geometry_msgs::Quaternion& quaternion)
+fuse_core::Vector4d AbsoluteOrientation3DStampedConstraint::toEigen(const geometry_msgs::Quaternion& quaternion)
 {
-  Eigen::Vector4d eigen_quaternion_vector;
+  fuse_core::Vector4d eigen_quaternion_vector;
   eigen_quaternion_vector << quaternion.w, quaternion.x, quaternion.y, quaternion.z;
   return eigen_quaternion_vector;
 }
 
-Eigen::Matrix3d AbsoluteOrientation3DStampedConstraint::toEigen(const std::array<double, 9>& covariance)
+fuse_core::Matrix3d AbsoluteOrientation3DStampedConstraint::toEigen(const std::array<double, 9>& covariance)
 {
-  return Eigen::Matrix3d(covariance.data());
+  return fuse_core::Matrix3d(covariance.data());
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -44,8 +44,8 @@ namespace fuse_constraints
 
 AbsoluteOrientation3DStampedEulerConstraint::AbsoluteOrientation3DStampedEulerConstraint(
   const fuse_variables::Orientation3DStamped& orientation,
-  const Eigen::VectorXd& mean,
-  const Eigen::MatrixXd& covariance,
+  const fuse_core::VectorXd& mean,
+  const fuse_core::MatrixXd& covariance,
   const std::vector<Euler> &axes) :
     fuse_core::Constraint{orientation.uuid()},
     mean_(mean),
@@ -57,7 +57,7 @@ AbsoluteOrientation3DStampedEulerConstraint::AbsoluteOrientation3DStampedEulerCo
   assert(mean.rows() == static_cast<int>(axes.size()));
 }
 
-Eigen::MatrixXd AbsoluteOrientation3DStampedEulerConstraint::covariance() const
+fuse_core::MatrixXd AbsoluteOrientation3DStampedEulerConstraint::covariance() const
 {
   return (sqrt_information_.transpose() * sqrt_information_).inverse();
 }

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -43,8 +43,8 @@ namespace fuse_constraints
 AbsolutePose2DStampedConstraint::AbsolutePose2DStampedConstraint(
   const fuse_variables::Position2DStamped& position,
   const fuse_variables::Orientation2DStamped& orientation,
-  const Eigen::Vector3d& mean,
-  const Eigen::Matrix3d& covariance) :
+  const fuse_core::Vector3d& mean,
+  const fuse_core::Matrix3d& covariance) :
     fuse_core::Constraint{position.uuid(), orientation.uuid()},
     mean_(mean),
     sqrt_information_(covariance.inverse().llt().matrixU())

--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -45,8 +45,8 @@ RelativePose2DStampedConstraint::RelativePose2DStampedConstraint(
   const fuse_variables::Orientation2DStamped& orientation1,
   const fuse_variables::Position2DStamped& position2,
   const fuse_variables::Orientation2DStamped& orientation2,
-  const Eigen::Vector3d& delta,
-  const Eigen::Matrix3d& covariance) :
+  const fuse_core::Vector3d& delta,
+  const fuse_core::Matrix3d& covariance) :
     fuse_core::Constraint{position1.uuid(), orientation1.uuid(), position2.uuid(), orientation2.uuid()},
     delta_(delta),
     sqrt_information_(covariance.inverse().llt().matrixU())

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -56,57 +57,57 @@ TEST(AbsoluteConstraint, Constructor)
   // Construct a constraint for every type, just to make sure they compile.
   {
     fuse_variables::AccelerationAngular2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("robby"));
-    Eigen::Matrix<double, 1, 1> mean;
+    fuse_core::Vector1d mean;
     mean << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::AccelerationLinear2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("bender"));
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::Orientation2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("johnny5"));
-    Eigen::Matrix<double, 1, 1> mean;
+    fuse_core::Vector1d mean;
     mean << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::AbsoluteOrientation2DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::Position2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("rosie"));
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::AbsolutePosition2DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::Position3DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("clank"));
-    Eigen::Matrix<double, 3, 1> mean;
+    fuse_core::Vector3d mean;
     mean << 1.0, 2.0, 3.0;
-    Eigen::Matrix<double, 3, 3> cov;
+    fuse_core::Matrix3d cov;
     cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
     EXPECT_NO_THROW(fuse_constraints::AbsolutePosition3DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::VelocityAngular2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("gort"));
-    Eigen::Matrix<double, 1, 1> mean;
+    fuse_core::Vector1d mean;
     mean << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint constraint(variable, mean, cov));
   }
   {
     fuse_variables::VelocityLinear2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("bishop"));
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint constraint(variable, mean, cov));
   }
@@ -115,9 +116,9 @@ TEST(AbsoluteConstraint, Constructor)
 TEST(AbsoluteConstraint, PartialMeasurement)
 {
   fuse_variables::Position3DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("vici"));
-  Eigen::Matrix<double, 2, 1> mean;
+  fuse_core::Vector2d mean;
   mean << 3.0, 1.0;
-  Eigen::Matrix<double, 2, 2> cov;
+  fuse_core::Matrix2d cov;
   cov << 3.0, 0.2, 0.2, 1.0;
   auto indices = std::vector<size_t>{2, 0};
   EXPECT_NO_THROW(fuse_constraints::AbsolutePosition3DStampedConstraint constraint(variable, mean, cov, indices));
@@ -129,16 +130,16 @@ TEST(AbsoluteConstraint, Covariance)
   {
     // Verify the covariance <--> sqrt information conversions are correct
     fuse_variables::AccelerationLinear2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("chappie"));
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint constraint(variable, mean, cov);
     // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
-    Eigen::Matrix<double, 2, 2> expected_sqrt_info;
+    fuse_core::Matrix2d expected_sqrt_info;
     expected_sqrt_info <<  1.002509414234171, -0.050125470711709,
                            0.000000000000000,  0.707106781186547;
-    Eigen::Matrix<double, 2, 2> expected_cov = cov;
+    fuse_core::Matrix2d expected_cov = cov;
     // Compare
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
     EXPECT_TRUE(expected_sqrt_info.isApprox(constraint.sqrtInformation(), 1.0e-9));
@@ -146,18 +147,18 @@ TEST(AbsoluteConstraint, Covariance)
   // Test the covariance of a partial measurement
   {
     fuse_variables::Position3DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("astroboy"));
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 3.0, 1.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 3.0, 0.2, 0.2, 1.0;
     auto indices = std::vector<size_t>{2, 0};
     fuse_constraints::AbsolutePosition3DStampedConstraint constraint(variable, mean, cov, indices);
     // Define the expected matrices
-    Eigen::Matrix<double, 3, 1> expected_mean;
+    fuse_core::Vector3d expected_mean;
     expected_mean << 1.0, 0.0, 3.0;
-    Eigen::Matrix<double, 3, 3> expected_cov;
+    fuse_core::Matrix3d expected_cov;
     expected_cov << 1.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.2, 0.0, 3.0;
-    Eigen::Matrix<double, 2, 3> expected_sqrt_info;
+    Eigen::Matrix<double, 2, 3, Eigen::RowMajor> expected_sqrt_info;
     expected_sqrt_info << -0.116247638743819,  0.000000000000000,  0.581238193719096,
                            1.000000000000000,  0.000000000000000,  0.000000000000000;
     // Compare
@@ -178,9 +179,9 @@ TEST(AbsoluteConstraint, Optimization)
     variable->x() = 10.7;
     variable->y() = -3.2;
     // Create an absolute constraint
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     auto constraint = fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared(*variable,
                                                                                                    mean,
@@ -212,7 +213,7 @@ TEST(AbsoluteConstraint, Optimization)
     covariance.Compute(covariance_blocks, &problem);
     std::vector<double> covariance_vector(variable->size() * variable->size());
     covariance.GetCovarianceBlock(variable->data(), variable->data(), covariance_vector.data());
-    Eigen::Matrix<double, 2, 2> covariance_matrix(covariance_vector.data());
+    fuse_core::Matrix2d covariance_matrix(covariance_vector.data());
     EXPECT_TRUE(cov.isApprox(covariance_matrix, 1.0e-9));
   }
   // Test optimizing a partial measurement. This is tricky, because a partial measurement is rank-deficient by
@@ -227,16 +228,16 @@ TEST(AbsoluteConstraint, Optimization)
     var->y() = -3.2;
     var->z() = 0.9;
     // Create a full measurement constraint
-    Eigen::Matrix<double, 3, 1> mean1;
+    fuse_core::Vector3d mean1;
     mean1 << 1.0, 2.0, 3.0;
-    Eigen::Matrix<double, 3, 3> cov1;
+    fuse_core::Matrix3d cov1;
     cov1 << 1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
             0.0, 0.0, 1.0;
     auto constraint1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(*var, mean1, cov1);
-    Eigen::Matrix<double, 2, 1> mean2;
+    fuse_core::Vector2d mean2;
     mean2 << 4.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov2;
+    fuse_core::Matrix2d cov2;
     cov2 << 1.0, 0.0,
             0.0, 1.0;
     auto indices2 = std::vector<size_t>{2, 0};
@@ -273,8 +274,8 @@ TEST(AbsoluteConstraint, Optimization)
     covariance.Compute(covariance_blocks, &problem);
     std::vector<double> covariance_vector(var->size() * var->size());
     covariance.GetCovarianceBlock(var->data(), var->data(), covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> actual_cov(covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> expected_cov;
+    fuse_core::Matrix3d actual_cov(covariance_vector.data());
+    fuse_core::Matrix3d expected_cov;
     expected_cov << 0.5, 0.0, 0.0,
                     0.0, 1.0, 0.0,
                     0.0, 0.0, 0.5;
@@ -290,9 +291,9 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
                                                                     fuse_core::uuid::generate("tiktok"));
   variable->yaw() = 0.7;
   // Create an absolute constraint
-  Eigen::Matrix<double, 1, 1> mean;
+  fuse_core::Vector1d mean;
   mean << 7.0;
-  Eigen::Matrix<double, 1, 1> cov;
+  fuse_core::Matrix1d cov;
   cov << 0.10;
   auto constraint = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared(*variable, mean, cov);
   // Build the problem
@@ -321,7 +322,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   covariance.Compute(covariance_blocks, &problem);
   std::vector<double> covariance_vector(variable->size() * variable->size());
   covariance.GetCovarianceBlock(variable->data(), variable->data(), covariance_vector.data());
-  Eigen::Matrix<double, 1, 1> covariance_matrix(covariance_vector.data());
+  fuse_core::Matrix1d covariance_matrix(covariance_vector.data());
   EXPECT_TRUE(cov.isApprox(covariance_matrix, 1.0e-9));
 }
 

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_orientation_3d_stamped_constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
@@ -53,9 +54,9 @@ TEST(AbsoluteOrientation3DStampedConstraint, Constructor)
 {
   // Construct a constraint just to make sure it compiles.
   Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
-  Eigen::Vector4d mean;
+  fuse_core::Vector4d mean;
   mean << 1.0, 0.0, 0.0, 0.0;
-  Eigen::Matrix<double, 3, 3> cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   EXPECT_NO_THROW(AbsoluteOrientation3DStampedConstraint constraint(orientation_variable, mean, cov));
 
@@ -72,18 +73,18 @@ TEST(AbsoluteOrientation3DStampedConstraint, Covariance)
 {
   // Verify the covariance <--> sqrt information conversions are correct
   Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("mo"));
-  Eigen::Vector4d mean;
+  fuse_core::Vector4d mean;
   mean << 1.0, 0.0, 0.0, 0.0;
-  Eigen::Matrix3d cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   AbsoluteOrientation3DStampedConstraint constraint(orientation_variable, mean, cov);
 
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
-  Eigen::Matrix3d expected_sqrt_info;
+  fuse_core::Matrix3d expected_sqrt_info;
   expected_sqrt_info <<  1.008395589795798, -0.040950074712520, -0.063131365181801,
                          0.000000000000000,  0.712470499879096, -0.071247049987910,
                          0.000000000000000,  0.000000000000000,  0.577350269189626;
-  Eigen::Matrix3d expected_cov = cov;
+  fuse_core::Matrix3d expected_cov = cov;
 
   // Compare
   EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -101,10 +102,10 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
   orientation_variable->z() = 0.239;
 
   // Create an absolute orientation constraint
-  Eigen::Vector4d mean;
+  fuse_core::Vector4d mean;
   mean << 1.0, 0.0, 0.0, 0.0;
 
-  Eigen::Matrix3d cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   auto constraint = AbsoluteOrientation3DStampedConstraint::make_shared(
     *orientation_variable,
@@ -146,8 +147,8 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
   covariance.GetCovarianceBlock(orientation_variable->data(), orientation_variable->data(), covariance_vector.data());
 
   // Assemble the full covariance from the covariance blocks
-  Eigen::Matrix4d actual_covariance(covariance_vector.data());
-  Eigen::Matrix3d expected_covariance = cov;
+  fuse_core::Matrix4d actual_covariance(covariance_vector.data());
+  fuse_core::Matrix3d expected_covariance = cov;
   EXPECT_TRUE(expected_covariance.isApprox(actual_covariance.block<3, 3>(1, 1), 1.0e-9));
 }
 

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
@@ -53,9 +54,9 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, Constructor)
 {
   // Construct a constraint just to make sure it compiles.
   Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
-  Eigen::Vector3d mean;
+  fuse_core::Vector3d mean;
   mean << 1.0, 2.0, 3.0;
-  Eigen::Matrix<double, 3, 3> cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   std::vector<Orientation3DStamped::Euler> axes =
     {Orientation3DStamped::Euler::YAW, Orientation3DStamped::Euler::ROLL, Orientation3DStamped::Euler::PITCH};
@@ -66,20 +67,20 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, Covariance)
 {
   // Verify the covariance <--> sqrt information conversions are correct
   Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("mo"));
-  Eigen::Vector3d mean;
+  fuse_core::Vector3d mean;
   mean << 1.0, 2.0, 3.0;
-  Eigen::Matrix<double, 3, 3> cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   std::vector<Orientation3DStamped::Euler> axes =
     {Orientation3DStamped::Euler::YAW, Orientation3DStamped::Euler::ROLL, Orientation3DStamped::Euler::PITCH};
   AbsoluteOrientation3DStampedEulerConstraint constraint(orientation_variable, mean, cov, axes);
 
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
-  Eigen::Matrix3d expected_sqrt_info;
+  fuse_core::Matrix3d expected_sqrt_info;
   expected_sqrt_info <<  1.008395589795798, -0.040950074712520, -0.063131365181801,
                          0.000000000000000,  0.712470499879096, -0.071247049987910,
                          0.000000000000000,  0.000000000000000,  0.577350269189626;
-  Eigen::Matrix3d expected_cov = cov;
+  fuse_core::Matrix3d expected_cov = cov;
 
   // Compare
   EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -97,9 +98,9 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationFull)
   orientation_variable->z() = 0.239;
 
   // Create an absolute orientation constraint
-  Eigen::Vector3d mean;
+  fuse_core::Vector3d mean;
   mean << 0.5, 1.0, 1.5;
-  Eigen::Matrix<double, 3, 3> cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   std::vector<Orientation3DStamped::Euler> axes =
     {Orientation3DStamped::Euler::YAW, Orientation3DStamped::Euler::ROLL, Orientation3DStamped::Euler::PITCH};
@@ -151,9 +152,9 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationPartial)
   orientation_variable->z() = 0.239;
 
   // Create an absolute orientation constraint
-  Eigen::Matrix<double, 2, 1> mean1;
+  fuse_core::Vector2d mean1;
   mean1 << 0.5, 1.5;
-  Eigen::Matrix<double, 2, 2> cov1;
+  fuse_core::Matrix2d cov1;
   cov1 << 1.0, 0.2, 0.2, 3.0;
   std::vector<Orientation3DStamped::Euler> axes1 =
     {Orientation3DStamped::Euler::YAW, Orientation3DStamped::Euler::PITCH};
@@ -163,9 +164,9 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationPartial)
     cov1,
     axes1);
 
-  Eigen::Matrix<double, 1, 1> mean2;
+  fuse_core::Vector1d mean2;
   mean2 << 1.0;
-  Eigen::Matrix<double, 1, 1> cov2;
+  fuse_core::Matrix1d cov2;
   cov2 << 2.0;
   std::vector<Orientation3DStamped::Euler> axes2 =
     {Orientation3DStamped::Euler::ROLL};

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
@@ -55,9 +56,9 @@ TEST(AbsolutePose2DStampedConstraint, Constructor)
   // Construct a constraint just to make sure it compiles.
   Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
   Position2DStamped position_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
-  Eigen::Matrix<double, 3, 1> mean;
+  fuse_core::Vector3d mean;
   mean << 1.0, 2.0, 3.0;
-  Eigen::Matrix<double, 3, 3> cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   EXPECT_NO_THROW(AbsolutePose2DStampedConstraint constraint(position_variable, orientation_variable, mean, cov));
 }
@@ -67,17 +68,17 @@ TEST(AbsolutePose2DStampedConstraint, Covariance)
   // Verify the covariance <--> sqrt information conversions are correct
   Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("mo"));
   Position2DStamped position_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("mo"));
-  Eigen::Vector3d mean;
+  fuse_core::Vector3d mean;
   mean << 1.0, 2.0, 3.0;
-  Eigen::Matrix3d cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   AbsolutePose2DStampedConstraint constraint(position_variable, orientation_variable, mean, cov);
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
-  Eigen::Matrix3d expected_sqrt_info;
+  fuse_core::Matrix3d expected_sqrt_info;
   expected_sqrt_info <<  1.008395589795798, -0.040950074712520, -0.063131365181801,
                          0.000000000000000,  0.712470499879096, -0.071247049987910,
                          0.000000000000000,  0.000000000000000,  0.577350269189626;
-  Eigen::Matrix3d expected_cov = cov;
+  fuse_core::Matrix3d expected_cov = cov;
   // Compare
   EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
   EXPECT_TRUE(expected_sqrt_info.isApprox(constraint.sqrtInformation(), 1.0e-9));
@@ -93,9 +94,9 @@ TEST(AbsolutePose2DStampedConstraint, Optimization)
   position_variable->x() = 1.5;
   position_variable->y() = -3.0;
   // Create an absolute pose constraint
-  Eigen::Vector3d mean;
+  fuse_core::Vector3d mean;
   mean << 1.0, 2.0, 3.0;
-  Eigen::Matrix3d cov;
+  fuse_core::Matrix3d cov;
   cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
   auto constraint = AbsolutePose2DStampedConstraint::make_shared(*position_variable,
                                                                  *orientation_variable,
@@ -141,7 +142,7 @@ TEST(AbsolutePose2DStampedConstraint, Optimization)
   std::vector<double> covariance_vector3(orientation_variable->size() * orientation_variable->size());
   covariance.GetCovarianceBlock(orientation_variable->data(), orientation_variable->data(), covariance_vector3.data());
   // Assemble the full covariance from the covariance blocks
-  Eigen::Matrix3d actual_covariance;
+  fuse_core::Matrix3d actual_covariance;
   actual_covariance(0, 0) = covariance_vector1[0];
   actual_covariance(0, 1) = covariance_vector1[1];
   actual_covariance(1, 0) = covariance_vector1[2];
@@ -151,7 +152,7 @@ TEST(AbsolutePose2DStampedConstraint, Optimization)
   actual_covariance(2, 0) = covariance_vector2[0];
   actual_covariance(2, 1) = covariance_vector2[1];
   actual_covariance(2, 2) = covariance_vector3[0];
-  Eigen::Matrix3d expected_covariance = cov;
+  fuse_core::Matrix3d expected_covariance = cov;
   EXPECT_TRUE(expected_covariance.isApprox(actual_covariance, 1.0e-9));
 }
 

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -33,6 +33,7 @@
  */
 #include <fuse_constraints/absolute_constraint.h>
 #include <fuse_constraints/relative_constraint.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -58,63 +59,63 @@ TEST(RelativeConstraint, Constructor)
   {
     fuse_variables::AccelerationAngular2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("robby"));
     fuse_variables::AccelerationAngular2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("robby"));
-    Eigen::Matrix<double, 1, 1> delta;
+    fuse_core::Vector1d delta;
     delta << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::RelativeAccelerationAngular2DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::AccelerationLinear2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("bender"));
     fuse_variables::AccelerationLinear2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("bender"));
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::RelativeAccelerationLinear2DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::Orientation2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("johnny5"));
     fuse_variables::Orientation2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("johnny5"));
-    Eigen::Matrix<double, 1, 1> delta;
+    fuse_core::Vector1d delta;
     delta << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::RelativeOrientation2DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::Position2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("rosie"));
     fuse_variables::Position2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("rosie"));
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::RelativePosition2DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::Position3DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("clank"));
     fuse_variables::Position3DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("clank"));
-    Eigen::Matrix<double, 3, 1> delta;
+    fuse_core::Vector3d delta;
     delta << 1.0, 2.0, 3.0;
-    Eigen::Matrix<double, 3, 3> cov;
+    fuse_core::Matrix3d cov;
     cov << 1.0, 0.1, 0.2, 0.3, 2.0, 0.3, 0.2, 0.3, 3.0;
     EXPECT_NO_THROW(fuse_constraints::RelativePosition3DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::VelocityAngular2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("gort"));
     fuse_variables::VelocityAngular2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("gort"));
-    Eigen::Matrix<double, 1, 1> delta;
+    fuse_core::Vector1d delta;
     delta << 3.0;
-    Eigen::Matrix<double, 1, 1> cov;
+    fuse_core::Matrix1d cov;
     cov << 1.0;
     EXPECT_NO_THROW(fuse_constraints::RelativeVelocityAngular2DStampedConstraint constraint(x1, x2, delta, cov));
   }
   {
     fuse_variables::VelocityLinear2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("bishop"));
     fuse_variables::VelocityLinear2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("bishop"));
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     EXPECT_NO_THROW(fuse_constraints::RelativeVelocityLinear2DStampedConstraint constraint(x1, x2, delta, cov));
   }
@@ -124,9 +125,9 @@ TEST(RelativeConstraint, PartialMeasurement)
 {
   fuse_variables::Position3DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("vici"));
   fuse_variables::Position3DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("vici"));
-  Eigen::Matrix<double, 2, 1> delta;
+  fuse_core::Vector2d delta;
   delta << 3.0, 1.0;
-  Eigen::Matrix<double, 2, 2> cov;
+  fuse_core::Matrix2d cov;
   cov << 3.0, 0.2, 0.2, 1.0;
   auto indices = std::vector<size_t>{2, 0};
   EXPECT_NO_THROW(fuse_constraints::RelativePosition3DStampedConstraint constraint(x1, x2, delta, cov, indices));
@@ -139,16 +140,16 @@ TEST(RelativeConstraint, Covariance)
     // Verify the covariance <--> sqrt information conversions are correct
     fuse_variables::AccelerationLinear2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("chappie"));
     fuse_variables::AccelerationLinear2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("chappie"));
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
     fuse_constraints::RelativeAccelerationLinear2DStampedConstraint constraint(x1, x2, delta, cov);
     // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
-    Eigen::Matrix<double, 2, 2> expected_sqrt_info;
+    fuse_core::Matrix2d expected_sqrt_info;
     expected_sqrt_info <<  1.002509414234171, -0.050125470711709,
                            0.000000000000000,  0.707106781186547;
-    Eigen::Matrix<double, 2, 2> expected_cov = cov;
+    fuse_core::Matrix2d expected_cov = cov;
     // Compare
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
     EXPECT_TRUE(expected_sqrt_info.isApprox(constraint.sqrtInformation(), 1.0e-9));
@@ -157,18 +158,18 @@ TEST(RelativeConstraint, Covariance)
   {
     fuse_variables::Position3DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("astroboy"));
     fuse_variables::Position3DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("astroboy"));
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 3.0, 1.0;
-    Eigen::Matrix<double, 2, 2> cov;
+    fuse_core::Matrix2d cov;
     cov << 3.0, 0.2, 0.2, 1.0;
     auto indices = std::vector<size_t>{2, 0};
     fuse_constraints::RelativePosition3DStampedConstraint constraint(x1, x2, delta, cov, indices);
     // Define the expected matrices
-    Eigen::Matrix<double, 3, 1> expected_delta;
+    fuse_core::Vector3d expected_delta;
     expected_delta << 1.0, 0.0, 3.0;
-    Eigen::Matrix<double, 3, 3> expected_cov;
+    fuse_core::Matrix3d expected_cov;
     expected_cov << 1.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.2, 0.0, 3.0;
-    Eigen::Matrix<double, 2, 3> expected_sqrt_info;
+    Eigen::Matrix<double, 2, 3, Eigen::RowMajor> expected_sqrt_info;
     expected_sqrt_info << -0.116247638743819,  0.000000000000000,  0.581238193719096,
                            1.000000000000000,  0.000000000000000,  0.000000000000000;
     // Compare
@@ -194,15 +195,15 @@ TEST(RelativeConstraint, Optimization)
     x2->x() = -4.2;
     x2->y() = 1.9;
     // Create an absolute constraint
-    Eigen::Matrix<double, 2, 1> mean;
+    fuse_core::Vector2d mean;
     mean << 1.0, 2.0;
-    Eigen::Matrix<double, 2, 2> cov1;
+    fuse_core::Matrix2d cov1;
     cov1 << 1.0, 0.1, 0.1, 2.0;
     auto prior = fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared(*x1, mean, cov1);
     // Create an relative constraint
-    Eigen::Matrix<double, 2, 1> delta;
+    fuse_core::Vector2d delta;
     delta << 0.1, 0.2;
-    Eigen::Matrix<double, 2, 2> cov2;
+    fuse_core::Matrix2d cov2;
     cov2 << 1.0, 0.0, 0.0, 2.0;
     auto relative = fuse_constraints::RelativeAccelerationLinear2DStampedConstraint::make_shared(*x1, *x2, delta, cov2);
     // Build the problem
@@ -247,15 +248,15 @@ TEST(RelativeConstraint, Optimization)
     // Check the x1 marginal covariance
     std::vector<double> x1_covariance_vector(x1->size() * x1->size());
     covariance.GetCovarianceBlock(x1->data(), x1->data(), x1_covariance_vector.data());
-    Eigen::Matrix<double, 2, 2> x1_actual_covariance(x1_covariance_vector.data());
-    Eigen::Matrix<double, 2, 2> x1_expected_covariance;
+    fuse_core::Matrix2d x1_actual_covariance(x1_covariance_vector.data());
+    fuse_core::Matrix2d x1_expected_covariance;
     x1_expected_covariance << 1.0, 0.1, 0.1, 2.0;
     EXPECT_TRUE(x1_expected_covariance.isApprox(x1_actual_covariance, 1.0e-9));
     // Check the x2 marginal covariance
     std::vector<double> x2_covariance_vector(x2->size() * x2->size());
     covariance.GetCovarianceBlock(x2->data(), x2->data(), x2_covariance_vector.data());
-    Eigen::Matrix<double, 2, 2> x2_actual_covariance(x2_covariance_vector.data());
-    Eigen::Matrix<double, 2, 2> x2_expected_covariance;
+    fuse_core::Matrix2d x2_actual_covariance(x2_covariance_vector.data());
+    fuse_core::Matrix2d x2_expected_covariance;
     x2_expected_covariance << 2.0, 0.1, 0.1, 4.0;
     EXPECT_TRUE(x2_expected_covariance.isApprox(x2_actual_covariance, 1.0e-9));
   }
@@ -277,21 +278,21 @@ TEST(RelativeConstraint, Optimization)
     x2->y() = 1.9;
     x2->z() = 19.2;
     // Create an absolute constraint
-    Eigen::Matrix<double, 3, 1> mean1;
+    fuse_core::Vector3d mean1;
     mean1 << 1.0, 2.0, 3.0;
-    Eigen::Matrix<double, 3, 3> cov1;
+    fuse_core::Matrix3d cov1;
     cov1 << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
     auto c1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(*x1, mean1, cov1);
     // Create an relative constraint
-    Eigen::Matrix<double, 3, 1> delta2;
+    fuse_core::Vector3d delta2;
     delta2 << 0.1, 0.2, 0.3;
-    Eigen::Matrix<double, 3, 3> cov2;
+    fuse_core::Matrix3d cov2;
     cov2 << 1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0;
     auto c2 = fuse_constraints::RelativePosition3DStampedConstraint::make_shared(*x1, *x2, delta2, cov2);
     // Create an partial relative constraint
-    Eigen::Matrix<double, 2, 1> delta3;
+    fuse_core::Vector2d delta3;
     delta3 << 0.1, 0.2;
-    Eigen::Matrix<double, 2, 2> cov3;
+    fuse_core::Matrix2d cov3;
     cov3 << 1.0, 0.0, 0.0, 3.0;
     auto indices3 = std::vector<size_t>{2, 0};
     auto c3 = fuse_constraints::RelativePosition3DStampedConstraint::make_shared(*x1, *x2, delta3, cov3, indices3);
@@ -346,15 +347,15 @@ TEST(RelativeConstraint, Optimization)
     // Check the x1 marginal covariance
     std::vector<double> x1_covariance_vector(x1->size() * x1->size());
     covariance.GetCovarianceBlock(x1->data(), x1->data(), x1_covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> x1_actual_covariance(x1_covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> x1_expected_covariance;
+    fuse_core::Matrix3d x1_actual_covariance(x1_covariance_vector.data());
+    fuse_core::Matrix3d x1_expected_covariance;
     x1_expected_covariance << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
     EXPECT_TRUE(x1_expected_covariance.isApprox(x1_actual_covariance, 1.0e-9));
     // Check the x2 marginal covariance
     std::vector<double> x2_covariance_vector(x2->size() * x2->size());
     covariance.GetCovarianceBlock(x2->data(), x2->data(), x2_covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> x2_actual_covariance(x2_covariance_vector.data());
-    Eigen::Matrix<double, 3, 3> x2_expected_covariance;
+    fuse_core::Matrix3d x2_actual_covariance(x2_covariance_vector.data());
+    fuse_core::Matrix3d x2_expected_covariance;
     x2_expected_covariance << 1.75, 0.1, 0.2, 0.1, 4.0, 0.3, 0.2, 0.3, 3.75;
     EXPECT_TRUE(x2_expected_covariance.isApprox(x2_actual_covariance, 1.0e-9));
   }
@@ -372,15 +373,15 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
                                                               fuse_core::uuid::generate("t800"));
   x2->yaw() = -2.2;
   // Create an absolute constraint
-  Eigen::Matrix<double, 1, 1> mean;
+  fuse_core::Vector1d mean;
   mean << 1.0;
-  Eigen::Matrix<double, 1, 1> cov1;
+  fuse_core::Matrix1d cov1;
   cov1 << 2.0;
   auto prior = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared(*x1, mean, cov1);
   // Create an relative constraint
-  Eigen::Matrix<double, 1, 1> delta;
+  fuse_core::Vector1d delta;
   delta << 0.1;
-  Eigen::Matrix<double, 1, 1> cov2;
+  fuse_core::Matrix1d cov2;
   cov2 << 1.0;
   auto relative = fuse_constraints::RelativeOrientation2DStampedConstraint::make_shared(*x1, *x2, delta, cov2);
   // Build the problem
@@ -423,15 +424,15 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   // Check the x1 marginal covariance
   std::vector<double> x1_covariance_vector(x1->size() * x1->size());
   covariance.GetCovarianceBlock(x1->data(), x1->data(), x1_covariance_vector.data());
-  Eigen::Matrix<double, 1, 1> x1_actual_covariance(x1_covariance_vector.data());
-  Eigen::Matrix<double, 1, 1> x1_expected_covariance;
+  fuse_core::Matrix1d x1_actual_covariance(x1_covariance_vector.data());
+  fuse_core::Matrix1d x1_expected_covariance;
   x1_expected_covariance << 2.0;
   EXPECT_TRUE(x1_expected_covariance.isApprox(x1_actual_covariance, 1.0e-9));
   // Check the x2 marginal covariance
   std::vector<double> x2_covariance_vector(x2->size() * x2->size());
   covariance.GetCovarianceBlock(x2->data(), x2->data(), x2_covariance_vector.data());
-  Eigen::Matrix<double, 1, 1> x2_actual_covariance(x2_covariance_vector.data());
-  Eigen::Matrix<double, 1, 1> x2_expected_covariance;
+  fuse_core::Matrix1d x2_actual_covariance(x2_covariance_vector.data());
+  fuse_core::Matrix1d x2_expected_covariance;
   x2_expected_covariance << 3.0;
   EXPECT_TRUE(x2_expected_covariance.isApprox(x2_actual_covariance, 1.0e-9));
 }

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -31,49 +31,38 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_constraints/normal_delta.h>
+#ifndef FUSE_CORE_EIGEN_H
+#define FUSE_CORE_EIGEN_H
 
-#include <ceres/internal/eigen.h>
 #include <Eigen/Core>
-#include <glog/logging.h>
 
 
-namespace fuse_constraints
+namespace fuse_core
 {
 
-NormalDelta::NormalDelta(const fuse_core::MatrixXd& A, const fuse_core::VectorXd& b) :
-  A_(A),
-  b_(b)
-{
-  CHECK_GT(b_.rows(), 0);
-  CHECK_GT(A_.rows(), 0);
-  CHECK_EQ(b_.rows(), A.cols());
-  set_num_residuals(A_.rows());
-  mutable_parameter_block_sizes()->push_back(b_.rows());
-  mutable_parameter_block_sizes()->push_back(b_.rows());
-}
+// Define some Eigen Typedefs that use Row-Major order
+using VectorXd = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+using Vector1d = Eigen::Matrix<double, 1, 1>;
+using Vector2d = Eigen::Matrix<double, 2, 1>;
+using Vector3d = Eigen::Matrix<double, 3, 1>;
+using Vector4d = Eigen::Matrix<double, 4, 1>;
+using Vector5d = Eigen::Matrix<double, 5, 1>;
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+using Vector7d = Eigen::Matrix<double, 7, 1>;
+using Vector8d = Eigen::Matrix<double, 8, 1>;
+using Vector9d = Eigen::Matrix<double, 9, 1>;
 
-bool NormalDelta::Evaluate(
-  double const* const* parameters,
-  double* residuals,
-  double** jacobians) const
-{
-  Eigen::Map<const fuse_core::VectorXd> x0(parameters[0], parameter_block_sizes()[0]);
-  Eigen::Map<const fuse_core::VectorXd> x1(parameters[1], parameter_block_sizes()[1]);
-  Eigen::Map<fuse_core::VectorXd> r(residuals, num_residuals());
-  r = A_ * (x1 - x0 - b_);
-  if (jacobians != NULL)
-  {
-    if (jacobians[0] != NULL)
-    {
-      Eigen::Map<fuse_core::MatrixXd>(jacobians[0], num_residuals(), parameter_block_sizes()[0]) = -A_;
-    }
-    if (jacobians[1] != NULL)
-    {
-      Eigen::Map<fuse_core::MatrixXd>(jacobians[1], num_residuals(), parameter_block_sizes()[1]) = A_;
-    }
-  }
-  return true;
-}
+using MatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+using Matrix1d = Eigen::Matrix<double, 1, 1, Eigen::RowMajor>;
+using Matrix2d = Eigen::Matrix<double, 2, 2, Eigen::RowMajor>;
+using Matrix3d = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+using Matrix4d = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
+using Matrix5d = Eigen::Matrix<double, 5, 5, Eigen::RowMajor>;
+using Matrix6d = Eigen::Matrix<double, 6, 6, Eigen::RowMajor>;
+using Matrix7d = Eigen::Matrix<double, 7, 7, Eigen::RowMajor>;
+using Matrix8d = Eigen::Matrix<double, 8, 8, Eigen::RowMajor>;
+using Matrix9d = Eigen::Matrix<double, 9, 9, Eigen::RowMajor>;
 
-}  // namespace fuse_constraints
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_EIGEN_H


### PR DESCRIPTION
Converted all Eigen objects to use row-major order. Eigen::Vector objects do not need the RowMajor attribute.