### PR TITLE
[RST-1940] Added a localSize() to the Variable class

### DIFF
--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
@@ -147,14 +147,11 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
-  // TODO(swilliams) The covariance is in the tangent space, but there is currently no good way of getting the
-  //                 tangent space size
-  std::vector<double> covariance_vector(3 * 3);
+  fuse_core::Matrix3d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), covariance_vector.data());
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
 
-  // Assemble the full covariance from the covariance blocks
-  fuse_core::Matrix3d actual_covariance(covariance_vector.data());
+  // Define the expected covariance
   fuse_core::Matrix3d expected_covariance;
   expected_covariance <<
     1.0, 0.1, 0.2,

--- a/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
@@ -186,11 +186,11 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
   fuse_core::MatrixXd cov_pos_pos(position_variable->size(), position_variable->size());
   covariance.GetCovarianceBlock(position_variable->data(), position_variable->data(), cov_pos_pos.data());
 
-  fuse_core::MatrixXd cov_or_or(3, 3);
+  fuse_core::MatrixXd cov_or_or(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
     orientation_variable->data(), orientation_variable->data(), cov_or_or.data());
 
-  fuse_core::MatrixXd cov_pos_or(position_variable->size(), 3);
+  fuse_core::MatrixXd cov_pos_or(position_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
     position_variable->data(), orientation_variable->data(), cov_pos_or.data());
 
@@ -198,6 +198,7 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
   fuse_core::Matrix6d actual_covariance;
   actual_covariance << cov_pos_pos, cov_pos_or, cov_pos_or.transpose(), cov_or_or;
 
+  // Define the expected covariance
   fuse_core::Matrix6d expected_covariance;
   expected_covariance <<
     1.0, 0.1, 0.2, 0.3, 0.4, 0.5,

--- a/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
@@ -249,6 +249,7 @@ TEST(RelativePose3DStampedConstraint, Optimization)
     fuse_core::Matrix6d actual_covariance;
     actual_covariance << cov_pos_pos, cov_pos_or, cov_pos_or.transpose(), cov_or_or;
 
+    // Define the expected covariance
     fuse_core::Matrix6d expected_covariance;
     expected_covariance <<
       1.0,  0.0,  0.0,  0.0,  0.0,  0.0,
@@ -285,6 +286,7 @@ TEST(RelativePose3DStampedConstraint, Optimization)
     fuse_core::Matrix6d actual_covariance;
     actual_covariance << cov_pos_pos, cov_pos_or, cov_pos_or.transpose(), cov_or_or;
 
+    // Define the expected covariance
     fuse_core::Matrix6d expected_covariance;
     expected_covariance <<
       2.0,  0.0,  0.0,  0.0,  0.0,  0.0,

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -114,6 +114,14 @@ public:
   virtual size_t size() const = 0;
 
   /**
+   * @brief Returns the number of elements of the local parameterization space.
+   *
+   * If you override the \p localParameterization() method, it is good practice to also override the \p localSize()
+   * method. By default, the \p size() method is used for \p localSize() as well.
+   */
+  virtual size_t localSize() const { return size(); }
+
+  /**
    * @brief Read-only access to the variable data
    *
    * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
@@ -155,7 +163,9 @@ public:
   /**
    * @brief Create a new Ceres local parameterization object to apply to updates of this variable
    *
-   * If a local parameterization is not needed, a null pointer should be returned.
+   * If a local parameterization is not needed, a null pointer should be returned. If a local parameterization is
+   * needed, remember to also override the \p localSize() method to return the appropriate local parameterization
+   * size.
    *
    * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
    * delete the local parameterization when it is done. Additionally, fuse promises that the Variable object will

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -107,6 +107,14 @@ public:
   fuse_core::Variable::UniquePtr clone() const override;
 
   /**
+   * @brief Returns the number of elements of the local parameterization space.
+   *
+   * Since we are overriding the \p localParameterization() method, it is good practice to override the \p localSize()
+   * method as well.
+   */
+  size_t localSize() const override { return 1u; }
+
+  /**
    * @brief Create a new Ceres local parameterization object to apply to updates of this variable
    *
    * A 2D rotation has a nonlinearity when the angle wraps around from -PI to PI. This is handled by a custom

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -171,6 +171,14 @@ public:
   fuse_core::Variable::UniquePtr clone() const override;
 
   /**
+   * @brief Returns the number of elements of the local parameterization space.
+   *
+   * While a quaternion has 4 parameters, a 3D rotation only has 3 degrees of freedom. Hence, the local
+   * parameterization space is only size 3.
+   */
+  size_t localSize() const override { return 3u; }
+
+  /**
    * @brief Provides a Ceres local parameterization for the quaternion
    *
    * @return A pointer to a local parameterization object that indicates how to "add" increments to the quaternion


### PR DESCRIPTION
It is handy to know the size of the local parameterization tangent space. For example, when computing a 3D orientation covariance, the tangent space values are used. Being able to access the size of the resulting covariance is convenient for creating generic code.