### PR TITLE
[RST-1653] transaction stamps

### DIFF
--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -43,7 +43,6 @@
 #include <ros/spinner.h>
 
 #include <functional>
-#include <set>
 #include <string>
 
 
@@ -116,8 +115,8 @@ public:
    * private node handle will be in a namespace based on the plugin's name. This should prevent conflicts and allow
    * the same plugin to be used multiple times with different settings and topics.
    *
-   * @param[in] name                       A unique name to give this plugin instance
-   * @param[in] transaction_callback       The function to call every time a transaction is published
+   * @param[in] name                 A unique name to give this plugin instance
+   * @param[in] transaction_callback The function to call every time a transaction is published
    */
   void initialize(
     const std::string& name,
@@ -134,12 +133,9 @@ public:
    * This should be called by derived classes whenever a new Transaction is generated, probably from within the sensor
    * message callback function.
    *
-   * @param[in] stamps      Any timestamps associated with the added variables. These are sent to the motion models.
    * @param[in] transaction A Transaction object describing the set of variables that have been added and removed.
    */
-  void sendTransaction(
-    const std::set<ros::Time>& stamps,
-    const Transaction::SharedPtr& transaction);
+  void sendTransaction(Transaction::SharedPtr transaction);
 
   /**
    * @brief Get the unique name of this sensor
@@ -189,7 +185,7 @@ protected:
    * Derived sensor models classes must implement this function, because otherwise I'm not sure how the derived
    * sensor model would actually do anything.
    */
-  virtual void onInit() = 0;
+  virtual void onInit() {}
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -52,24 +52,6 @@ namespace fuse_core
 {
 
 /**
- * @brief A range of fuse_ros::Constraint objects
- *
- * An object representing a range defined by two iterators. It has begin() and end() methods (which means it can
- * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
- * member. When dereferenced, an iterator returns a const Constraint&.
- */
-using const_constraint_range = boost::any_range<const Constraint, boost::forward_traversal_tag>;
-
-/**
- * @brief A range of fuse_ros::Variable objects
- *
- * An object representing a range defined by two iterators. It has begin() and end() methods (which means it can
- * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
- * member. When dereferenced, an iterator returns a const Variable&.
- */
-using const_variable_range = boost::any_range<const Variable, boost::forward_traversal_tag>;
-
-/**
  * @brief This is an interface definition describing the collection of constraints and variables that form the factor
  * graph, a graphical model of a nonlinear least-squares problem.
  *
@@ -81,6 +63,24 @@ class Graph
 {
 public:
   SMART_PTR_ALIASES_ONLY(Graph);
+
+  /**
+   * @brief A range of fuse_ros::Constraint objects
+   *
+   * An object representing a range defined by two iterators. It has begin() and end() methods (which means it can
+   * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
+   * member. When dereferenced, an iterator returns a const Constraint&.
+   */
+  using const_constraint_range = boost::any_range<const Constraint, boost::forward_traversal_tag>;
+
+  /**
+   * @brief A range of fuse_ros::Variable objects
+   *
+   * An object representing a range defined by two iterators. It has begin() and end() methods (which means it can
+   * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
+   * member. When dereferenced, an iterator returns a const Variable&.
+   */
+  using const_variable_range = boost::any_range<const Variable, boost::forward_traversal_tag>;
 
   /**
    * @brief Constructor
@@ -95,7 +95,7 @@ public:
 
   /**
    * @brief Return a deep copy of the graph object.
-   * 
+   *
    * This should include deep copies of all variables and constraints; not pointer copies.
    */
   virtual Graph::UniquePtr clone() const = 0;

--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -58,7 +58,7 @@ namespace fuse_core
  * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
  * member. When dereferenced, an iterator returns a const Constraint&.
  */
-using const_constraint_range = boost::any_range<const fuse_core::Constraint, boost::forward_traversal_tag>;
+using const_constraint_range = boost::any_range<const Constraint, boost::forward_traversal_tag>;
 
 /**
  * @brief A range of fuse_ros::Variable objects
@@ -67,7 +67,7 @@ using const_constraint_range = boost::any_range<const fuse_core::Constraint, boo
  * be used in range-based for loops), an empty() method, and a front() method for directly accessing the first
  * member. When dereferenced, an iterator returns a const Variable&.
  */
-using const_variable_range = boost::any_range<const fuse_core::Variable, boost::forward_traversal_tag>;
+using const_variable_range = boost::any_range<const Variable, boost::forward_traversal_tag>;
 
 /**
  * @brief This is an interface definition describing the collection of constraints and variables that form the factor
@@ -252,18 +252,18 @@ public:
   /**
    * @brief Update the graph with the contents of a transaction
    *
-   * @param[in]  transaction  A set of variable and constraints additions and deletions
+   * @param[in] transaction A set of variable and constraints additions and deletions
    */
-  void update(const fuse_core::Transaction& transaction);
+  void update(const Transaction& transaction);
 
   /**
    * @brief Optimize the values of the current set of variables, given the current set of constraints.
    *
    * After the call, the values in the graph will be updated to the latest values.
    *
-   * @param[in]  options  An optional Ceres Solver::Options object that controls various aspects of the optimizer.
-   *                      See https://ceres-solver.googlesource.com/ceres-solver/+/master/include/ceres/solver.h#59
-   * @return              A Ceres Solver Summary structure containing information about the optimization process
+   * @param[in] options An optional Ceres Solver::Options object that controls various aspects of the optimizer.
+   *                    See https://ceres-solver.googlesource.com/ceres-solver/+/master/include/ceres/solver.h#59
+   * @return            A Ceres Solver Summary structure containing information about the optimization process
    */
   virtual ceres::Solver::Summary optimize(const ceres::Solver::Options& options = ceres::Solver::Options()) = 0;
 };

--- a/fuse_core/include/fuse_core/motion_model.h
+++ b/fuse_core/include/fuse_core/motion_model.h
@@ -37,9 +37,7 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/transaction.h>
-#include <ros/time.h>
 
-#include <set>
 #include <string>
 
 
@@ -94,15 +92,14 @@ public:
   virtual void graphCallback(Graph::ConstSharedPtr graph) {}
 
   /**
-   * @brief Augment a transaction structure such that the provided timestamps are connected by motion model constraints.
+   * @brief Augment a transaction object such that all involved timestamps are connected by motion model constraints.
    *
    * This function will be called by the optimizer (in the Optimizer's thread) for each received transaction.
    *
-   * @param[in]  stamps      The set of timestamps that should be connected by motion model constraints
-   * @param[out] transaction The transaction object that should be augmented with motion model constraints
-   * @return                 True if the motion models were generated successfully, false otherwise
+   * @param[in,out] transaction The transaction object that should be augmented with motion model constraints
+   * @return                    True if the motion models were generated successfully, false otherwise
    */
-  virtual bool apply(const std::set<ros::Time>& stamps, Transaction& transaction) = 0;
+  virtual bool apply(Transaction& transaction) = 0;
 
 protected:
   /**

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -37,11 +37,8 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/transaction.h>
-#include <ros/callback_queue.h>
-#include <ros/time.h>
 
 #include <functional>
-#include <set>
 #include <string>
 
 
@@ -51,8 +48,7 @@ namespace fuse_core
 /**
  * @brief The signature of the callback function that will be executed for every generated transaction object.
  */
-using TransactionCallback = std::function<void(const std::set<ros::Time>& stamps,
-                                               const Transaction::SharedPtr& transaction)>;
+using TransactionCallback = std::function<void(Transaction::SharedPtr transaction)>;
 
 /**
  * @brief The interface definiton for sensor model plugins in the fuse ecosystem.
@@ -101,8 +97,8 @@ public:
    * encouraged to subnamespace any of their parameters to prevent conflicts and allow the same plugin to be used
    * multiple times with different settings and topics.
    *
-   * @param[in] name                       A unique name to give this plugin instance
-   * @param[in] transaction_callback       The function to call every time a transaction is published
+   * @param[in] name                 A unique name to give this plugin instance
+   * @param[in] transaction_callback The function to call every time a transaction is published
    */
   virtual void initialize(
     const std::string& name,

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -36,12 +36,10 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
 #include <ros/node_handle.h>
-#include <ros/time.h>
 
 #include <boost/make_shared.hpp>
 
 #include <functional>
-#include <set>
 #include <string>
 
 
@@ -54,7 +52,7 @@ AsyncMotionModel::AsyncMotionModel(size_t thread_count) :
 {
 }
 
-bool AsyncMotionModel::apply(const std::set<ros::Time>& stamps, Transaction& transaction)
+bool AsyncMotionModel::apply(Transaction& transaction)
 {
   // Insert a call to the motion model's queryCallback() function into the motion model's callback queue. While this
   // makes this particular function more difficult to write, it does simplify the threading model on all derived
@@ -63,7 +61,7 @@ bool AsyncMotionModel::apply(const std::set<ros::Time>& stamps, Transaction& tra
   // This function blocks until the queryCallback() call completes, thus enforcing that motion models are generated
   // in order.
   auto callback = boost::make_shared<CallbackWrapper<bool> >(
-    std::bind(&AsyncMotionModel::applyCallback, this, std::ref(stamps), std::ref(transaction)));
+    std::bind(&AsyncMotionModel::applyCallback, this, std::ref(transaction)));
   auto result = callback->getFuture();
   callback_queue_.addCallback(callback);
   result.wait();

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -71,7 +71,7 @@ void AsyncPublisher::notify(Transaction::ConstSharedPtr transaction, Graph::Cons
 {
   // Insert a call to the `notifyCallback` method into the internal callback queue.
   // This minimizes the time spent by the optimizer's thread calling this function.
-  auto callback = boost::make_shared<fuse_core::CallbackWrapper<void>>(
+  auto callback = boost::make_shared<CallbackWrapper<void>>(
     std::bind(&AsyncPublisher::notifyCallback, this, std::move(transaction), std::move(graph)));
   callback_queue_.addCallback(callback);
 }

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -36,12 +36,10 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
 #include <ros/callback_queue.h>
-#include <ros/time.h>
 
 #include <boost/make_shared.hpp>
 
 #include <functional>
-#include <set>
 #include <string>
 
 
@@ -78,11 +76,9 @@ void AsyncSensorModel::initialize(
   spinner_.start();
 }
 
-void AsyncSensorModel::sendTransaction(
-  const std::set<ros::Time>& stamps,
-  const Transaction::SharedPtr& transaction)
+void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
 {
-  transaction_callback_(stamps, transaction);
+  transaction_callback_(std::move(transaction));
 }
 
 }  // namespace fuse_core

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_core/graph.h>
+#include <fuse_core/transaction.h>
 
 #include <vector>
 
@@ -47,7 +48,7 @@ void Graph::marginalizeVariables(const std::vector<UUID>& variable_uuids)
   }
 }
 
-void Graph::update(const fuse_core::Transaction& transaction)
+void Graph::update(const Transaction& transaction)
 {
   // Update the graph with a new transaction. In order to keep the graph consistent, variables are added first,
   // followed by the constraints which might use the newly added variables. Then constraints are removed so that
@@ -56,12 +57,12 @@ void Graph::update(const fuse_core::Transaction& transaction)
   // Insert the new variables into the graph
   for (const auto& variable : transaction.addedVariables())
   {
-    addVariable(variable);
+    addVariable(variable.clone());
   }
   // Insert the new constraints into the graph
   for (const auto& constraint : transaction.addedConstraints())
   {
-    addConstraint(constraint);
+    addConstraint(constraint.clone());
   }
   // Delete constraints from the graph
   for (const auto& constraint_uuid : transaction.removedConstraints())

--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -68,21 +68,26 @@ void TimestampManager::query(
   // Verify the query is within the buffer length
   if ( (!motion_model_history_.empty())
     && (buffer_length_ != ros::DURATION_MAX)
-    && (*stamps.begin() < motion_model_history_.begin()->first)
-    && (*stamps.begin() < (motion_model_history_.rbegin()->first - buffer_length_)))
+    && (stamps.front() < motion_model_history_.begin()->first)
+    && (stamps.front() < (motion_model_history_.rbegin()->first - buffer_length_)))
   {
     throw std::invalid_argument("All timestamps must be within the defined buffer length of the motion model");
   }
   // Create a list of all the required timestamps involved in motion model segments that must be created
   // Add all of the existing timestamps between the first and last input stamp
   Transaction motion_model_transaction;
-  auto first_stamp = *stamps.begin();
-  auto last_stamp = *stamps.begin();
-  for (const auto& stamp : stamps)
+  auto first_stamp = stamps.front();
+  // stamps is a forward-only range. Getting the last element takes a bit of work.
+  ros::Time last_stamp;
   {
-    motion_model_transaction.addInvolvedStamp(stamp);
-    last_stamp = stamp;
+    auto iter = stamps.begin();
+    while (std::next(iter) != stamps.end())
+    {
+      ++iter;
+    }
+    last_stamp = *iter;
   }
+  std::set<ros::Time> augmented_stamps(stamps.begin(), stamps.end());
   {
     auto begin = motion_model_history_.upper_bound(first_stamp);
     if (begin != motion_model_history_.begin())
@@ -92,40 +97,39 @@ void TimestampManager::query(
     auto end = motion_model_history_.upper_bound(last_stamp);
     for (auto iter = begin; iter != end; ++iter)
     {
-      motion_model_transaction.addInvolvedStamp(iter->first);
+      augmented_stamps.insert(iter->first);
     }
     if (end != motion_model_history_.end())
     {
-      motion_model_transaction.addInvolvedStamp(end->first);
+      augmented_stamps.insert(end->first);
     }
   }
   // Convert the sequence of stamps into stamp pairs that must be generated
   std::vector<std::pair<ros::Time, ros::Time>> stamp_pairs;
   {
-    auto augmented_stamps = motion_model_transaction.involvedStamps();
-    auto augmented_stamps_iter = augmented_stamps.begin();
-    ros::Time previous_stamp = *augmented_stamps_iter;
-    ++augmented_stamps_iter;
-    while (augmented_stamps_iter != augmented_stamps.end())
+    for (auto previous_iter = augmented_stamps.begin(), current_iter = std::next(augmented_stamps.begin());
+         current_iter != augmented_stamps.end();
+         ++previous_iter, ++current_iter)
     {
-      const ros::Time& current_stamp = *augmented_stamps_iter;
+      const ros::Time& previous_stamp = *previous_iter;
+      const ros::Time& current_stamp = *current_iter;
       // Check if the timestamp pair is exactly an existing pair. If so, don't add it.
       auto history_iter = motion_model_history_.lower_bound(previous_stamp);
-      if (!(   (history_iter != motion_model_history_.end())
-            && (history_iter->second.beginning_stamp == previous_stamp)
-            && (history_iter->second.ending_stamp == current_stamp)))
+      if ((history_iter != motion_model_history_.end()) &&
+          (history_iter->second.beginning_stamp == previous_stamp) &&
+          (history_iter->second.ending_stamp == current_stamp))
       {
-        stamp_pairs.emplace_back(previous_stamp, current_stamp);
-        // Check if this stamp is in the middle of an existing entry. If so, delete it.
-        if ( (history_iter != motion_model_history_.end())
-          && (history_iter->second.beginning_stamp < current_stamp)
-          && (history_iter->second.ending_stamp >= current_stamp))
-        {
-          removeSegment(history_iter, motion_model_transaction);
-        }
+        continue;
       }
-      previous_stamp = current_stamp;
-      ++augmented_stamps_iter;
+      // Check if this stamp is in the middle of an existing entry. If so, delete it.
+      if ((history_iter != motion_model_history_.end()) &&
+          (history_iter->second.beginning_stamp < current_stamp) &&
+          (history_iter->second.ending_stamp >= current_stamp))
+      {
+        removeSegment(history_iter, motion_model_transaction);
+      }
+      // Add this pair
+      stamp_pairs.emplace_back(previous_stamp, current_stamp);
     }
   }
   // Create the required segments
@@ -167,6 +171,8 @@ void TimestampManager::addSegment(
   std::vector<Variable::SharedPtr> variables;
   generator_(beginning_stamp, ending_stamp, constraints, variables);
   // Update the transaction with the generated constraints/variables
+  transaction.addInvolvedStamp(beginning_stamp);
+  transaction.addInvolvedStamp(ending_stamp);
   for (const auto& constraint : constraints)
   {
     transaction.addConstraint(constraint);
@@ -187,6 +193,8 @@ void TimestampManager::removeSegment(
   Transaction& transaction)
 {
   // Mark the previously generated constraints for removal
+  transaction.addInvolvedStamp(iter->second.beginning_stamp);
+  transaction.addInvolvedStamp(iter->second.ending_stamp);
   for (const auto& constraint : iter->second.constraints)
   {
     transaction.removeConstraint(constraint->uuid());

--- a/fuse_core/test/test_async_motion_model.cpp
+++ b/fuse_core/test/test_async_motion_model.cpp
@@ -36,8 +36,6 @@
 
 #include <gtest/gtest.h>
 
-#include <set>
-
 
 /**
  * @brief Derived AsyncMotionModel used to verify the functions get called when expected
@@ -53,7 +51,7 @@ public:
 
   virtual ~MyMotionModel() = default;
 
-  bool applyCallback(const std::set<ros::Time>& stamps, fuse_core::Transaction& transaction)
+  bool applyCallback(fuse_core::Transaction& transaction)
   {
     ros::Duration(1.0).sleep();
     transaction_received = true;
@@ -111,10 +109,9 @@ TEST(AsyncMotionModel, ApplyCallback)
   // Call the motion model base class "apply()" method to send a transaction to the derived model. The AsyncMotionModel
   // will then inject a call to applyCallback() into the motion model's callback queue. There is a time delay there, so
   // this call should block for *at least* 1.0 second. Once it returns, the "received_transaction" flag should be set.
-  std::set<ros::Time> stamps;
   fuse_core::Transaction transaction;
   ros::Time before_apply = ros::Time::now();
-  motion_model.apply(stamps, transaction);
+  motion_model.apply(transaction);
   ros::Time after_apply = ros::Time::now();
   EXPECT_TRUE(motion_model.transaction_received);
   EXPECT_LE(ros::Duration(1.0), after_apply - before_apply);

--- a/fuse_core/test/test_async_sensor_model.cpp
+++ b/fuse_core/test/test_async_sensor_model.cpp
@@ -36,8 +36,6 @@
 
 #include <gtest/gtest.h>
 
-#include <set>
-
 
 /**
  * @brief Flag used to track the execution of the transaction callback
@@ -47,7 +45,7 @@ static bool received_transaction = false;
 /**
  * @brief Transaction callback function used to verify the function gets called in the background
  */
-void transactionCallback(const std::set<ros::Time>& stamps, const fuse_core::Transaction::SharedPtr& transaction)
+void transactionCallback(fuse_core::Transaction::SharedPtr transaction)
 {
   ros::Duration(1.0).sleep();
   received_transaction = true;
@@ -115,9 +113,8 @@ TEST(AsyncSensorModel, SendTransaction)
   sensor.initialize("my_sensor", &transactionCallback);
 
   // Use the sensor "sendTransaction()" method to execute the transaction callback. This will get executed immediately.
-  std::set<ros::Time> stamps;
   fuse_core::Transaction::SharedPtr transaction;  // nullptr, okay because we don't actually use it for anything
-  sensor.sendTransaction(stamps, transaction);
+  sensor.sendTransaction(transaction);
   EXPECT_TRUE(received_transaction);
 }
 

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -60,7 +60,7 @@ namespace fuse_graphs
  * full SLAM and mapping applications. The hashmap overhead may be too expensive for use in high-frequency systems with
  * a basically fixed graph size. Something base on a boost::flat_map or similar may perform better in those situations.
  * The final decision on the graph type should be based actual performance testing.
- * 
+ *
  * This class is not thread-safe. If used in a multi-threaded application, standard thread synchronization techniques
  * should be used to guard access to the graph.
  */
@@ -79,7 +79,7 @@ public:
 
   /**
    * @brief Copy constructor
-   * 
+   *
    * Performs a deep copy of the graph
    */
   HashGraph(const HashGraph& other);
@@ -91,14 +91,14 @@ public:
 
   /**
    * @brief Assignment operator
-   * 
+   *
    * Performs a deep copy of the graph
    */
   HashGraph& operator=(const HashGraph& other);
 
   /**
    * @brief Return a deep copy of the graph object.
-   * 
+   *
    * This should include deep copies of all variables and constraints; not pointer copies.
    */
   fuse_core::Graph::UniquePtr clone() const override;
@@ -162,10 +162,10 @@ public:
    * Exceptions: None
    * Complexity: O(1) This function returns in constant time. However, iterating through the returned
    *                  range is naturally O(N).
-   * 
+   *
    * @return A read-only iterator range containing all constraints
    */
-  fuse_core::const_constraint_range getConstraints() const noexcept override;
+  fuse_core::Graph::const_constraint_range getConstraints() const noexcept override;
 
   /**
    * @brief Check if the variable already exists in the graph
@@ -224,10 +224,10 @@ public:
    * Exceptions: None
    * Complexity: O(1) This function returns in constant time. However, iterating through the returned
    *                  range is naturally O(N).
-   * 
+   *
    * @return A read-only iterator range containing all variables
    */
-  fuse_core::const_variable_range getVariables() const noexcept override;
+  fuse_core::Graph::const_variable_range getVariables() const noexcept override;
 
   /**
    * @brief Configure a variable to hold its current value during optimization
@@ -272,7 +272,7 @@ public:
    * Complexity: O(N) in the best case, O(N^3) in the worst case, where N is the total number of variables in
    *             the graph. In practice, it is significantly cheaper than the worst-case bound, but it is still
    *             an expensive operation.
-   * 
+   *
    * @param[in]  covariance_requests A set of variable UUID pairs for which the marginal covariance is desired.
    * @param[out] covariance_matrices The dense covariance blocks of the requests.
    * @param[in]  options             A Ceres Covariance Options structure that controls the method and settings used

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -156,7 +156,7 @@ const fuse_core::Constraint& HashGraph::getConstraint(const fuse_core::UUID& con
   return *constraints_iter->second;
 }
 
-fuse_core::const_constraint_range HashGraph::getConstraints() const noexcept
+fuse_core::Graph::const_constraint_range HashGraph::getConstraints() const noexcept
 {
   std::function<const fuse_core::Constraint&(const Constraints::value_type& uuid__constraint)> to_constraint_ref =
     [](const Constraints::value_type& uuid__constraint) -> const fuse_core::Constraint&
@@ -164,7 +164,7 @@ fuse_core::const_constraint_range HashGraph::getConstraints() const noexcept
       return *uuid__constraint.second;
     };
 
-  return fuse_core::const_constraint_range(
+  return fuse_core::Graph::const_constraint_range(
     boost::make_transform_iterator(constraints_.cbegin(), to_constraint_ref),
     boost::make_transform_iterator(constraints_.cend(), to_constraint_ref));
 }
@@ -221,7 +221,7 @@ const fuse_core::Variable& HashGraph::getVariable(const fuse_core::UUID& variabl
   return *variables_iter->second;
 }
 
-fuse_core::const_variable_range HashGraph::getVariables() const noexcept
+fuse_core::Graph::const_variable_range HashGraph::getVariables() const noexcept
 {
   std::function<const fuse_core::Variable&(const Variables::value_type& uuid__variable)> to_variable_ref =
     [](const Variables::value_type& uuid__variable) -> const fuse_core::Variable&
@@ -229,7 +229,7 @@ fuse_core::const_variable_range HashGraph::getVariables() const noexcept
       return *uuid__variable.second;
     };
 
-  return fuse_core::const_variable_range(
+  return fuse_core::Graph::const_variable_range(
     boost::make_transform_iterator(variables_.cbegin(), to_variable_ref),
     boost::make_transform_iterator(variables_.cend(), to_variable_ref));
 }

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -128,15 +128,12 @@ protected:
   struct TransactionQueueElement
   {
     std::string sensor_name;
-    std::set<ros::Time> stamps;
     fuse_core::Transaction::SharedPtr transaction;
 
     TransactionQueueElement(
       const std::string& sensor_name,
-      const std::set<ros::Time>& stamps,
       fuse_core::Transaction::SharedPtr transaction) :
         sensor_name(sensor_name),
-        stamps(stamps),
         transaction(std::move(transaction)) {}
   };
 
@@ -213,8 +210,7 @@ protected:
    */
   void transactionCallback(
     const std::string& sensor_name,
-    const std::set<ros::Time>& stamps,
-    const fuse_core::Transaction::SharedPtr& transaction) override;
+    fuse_core::Transaction::SharedPtr transaction) override;
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -43,7 +43,6 @@
 #include <pluginlib/class_loader.h>
 #include <ros/ros.h>
 
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -147,8 +146,7 @@ protected:
    */
   virtual void transactionCallback(
     const std::string& sensor_name,
-    const std::set<ros::Time>& stamps,
-    const fuse_core::Transaction::SharedPtr& transaction) = 0;
+    fuse_core::Transaction::SharedPtr transaction) = 0;
 
   /**
    * @brief Configure the motion model plugins specified on the parameter server
@@ -187,7 +185,6 @@ protected:
    */
   bool applyMotionModels(
     const std::string& sensor_name,
-    const std::set<ros::Time>& stamps,
     fuse_core::Transaction& transaction) const;
 
   /**
@@ -204,14 +201,11 @@ protected:
    * @brief Inject a transaction callback function into the global callback queue
    *
    * @param[in] sensor_name The name of the sensor that produced the Transaction
-   * @param[in] stamps      Any timestamps associated with the added variables. These are sent to the motion models
-   *                        to generate connected constraints.
    * @param[in] transaction The populated Transaction object created by the loaded SensorModel plugin
    */
   void injectCallback(
     const std::string& sensor_name,
-    const std::set<ros::Time>& stamps,
-    const fuse_core::Transaction::SharedPtr& transaction);
+    fuse_core::Transaction::SharedPtr transaction);
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -229,7 +229,7 @@ void Pose2DPublisher::notifyCallback(
   for (const auto& added_variable : transaction->addedVariables())
   {
     ros::Time stamp;
-    if (checkVariable(*added_variable, fuse_variables::Orientation2DStamped::TYPE, device_id_, stamp) &&
+    if (checkVariable(added_variable, fuse_variables::Orientation2DStamped::TYPE, device_id_, stamp) &&
        stamp >= latest_stamp_)
     {
       latest_stamp_ = stamp;

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -89,6 +89,14 @@ public:
                                                                           fuse_core::uuid::generate("kitt"));
     orientation4->yaw() = 3.04;
 
+    transaction_->addInvolvedStamp(position1->stamp());
+    transaction_->addInvolvedStamp(orientation1->stamp());
+    transaction_->addInvolvedStamp(position2->stamp());
+    transaction_->addInvolvedStamp(orientation2->stamp());
+    transaction_->addInvolvedStamp(position3->stamp());
+    transaction_->addInvolvedStamp(orientation3->stamp());
+    transaction_->addInvolvedStamp(position4->stamp());
+    transaction_->addInvolvedStamp(orientation4->stamp());
     transaction_->addVariable(position1);
     transaction_->addVariable(orientation1);
     transaction_->addVariable(position2);

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -92,6 +92,14 @@ public:
                                                                           fuse_core::uuid::generate("kitt"));
     orientation4->yaw() = 3.04;
 
+    transaction_->addInvolvedStamp(position1->stamp());
+    transaction_->addInvolvedStamp(orientation1->stamp());
+    transaction_->addInvolvedStamp(position2->stamp());
+    transaction_->addInvolvedStamp(orientation2->stamp());
+    transaction_->addInvolvedStamp(position3->stamp());
+    transaction_->addInvolvedStamp(orientation3->stamp());
+    transaction_->addInvolvedStamp(position4->stamp());
+    transaction_->addInvolvedStamp(orientation4->stamp());
     transaction_->addVariable(position1);
     transaction_->addVariable(orientation1);
     transaction_->addVariable(position2);


### PR DESCRIPTION
I'm sorry....
This seemed like a simple change...
Then it rippled to a lot more places than I expected.
Might make sense to walk through the changes on a per-commit basis.

Anyway, whenever a sensor/motion model publishes a Transaction, it also sends a set of "involved timestamps" with it. Since the two always go together, I thought "Why not put them together?" It has the added bonus of moving the timestamp container around via pointer instead of via copy...because the Transaction is moved around via pointer.

There will be additional ripples to `fuse_rl` and `fuse_locus` later.