### PR TITLE
Adding subset measurement support for AbsolutePose2DStampedConstraint

### DIFF
--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -71,19 +71,26 @@ public:
    * Note that, when measuring subset of dimensions, empty axis vectors are permitted. This signifies, e.g., that you
    * don't want to measure any of the quantities in that variable.
    *
-   * @param[in] position        The variable representing the position components of the pose
-   * @param[in] orientation     The variable representing the orientation components of the pose
-   * @param[in] mean            The measured/prior pose as a vector (max 3x1 vector: x, y, yaw)
-   * @param[in] covariance      The measurement/prior covariance (max 3x3 matrix: x, y, yaw)
-   * @param[in] linear_indices  The set of indices corresponding to the measured position dimensions
-   *                         e.g. "{ fuse_variables::Position2DStamped::X, fuse_variables::Position2DStamped::Y }"
-   * @param[in] angular_indices The set of indices corresponding to the measured orientation dimensions (just yaw)
+   * The mean is given as a vector. The first components (if any) will be dictated, both in content and in ordering, by
+   * the value of the \p linear_indices. The final component (if any) is dictated by the \p angular_indices.
+   * The covariance matrix follows the same ordering.
+   *
+   * @param[in] position           The variable representing the position components of the pose
+   * @param[in] orientation        The variable representing the orientation components of the pose
+   * @param[in] partial_mean       The measured/prior pose as a vector (max 3x1 vector, components are dictated by
+   *                               \p linear_indices and \p angular_indices)
+   * @param[in] partial_covariance The measurement/prior covariance (max 3x3 matrix, components are dictated by
+   *                               \p linear_indices and \p angular_indices)
+   * @param[in] linear_indices     The set of indices corresponding to the measured position dimensions
+   *                               e.g. "{fuse_variables::Position2DStamped::X, fuse_variables::Position2DStamped::Y}"
+   * @param[in] angular_indices    The set of indices corresponding to the measured orientation dimensions
+   *                               e.g. "{fuse_variables::Orientation2DStamped::Yaw}"
    */
   AbsolutePose2DStampedConstraint(
     const fuse_variables::Position2DStamped& position,
     const fuse_variables::Orientation2DStamped& orientation,
-    const fuse_core::VectorXd& mean,
-    const fuse_core::MatrixXd& covariance,
+    const fuse_core::VectorXd& partial_mean,
+    const fuse_core::MatrixXd& partial_covariance,
     const std::vector<size_t>& linear_indices =
       {fuse_variables::Position2DStamped::X, fuse_variables::Position2DStamped::Y},             // NOLINT
     const std::vector<size_t>& angular_indices = {fuse_variables::Orientation2DStamped::YAW});  // NOLINT
@@ -96,14 +103,16 @@ public:
   /**
    * @brief Read-only access to the measured/prior vector of mean values.
    *
-   * Order is (x, y, yaw)
+   * Order is (x, y, yaw). Note that the returned vector will be full sized (3x1) and in the stated order.
    */
   const fuse_core::VectorXd& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
    *
-   * Order is (x, y, yaw)
+   * Order is (x, y, yaw). Note that the returned covariance matrix will be full sized (3x3) and in the stated order.
+   * If only a partial covariance matrix was provided in the constructor, this covariance matrix may be a different
+   * size and in a different order than the constructor input.
    */
   const fuse_core::MatrixXd& sqrtInformation() const { return sqrt_information_; }
 
@@ -112,7 +121,7 @@ public:
    *
    * Order is (x, y, yaw)
    */
-  fuse_core::MatrixXd covariance() const { return (sqrt_information_.transpose() * sqrt_information_).inverse(); }
+  fuse_core::MatrixXd covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -144,7 +153,6 @@ public:
 protected:
   fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
-  size_t total_indices_;  //!< The number of indices we're constraining
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -105,23 +105,23 @@ public:
    *
    * Order is (x, y, yaw). Note that the returned vector will be full sized (3x1) and in the stated order.
    */
-  const fuse_core::VectorXd& mean() const { return mean_; }
+  const fuse_core::Vector3d& mean() const { return mean_; }
 
   /**
    * @brief Read-only access to the square root information matrix.
    *
-   * Order is (x, y, yaw). Note that the returned covariance matrix will be full sized (3x3) and in the stated order.
-   * If only a partial covariance matrix was provided in the constructor, this covariance matrix may be a different
-   * size and in a different order than the constructor input.
+   * If only a partial covariance matrix was provided in the constructor, this covariance matrix will not be square.
    */
   const fuse_core::MatrixXd& sqrtInformation() const { return sqrt_information_; }
 
   /**
    * @brief Compute the measurement covariance matrix.
    *
-   * Order is (x, y, yaw)
+   * Order is (x, y, yaw). Note that the returned covariance matrix will be full sized (3x3) and in the stated order.
+   * If only a partial covariance matrix was provided in the constructor, this covariance matrix may be a different
+   * size and in a different order than the constructor input.
    */
-  fuse_core::MatrixXd covariance() const;
+  fuse_core::Matrix3d covariance() const;
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -151,7 +151,7 @@ public:
   ceres::CostFunction* costFunction() const override;
 
 protected:
-  fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
+  fuse_core::Vector3d mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
 };
 

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -37,6 +37,8 @@
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Dense>
 
+#include <vector>
+
 
 namespace fuse_constraints
 {
@@ -44,12 +46,43 @@ namespace fuse_constraints
 AbsolutePose2DStampedConstraint::AbsolutePose2DStampedConstraint(
   const fuse_variables::Position2DStamped& position,
   const fuse_variables::Orientation2DStamped& orientation,
-  const fuse_core::Vector3d& mean,
-  const fuse_core::Matrix3d& covariance) :
-    fuse_core::Constraint{position.uuid(), orientation.uuid()},
-    mean_(mean),
-    sqrt_information_(covariance.inverse().llt().matrixU())
+  const fuse_core::VectorXd& partial_mean,
+  const fuse_core::MatrixXd& partial_covariance,
+  const std::vector<size_t>& linear_indices,
+  const std::vector<size_t>& angular_indices) :
+    fuse_core::Constraint{position.uuid(), orientation.uuid()}
 {
+  size_t total_variable_size = position.size() + orientation.size();
+  total_indices_ = linear_indices.size() + angular_indices.size();
+
+  assert(partial_mean.rows() == static_cast<int>(total_indices_));
+  assert(partial_covariance.rows() == static_cast<int>(total_indices_));
+  assert(partial_covariance.cols() == static_cast<int>(total_indices_));
+
+  // Compute the sqrt information of the provided cov matrix
+  fuse_core::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
+
+  // Assemble a mean vector and sqrt information matrix from the provided values, but in proper Variable order
+  // What are we doing here?
+  // The constraint equation is defined as: cost(x) = ||A * (x - b)||^2
+  // If we are measuring a subset of dimensions, we only want to produce costs for the measured dimensions.
+  // But the variable vectors will be full sized. We can make this all work out by creating a non-square A
+  // matrix, where each row computes a cost for one measured dimensions, and the columns are in the order
+  // defined by the variable.
+  mean_ = fuse_core::VectorXd::Zero(total_variable_size);
+  sqrt_information_ = fuse_core::MatrixXd::Zero(total_indices_, total_variable_size);
+  for (size_t i = 0; i < linear_indices.size(); ++i)
+  {
+    mean_(linear_indices[i]) = partial_mean(i);
+    sqrt_information_.col(linear_indices[i]) = partial_sqrt_information.col(i);
+  }
+
+  for (size_t i = linear_indices.size(); i < total_indices_; ++i)
+  {
+    size_t final_index = position.size() + angular_indices[i - linear_indices.size()];
+    mean_(final_index) = partial_mean(i);
+    sqrt_information_.col(final_index) = partial_sqrt_information.col(i);
+  }
 }
 
 void AbsolutePose2DStampedConstraint::print(std::ostream& stream) const
@@ -69,8 +102,8 @@ fuse_core::Constraint::UniquePtr AbsolutePose2DStampedConstraint::clone() const
 
 ceres::CostFunction* AbsolutePose2DStampedConstraint::costFunction() const
 {
-  return new ceres::AutoDiffCostFunction<NormalPriorPose2DCostFunctor, 3, 2, 1>(
-    new NormalPriorPose2DCostFunctor(sqrt_information_, mean_));
+  return new ceres::AutoDiffCostFunction<NormalPriorPose2DCostFunctor, ceres::DYNAMIC, 2, 1>(
+    new NormalPriorPose2DCostFunctor(sqrt_information_, mean_), total_indices_);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -85,7 +85,7 @@ AbsolutePose2DStampedConstraint::AbsolutePose2DStampedConstraint(
   }
 }
 
-fuse_core::MatrixXd AbsolutePose2DStampedConstraint::covariance() const
+fuse_core::Matrix3d AbsolutePose2DStampedConstraint::covariance() const
 {
   // We want to compute:
   // cov = (sqrt_info' * sqrt_info)^-1

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -305,7 +305,7 @@ TEST(AbsoluteConstraint, PartialOptimization)
   mean2 << 2.0;
   fuse_core::Matrix1d cov2;
   cov2 << 1.0;
-  std::vector<size_t> indices2 = {1};
+  std::vector<size_t> indices2 = {fuse_variables::Position3DStamped::Y};
   auto constraint2 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(*var, mean2, cov2, indices2);
 
   // Build the problem

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -297,7 +297,7 @@ TEST(AbsoluteConstraint, PartialOptimization)
   fuse_core::Matrix2d cov1;
   cov1 << 1.0, 0.0,
           0.0, 1.0;
-  std::vector<size_t> indices1 = {2, 0};
+  std::vector<size_t> indices1 = {fuse_variables::Position3DStamped::Z, fuse_variables::Position3DStamped::X};
   auto constraint1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(*var, mean1, cov1, indices1);
 
   // Create another constraint for the second index


### PR DESCRIPTION
I needed this functionality in `fuse_rl`. Note that I also added an `AbsoluteConstraint` test that uses a mutually exclusive dimension set for the two constraints. The previous partial optimization test added a partial measurement to a full measurement.