### PR TITLE
[RST-1567] Check the system has started before attempting to optimize

### DIFF
--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -36,6 +36,8 @@
 
 #include <ceres/autodiff_cost_function.h>
 
+#include <vector>
+
 
 namespace fuse_constraints
 {
@@ -58,10 +60,10 @@ RelativePose2DStampedConstraint::RelativePose2DStampedConstraint(
   assert(partial_covariance.rows() == static_cast<int>(total_indices));
   assert(partial_covariance.cols() == static_cast<int>(total_indices));
 
-   // Compute the sqrt information of the provided cov matrix
+  // Compute the sqrt information of the provided cov matrix
   fuse_core::MatrixXd partial_sqrt_information = partial_covariance.inverse().llt().matrixU();
 
-   // Assemble a mean vector and sqrt information matrix from the provided values, but in proper variable order
+  // Assemble a mean vector and sqrt information matrix from the provided values, but in proper variable order
   // What are we doing here?
   // The constraint equation is defined as: cost(x) = ||A * (x - b)||^2
   // If we are measuring a subset of dimensions, we only want to produce costs for the measured dimensions.

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -202,6 +202,11 @@ void BatchOptimizer::optimizationLoop()
 
 void BatchOptimizer::optimizerTimerCallback(const ros::TimerEvent& event)
 {
+  // If an "ignition" transaction hasn't been received, then we can't do anything yet.
+  if (!started_)
+  {
+    return;
+  }
   // Attempt to generate motion models for any queued transactions
   applyMotionModelsToQueue();
   // Check if there is any pending information to be applied to the graph.


### PR DESCRIPTION
Running a bagfile-based optimizer test throws an error during a covariance calculation, claiming the system is rank deficient.

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
E1206 06:45:02.572094 18895 covariance_impl.cc:656] Jacobian matrix is rank deficient. Number of columns: 6 rank: 3
terminate called after throwing an instance of 'std::runtime_error'
what(): Could not compute requested covariance blocks.
```

* The error is thrown almost immediately after the bagfile starts playing.
* Currently the covariance computation is only done in the publishers, for displaying the PoseWithCovariance.
* The rank deficiency of 6 columns but rank 3 makes me think the first relative pose is added, but the initial prior/origin constraint is not. This is supposed to be guarded from happening by the "ignition sensor" system.
* The fact that the ignition sensor is not publishing is an unrelated problem with my machine. :)