### PR TITLE
[RST-1744] Added a marginal constraint class

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -198,8 +198,6 @@ if(CATKIN_ENABLE_TESTING)
     PRIVATE
       include
       ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-      ${EIGEN3_INCLUDE_DIRS}
   )
   target_link_libraries(test_marginal_constraint
     ${PROJECT_NAME}

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(${PROJECT_NAME}
   src/absolute_orientation_3d_stamped_euler_constraint.cpp
   src/absolute_pose_2d_stamped_constraint.cpp
   src/absolute_pose_3d_stamped_constraint.cpp
+  src/marginal_constraint.cpp
+  src/marginal_cost_function.cpp
   src/normal_delta.cpp
   src/normal_delta_orientation_2d.cpp
   src/normal_prior_orientation_2d.cpp
@@ -181,6 +183,25 @@ if(CATKIN_ENABLE_TESTING)
       ${EIGEN3_INCLUDE_DIRS}
   )
   target_link_libraries(test_absolute_pose_3d_stamped_constraint
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+
+  # Marginal Constraint Tests
+  catkin_add_gtest(test_marginal_constraint
+    test/test_marginal_constraint.cpp
+  )
+  add_dependencies(test_marginal_constraint
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_marginal_constraint
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${EIGEN3_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_marginal_constraint
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
   )

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -1,0 +1,219 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CONSTRAINTS_MARGINAL_CONSTRAINT_H
+#define FUSE_CONSTRAINTS_MARGINAL_CONSTRAINT_H
+
+#include <fuse_core/constraint.h>
+#include <fuse_core/eigen.h>
+#include <fuse_core/local_parameterization.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/variable.h>
+
+#include <boost/iterator/transform_iterator.hpp>
+#include <ceres/cost_function.h>
+
+#include <cassert>
+#include <ostream>
+#include <vector>
+
+
+namespace fuse_constraints
+{
+
+/**
+ * @brief A constraint that represents remaining marginal information on a set of variables
+ *
+ * The marginal constraint cost function is of the form:
+ *   cost = A1 * (x1 - x1_bar) + A2 * (x2 - x2_bar) + ... + b
+ * where x_bar is the linearization point of the variable taken from the variable value at the time of construction,
+ * and the minus operator in implemented in the variable's local parameterization.
+ */
+class MarginalConstraint : public fuse_core::Constraint
+{
+public:
+  SMART_PTR_DEFINITIONS(MarginalConstraint);
+
+  /**
+   * @brief Create a linear/marginal constraint
+   *
+   * The variable iterators and matrix iterators must be the same size. Further, all A matrices and the b vector must
+   * have the same number of rows, and the number of columns of each A matrix must match the \p localSize() of its
+   * associated variable.
+   *
+   * @param[in] first_variable Iterator pointing to the first involved variable for this constraint
+   * @param[in] last_variable  Iterator pointing to one passed the last involved variable for this constraint
+   * @param[in] first_A        Iterator pointing to the first A matrix, associated with the first variable
+   * @param[in] last_A         Iterator pointing to one passed the last A matrix
+   * @param[in] b              The b vector of the marginal cost (of the form A*(x - x_bar) + b)
+   */
+  template<typename VariableIterator, typename MatrixIterator>
+  MarginalConstraint(
+    VariableIterator first_variable,
+    VariableIterator last_variable,
+    MatrixIterator first_A,
+    MatrixIterator last_A,
+    const fuse_core::VectorXd& b);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~MarginalConstraint();
+
+  /**
+   * @brief Read-only access to the A matrices of the marginal constraint
+   */
+  const std::vector<fuse_core::MatrixXd>& A() const { return A_; }
+
+  /**
+   * @brief Read-only access to the b vector of the marginal constraint
+   */
+  const fuse_core::VectorXd& b() const { return b_; }
+
+  /**
+   * @brief Read-only access to the variable linearization points, x_bar
+   */
+  const std::vector<fuse_core::VectorXd>& x_bar() const { return x_bar_; }
+
+  /**
+   * @brief Read-only access to the variable local parameterizations
+   */
+  const std::vector<fuse_core::LocalParameterization*>& localParameterizations() const { return local_; }
+
+  /**
+   * @brief Print a human-readable description of the constraint to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  void print(std::ostream& stream = std::cout) const override;
+
+  /**
+   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
+   *
+   * Unique pointers can be implicitly upgraded to shared pointers if needed.
+   *
+   * @return A unique pointer to a new instance of the most-derived constraint
+   */
+  fuse_core::Constraint::UniquePtr clone() const override;
+
+  /**
+   * @brief Construct an instance of this constraint's cost function
+   *
+   * The function caller will own the new cost function instance. It is the responsibility of the caller to delete
+   * the cost function object when it is no longer needed. If the pointer is provided to a Ceres::Problem object, the
+   * Ceres::Problem object will takes ownership of the pointer and delete it during destruction.
+   *
+   * @return A base pointer to an instance of a derived CostFunction.
+   */
+  ceres::CostFunction* costFunction() const override;
+
+protected:
+  std::vector<fuse_core::MatrixXd> A_;  //!< The A matrices of the marginal constraint
+  std::vector<fuse_core::VectorXd> x_bar_;  //!< The linearization point of each involved variable
+  std::vector<fuse_core::LocalParameterization*> local_;  //!< The local parameterization of each involved variable
+  fuse_core::VectorXd b_;  //!< The b vector of the marginal constraint
+};
+
+namespace detail
+{
+/**
+ * @brief Return the UUID of the provided variable
+ */
+const fuse_core::UUID getUuid(const fuse_core::Variable& variable)
+{
+  return variable.uuid();
+}
+
+/**
+ * @brief Return the current value of the provided variable
+ */
+const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& variable)
+{
+  return Eigen::Map<const fuse_core::VectorXd>(variable.data(), variable.size());
+}
+
+/**
+ * @brief Return the local parameterization of the provided variable
+ */
+fuse_core::LocalParameterization* const getLocalParameterization(const fuse_core::Variable& variable)
+{
+  return variable.localParameterization();
+}
+
+/**
+ * @brief Checks if the binary predicate returns true for all elements in the provided ranges
+ */
+template <class InputIt1, class InputIt2, class BinaryPredicate>
+constexpr bool all_of(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, BinaryPredicate pred)
+{
+  for (; first1 != last1; ++first1, first2)
+  {
+    if (!pred(*first1, *first2))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace detail
+
+template<typename VariableIterator, typename MatrixIterator>
+MarginalConstraint::MarginalConstraint(
+  VariableIterator first_variable,
+  VariableIterator last_variable,
+  MatrixIterator first_A,
+  MatrixIterator last_A,
+  const fuse_core::VectorXd& b) :
+    Constraint(boost::make_transform_iterator(first_variable, &detail::getUuid),
+               boost::make_transform_iterator(last_variable, &detail::getUuid)),
+    A_(first_A, last_A),
+    x_bar_(boost::make_transform_iterator(first_variable, &detail::getCurrentValue),
+           boost::make_transform_iterator(last_variable, &detail::getCurrentValue)),
+    local_(boost::make_transform_iterator(first_variable, &detail::getLocalParameterization),
+           boost::make_transform_iterator(last_variable, &detail::getLocalParameterization)),
+    b_(b)
+{
+  assert(A_.size() > 0);
+  assert(A_.size() == x_bar_.size());
+  assert(A_.size() == local_.size());
+  assert(b_.rows() > 0);
+  assert(std::all_of(A_.begin(), A_.end(), [&b_](const auto& A){ return A.rows() == b_.rows(); }));  // NOLINT
+  assert(detail::all_of(A_.begin(), A_.end(),
+                        first_variable, last_variable,
+                        [](const auto& A, const auto& x){ return A.cols() == x.localSize(); }));  // NOLINT
+}
+
+}  // namespace fuse_constraints
+
+#endif  // FUSE_CONSTRAINTS_MARGINAL_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -110,7 +110,10 @@ public:
   /**
    * @brief Read-only access to the variable local parameterizations
    */
-  const std::vector<fuse_core::LocalParameterization::SharedPtr>& localParameterizations() const { return local_; }
+  const std::vector<fuse_core::LocalParameterization::SharedPtr>& localParameterizations() const
+  {
+    return local_parameterizations_;
+  }
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -195,10 +198,10 @@ MarginalConstraint::MarginalConstraint(
   assert(A_.size() == x_bar_.size());
   assert(A_.size() == local_parameterizations_.size());
   assert(b_.rows() > 0);
-  assert(std::all_of(A_.begin(), A_.end(), [&b_](const auto& A){ return A.rows() == b_.rows(); }));  // NOLINT
+  assert(std::all_of(A_.begin(), A_.end(), [this](const auto& A){ return A.rows() == this->b_.rows(); }));  // NOLINT
   assert(std::all_of(boost::make_zip_iterator(boost::make_tuple(A_.begin(), first_variable)),
-                     boost::make_zip_iterator(boost::make_tuple(A_.end(), last_variable)),
-                     [](const auto& pair){ return pair.get<0>().cols() == pair.get<1>().localSize(); }));  // NOLINT
+                     boost::make_zip_iterator(std::make_pair(A_.end(), last_variable)),
+                     [](const auto& pair){ return pair.first.cols() == pair.second.localSize(); }));  // NOLINT
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -43,6 +43,7 @@
 #include <boost/iterator/transform_iterator.hpp>
 #include <ceres/cost_function.h>
 
+#include <algorithm>
 #include <cassert>
 #include <ostream>
 #include <vector>
@@ -149,7 +150,7 @@ namespace detail
 /**
  * @brief Return the UUID of the provided variable
  */
-const fuse_core::UUID getUuid(const fuse_core::Variable& variable)
+inline const fuse_core::UUID getUuid(const fuse_core::Variable& variable)
 {
   return variable.uuid();
 }
@@ -157,7 +158,7 @@ const fuse_core::UUID getUuid(const fuse_core::Variable& variable)
 /**
  * @brief Return the current value of the provided variable
  */
-const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& variable)
+inline const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& variable)
 {
   return Eigen::Map<const fuse_core::VectorXd>(variable.data(), variable.size());
 }
@@ -165,7 +166,7 @@ const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& variable)
 /**
  * @brief Return the local parameterization of the provided variable
  */
-fuse_core::LocalParameterization* const getLocalParameterization(const fuse_core::Variable& variable)
+inline fuse_core::LocalParameterization* const getLocalParameterization(const fuse_core::Variable& variable)
 {
   return variable.localParameterization();
 }

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -89,7 +89,7 @@ public:
   /**
    * @brief Destructor
    */
-  virtual ~MarginalConstraint();
+  virtual ~MarginalConstraint() = default;
 
   /**
    * @brief Read-only access to the A matrices of the marginal constraint
@@ -109,7 +109,7 @@ public:
   /**
    * @brief Read-only access to the variable local parameterizations
    */
-  const std::vector<fuse_core::LocalParameterization*>& localParameterizations() const { return local_; }
+  const std::vector<fuse_core::LocalParameterization::SharedPtr>& localParameterizations() const { return local_; }
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -141,12 +141,13 @@ public:
 protected:
   std::vector<fuse_core::MatrixXd> A_;  //!< The A matrices of the marginal constraint
   std::vector<fuse_core::VectorXd> x_bar_;  //!< The linearization point of each involved variable
-  std::vector<fuse_core::LocalParameterization*> local_;  //!< The local parameterization of each involved variable
+  std::vector<fuse_core::LocalParameterization::SharedPtr> local_;  //!< The local parameterization of each variable
   fuse_core::VectorXd b_;  //!< The b vector of the marginal constraint
 };
 
 namespace detail
 {
+
 /**
  * @brief Return the UUID of the provided variable
  */
@@ -166,9 +167,9 @@ inline const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& vari
 /**
  * @brief Return the local parameterization of the provided variable
  */
-inline fuse_core::LocalParameterization* const getLocalParameterization(const fuse_core::Variable& variable)
+inline fuse_core::LocalParameterization::SharedPtr const getLocalParameterization(const fuse_core::Variable& variable)
 {
-  return variable.localParameterization();
+  return fuse_core::LocalParameterization::SharedPtr(variable.localParameterization());
 }
 
 /**

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -73,7 +73,7 @@ public:
    * associated variable.
    *
    * @param[in] first_variable Iterator pointing to the first involved variable for this constraint
-   * @param[in] last_variable  Iterator pointing to one passed the last involved variable for this constraint
+   * @param[in] last_variable  Iterator pointing to one past the last involved variable for this constraint
    * @param[in] first_A        Iterator pointing to the first A matrix, associated with the first variable
    * @param[in] last_A         Iterator pointing to one passed the last A matrix
    * @param[in] b              The b vector of the marginal cost (of the form A*(x - x_bar) + b)
@@ -178,7 +178,7 @@ inline fuse_core::LocalParameterization::SharedPtr const getLocalParameterizatio
 template <class InputIt1, class InputIt2, class BinaryPredicate>
 constexpr bool all_of(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, BinaryPredicate pred)
 {
-  for (; first1 != last1; ++first1, first2)
+  for (; first1 != last1; ++first1, ++first2)
   {
     if (!pred(*first1, *first2))
     {
@@ -206,7 +206,7 @@ MarginalConstraint::MarginalConstraint(
            boost::make_transform_iterator(last_variable, &detail::getLocalParameterization)),
     b_(b)
 {
-  assert(A_.size() > 0);
+  assert(!A_.empty());
   assert(A_.size() == x_bar_.size());
   assert(A_.size() == local_.size());
   assert(b_.rows() > 0);

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -50,14 +50,16 @@ namespace fuse_constraints
  *
  * The cost function is of the form:
  *
- *   cost(x) = ||A1 * (x1 - x1_bar) + A2 * (x2 - x2_bar) + ... + An * (xn - xn_bar) + b||^2
+ *             ||                                                                        ||^2
+ *   cost(x) = || A1 * (x1 - x1_bar) + A2 * (x2 - x2_bar) + ... + An * (xn - xn_bar) + b ||
+ *             ||                                                                        ||
  *
  * where, the A matrices and the b vector are fixed, x_bar is the linearization point used when calculating the A
- * matrices and b vector, and the minus operator in (x - x_bar) is provided by the variable's local parameterization
+ * matrices and b vector, and the minus operator in (x - x_bar) is provided by the variable's local parameterization.
  * 
- * The A matrices can have any number of rows, but they must all be the same. The number of columns of A must match
- * the size of the associated variable's local parameterization size, and the number of rows of x_bar must match the
- * associated variable's global size. The cost function will have the same number of residuals as the rows of A.
+ * The A matrices can have any number of rows, but they must all be the same. The number of columns of each A matrix
+ * must match the associated variable's local parameterization size, and the number of rows of each x_bar must match
+ * the associated variable's global size. The cost function will have the same number of residuals as the rows of A.
  */
 class MarginalCostFunction : public ceres::CostFunction
 {
@@ -65,16 +67,16 @@ public:
   /**
    * @brief Construct a cost function instance
    *
-   * @param[in] A     The A matrix of the marginal cost (of the form A*(x - x_bar) + b)
-   * @param[in] b     The b vector of the marginal cost (of the form A*(x - x_bar) + b)
-   * @param[in] x_bar The linearization point of the involved variables
-   * @param[in] param The local parameterization associated with the variable
+   * @param[in] A                       The A matrix of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] b                       The b vector of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] x_bar                   The linearization point of the involved variables
+   * @param[in] local_parameterizations The local parameterization associated with the variable
    */
   MarginalCostFunction(
     const std::vector<fuse_core::MatrixXd>& A,
+    const fuse_core::VectorXd& b,
     const std::vector<fuse_core::VectorXd>& x_bar,
-    const std::vector<fuse_core::LocalParameterization::SharedPtr>& local,
-    const fuse_core::VectorXd& b);
+    const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations);
 
   /**
    * @brief Destructor
@@ -85,16 +87,16 @@ public:
    * @brief Compute the cost values/residuals, and optionally the Jacobians, using the provided variable/parameter
    *        values
    */
-  virtual bool Evaluate(
+  bool Evaluate(
     double const* const* parameters,
     double* residuals,
-    double** jacobians) const;
+    double** jacobians) const override;
 
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
-  const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
-  const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_;  //!< The local parameterizations
   const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
+  const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
+  const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
 };
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -73,7 +73,7 @@ public:
   MarginalCostFunction(
     const std::vector<fuse_core::MatrixXd>& A,
     const std::vector<fuse_core::VectorXd>& x_bar,
-    const std::vector<fuse_core::LocalParameterization*>& local,
+    const std::vector<fuse_core::LocalParameterization::SharedPtr>& local,
     const fuse_core::VectorXd& b);
 
   /**
@@ -93,7 +93,7 @@ public:
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
   const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
-  const std::vector<fuse_core::LocalParameterization*>& local_;  //!< The local parameterizaation of each variable
+  const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_;  //!< The local parameterizations
   const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
 };
 

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CONSTRAINTS_MARGINAL_COST_FUNCTION_H
+#define FUSE_CONSTRAINTS_MARGINAL_COST_FUNCTION_H
+
+#include <fuse_core/eigen.h>
+#include <fuse_core/local_parameterization.h>
+
+#include <ceres/cost_function.h>
+
+#include <vector>
+
+
+namespace fuse_constraints
+{
+
+/**
+ * @brief Implements a cost function designed for precomputed marginal distributions
+ *
+ * The cost function is of the form:
+ *
+ *   cost(x) = ||A1 * (x1 - x1_bar) + A2 * (x2 - x2_bar) + ... + An * (xn - xn_bar) + b||^2
+ *
+ * where, the A matrices and the b vector are fixed, x_bar is the linearization point used when calculating the A
+ * matrices and b vector, and the minus operator in (x - x_bar) is provided by the variable's local parameterization
+ * 
+ * The A matrices can have any number of rows, but they must all be the same. The number of columns of A must match
+ * the size of the associated variable's local parameterization size, and the number of rows of x_bar must match the
+ * associated variable's global size. The cost function will have the same number of residuals as the rows of A.
+ */
+class MarginalCostFunction : public ceres::CostFunction
+{
+public:
+  /**
+   * @brief Construct a cost function instance
+   *
+   * @param[in] A     The A matrix of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] b     The b vector of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] x_bar The linearization point of the involved variables
+   * @param[in] param The local parameterization associated with the variable
+   */
+  MarginalCostFunction(
+    const std::vector<fuse_core::MatrixXd>& A,
+    const std::vector<fuse_core::VectorXd>& x_bar,
+    const std::vector<fuse_core::LocalParameterization*>& local,
+    const fuse_core::VectorXd& b);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~MarginalCostFunction() = default;
+
+  /**
+   * @brief Compute the cost values/residuals, and optionally the Jacobians, using the provided variable/parameter
+   *        values
+   */
+  virtual bool Evaluate(
+    double const* const* parameters,
+    double* residuals,
+    double** jacobians) const;
+
+private:
+  const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
+  const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
+  const std::vector<fuse_core::LocalParameterization*>& local_;  //!< The local parameterizaation of each variable
+  const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
+};
+
+}  // namespace fuse_constraints
+
+#endif  // FUSE_CONSTRAINTS_MARGINAL_COST_FUNCTION_H

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -33,8 +33,12 @@
  */
 #include <fuse_constraints/marginal_constraint.h>
 #include <fuse_constraints/marginal_cost_function.h>
+#include <fuse_core/constraint.h>
 
 #include <Eigen/Core>
+
+#include <ostream>
+
 
 namespace fuse_constraints
 {

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -1,0 +1,82 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/marginal_constraint.h>
+#include <fuse_constraints/marginal_cost_function.h>
+
+#include <Eigen/Core>
+
+namespace fuse_constraints
+{
+
+MarginalConstraint::~MarginalConstraint()
+{
+  for (auto& local : local_)
+  {
+    if (local)
+    {
+      delete local;
+    }
+  }
+  local_.clear();
+}
+
+void MarginalConstraint::print(std::ostream& stream) const
+{
+  stream << type() << "\n"
+         << "  uuid: " << uuid() << "\n"
+         << "  variable:\n";
+  for (const auto& variable : variables_)
+  {
+    stream << "   - " << variable << "\n";
+  }
+  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
+  for (size_t i = 0; i < A_.size(); ++i)
+  {
+    stream << "  A[" << i << "]:     " << A_[i].format(clean) << "\n"
+           << "  x_bar[" << i << "]: " << x_bar_[i].format(clean) << "\n";
+  }
+  stream << "  b: " << b_.format(clean) << "\n";
+}
+
+fuse_core::Constraint::UniquePtr MarginalConstraint::clone() const
+{
+  return MarginalConstraint::make_unique(*this);
+}
+
+ceres::CostFunction* MarginalConstraint::costFunction() const
+{
+  return new MarginalCostFunction(A_, x_bar_, local_, b_);
+}
+
+}  // namespace fuse_constraints

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/marginal_constraint.h>
+
 #include <fuse_constraints/marginal_cost_function.h>
 #include <fuse_core/constraint.h>
 
@@ -52,13 +53,13 @@ void MarginalConstraint::print(std::ostream& stream) const
   {
     stream << "   - " << variable << "\n";
   }
-  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
+  Eigen::IOFormat indent(4, 0, ", ", "\n", "   [", "]");
   for (size_t i = 0; i < A_.size(); ++i)
   {
-    stream << "  A[" << i << "]:     " << A_[i].format(clean) << "\n"
-           << "  x_bar[" << i << "]: " << x_bar_[i].format(clean) << "\n";
+    stream << "  A[" << i << "]:\n" << A_[i].format(indent) << "\n"
+           << "  x_bar[" << i << "]:\n" << x_bar_[i].format(indent) << "\n";
   }
-  stream << "  b: " << b_.format(clean) << "\n";
+  stream << "  b:\n" << b_.format(indent) << "\n";
 }
 
 fuse_core::Constraint::UniquePtr MarginalConstraint::clone() const
@@ -68,7 +69,7 @@ fuse_core::Constraint::UniquePtr MarginalConstraint::clone() const
 
 ceres::CostFunction* MarginalConstraint::costFunction() const
 {
-  return new MarginalCostFunction(A_, x_bar_, local_, b_);
+  return new MarginalCostFunction(A_, b_, x_bar_, local_parameterizations_);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -43,18 +43,6 @@
 namespace fuse_constraints
 {
 
-MarginalConstraint::~MarginalConstraint()
-{
-  for (auto& local : local_)
-  {
-    if (local)
-    {
-      delete local;
-    }
-  }
-  local_.clear();
-}
-
 void MarginalConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -1,0 +1,112 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/marginal_cost_function.h>
+
+#include <Eigen/Core>
+
+#include <vector>
+#include <iostream>
+
+
+namespace fuse_constraints
+{
+
+MarginalCostFunction::MarginalCostFunction(
+    const std::vector<fuse_core::MatrixXd>& A,
+    const std::vector<fuse_core::VectorXd>& x_bar,
+    const std::vector<fuse_core::LocalParameterization*>& local,
+    const fuse_core::VectorXd& b) :
+  A_(A),
+  x_bar_(x_bar),
+  local_(local),
+  b_(b)
+{
+  set_num_residuals(b_.rows());
+  for (const auto& x_bar : x_bar_)
+  {
+    mutable_parameter_block_sizes()->push_back(x_bar.size());
+  }
+}
+
+bool MarginalCostFunction::Evaluate(
+  double const* const* parameters,
+  double* residuals,
+  double** jacobians) const
+{
+  // Compute cost
+  Eigen::Map<fuse_core::VectorXd> residuals_map(residuals, num_residuals());
+  residuals_map = b_;
+  for (size_t i = 0; i < A_.size(); ++i)
+  {
+    fuse_core::VectorXd delta(A_[i].cols());
+    if (local_[i])
+    {
+      local_[i]->Minus(x_bar_[i].data(), parameters[i], delta.data());
+    }
+    else
+    {
+      for (int j = 0; j < x_bar_[i].rows(); ++j)
+      {
+        delta[j] = parameters[i][j] - x_bar_[i][j];
+      }
+    }
+    residuals_map += A_[i] * delta;
+  }
+
+  // Compute requested Jacobians
+  if (jacobians)
+  {
+    for (size_t i = 0; i < A_.size(); ++i)
+    {
+      if (jacobians[i])
+      {
+        if (local_[i])
+        {
+          const auto local = local_[i];
+          fuse_core::MatrixXd J_local(local->LocalSize(), local->GlobalSize());
+          local->ComputeMinusJacobian(parameters[i], J_local.data());
+          Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
+        }
+        else
+        {
+          Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i];
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+}  // namespace fuse_constraints

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -45,7 +45,7 @@ namespace fuse_constraints
 MarginalCostFunction::MarginalCostFunction(
     const std::vector<fuse_core::MatrixXd>& A,
     const std::vector<fuse_core::VectorXd>& x_bar,
-    const std::vector<fuse_core::LocalParameterization*>& local,
+    const std::vector<fuse_core::LocalParameterization::SharedPtr>& local,
     const fuse_core::VectorXd& b) :
   A_(A),
   x_bar_(x_bar),

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -1,0 +1,246 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/marginal_constraint.h>
+#include <fuse_core/eigen.h>
+#include <fuse_variables/orientation_3d_stamped.h>
+#include <fuse_variables/position_2d_stamped.h>
+#include <ros/time.h>
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+
+TEST(MarginalConstraint, OneVariable)
+{
+  // Create a marginal constraint with one variable, no local parameterizations
+  std::vector<fuse_variables::Position2DStamped> variables;
+  fuse_variables::Position2DStamped x1(ros::Time(1, 0));
+  x1.x() = 1.0;
+  x1.y() = 2.0;
+  variables.push_back(x1);
+
+  std::vector<fuse_core::MatrixXd> A;
+  fuse_core::MatrixXd A1(1, 2);
+  A1 << 5.0, 8.0;
+  A.push_back(A1);
+
+  fuse_core::Vector1d b;
+  b << 3.0;
+
+  auto constraint = fuse_constraints::MarginalConstraint(variables.begin(),
+                                                         variables.end(),
+                                                         A.begin(),
+                                                         A.end(),
+                                                         b);
+
+  auto cost_function = constraint.costFunction();
+
+  // Update the variable value
+  x1.x() = 4.0;
+  x1.y() = 6.0;
+
+  // Compute the actual residuals and jacobians
+  std::vector<const double*> variable_values = {x1.data()};
+  fuse_core::Vector1d actual_residuals;
+  fuse_core::MatrixXd actual_jacobian1(1, 2);
+  std::vector<double*> actual_jacobians = {actual_jacobian1.data()};
+  cost_function->Evaluate(variable_values.data(), actual_residuals.data(), actual_jacobians.data());
+
+  // Define the expected residuals and jacobians
+  fuse_core::Vector1d expected_residuals;
+  expected_residuals << 50.0;  // 5.0 * (4.0 - 1.0) + 8.0 * (6.0 - 2.0) + 3.0
+  fuse_core::MatrixXd expected_jacobian1(1, 2);
+  expected_jacobian1 << 5.0, 8.0;  // Just A1
+
+  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
+  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
+      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
+      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
+
+  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
+      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
+      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
+
+  delete cost_function;
+}
+
+TEST(MarginalConstraint, TwoVariables)
+{
+  // Create a marginal constraint with one variable, no local parameterizations
+  std::vector<fuse_variables::Position2DStamped> variables;
+  fuse_variables::Position2DStamped x1(ros::Time(1, 0));
+  x1.x() = 1.0;
+  x1.y() = 2.0;
+  variables.push_back(x1);
+
+  fuse_variables::Position2DStamped x2(ros::Time(2, 0));
+  x2.x() = 3.0;
+  x2.y() = 4.0;
+  variables.push_back(x2);
+
+  std::vector<fuse_core::MatrixXd> A;
+  fuse_core::MatrixXd A1(1, 2);
+  A1 << 5.0, 6.0;
+  A.push_back(A1);
+
+  fuse_core::MatrixXd A2(1, 2);
+  A2 << 7.0, 8.0;
+  A.push_back(A2);
+
+  fuse_core::Vector1d b;
+  b << 9.0;
+
+  auto constraint = fuse_constraints::MarginalConstraint(variables.begin(),
+                                                         variables.end(),
+                                                         A.begin(),
+                                                         A.end(),
+                                                         b);
+
+  auto cost_function = constraint.costFunction();
+
+  // Update the variable value
+  x1.x() = 10.0;
+  x1.y() = 12.0;
+
+  x2.x() = 15.0;
+  x2.y() = 18.0;
+
+  // Compute the actual residuals and jacobians
+  std::vector<const double*> variable_values = {x1.data(), x2.data()};
+  fuse_core::Vector1d actual_residuals;
+  fuse_core::MatrixXd actual_jacobian1(1, 2);
+  fuse_core::MatrixXd actual_jacobian2(1, 2);
+  std::vector<double*> actual_jacobians = {actual_jacobian1.data(), actual_jacobian2.data()};
+  cost_function->Evaluate(variable_values.data(), actual_residuals.data(), actual_jacobians.data());
+
+  // Define the expected residuals and jacobians
+  fuse_core::Vector1d expected_residuals;
+  expected_residuals << 310.0;  // 5 * (10 - 1) + 6 * (12 - 2)   +   7 * (15 - 3) + 8 * (18 - 4)   +   9
+  fuse_core::MatrixXd expected_jacobian1(1, 2);
+  expected_jacobian1 << 5.0, 6.0;  // Just A1
+  fuse_core::MatrixXd expected_jacobian2(1, 2);
+  expected_jacobian2 << 7.0, 8.0;  // Just A2
+
+  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
+  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
+      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
+      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
+
+  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
+      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
+      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
+
+  EXPECT_TRUE(expected_jacobian2.isApprox(actual_jacobian2, 1.0e-5)) <<
+      "Expected is:\n" << expected_jacobian2.format(clean) << "\n" <<
+      "Actual is:\n" << actual_jacobian2.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_jacobian2 - actual_jacobian2).format(clean) << "\n";
+
+  delete cost_function;
+}
+
+TEST(MarginalConstraint, LocalParameterization)
+{
+  // Create a marginal constraint with one variable, no local parameterizations
+  std::vector<fuse_variables::Orientation3DStamped> variables;
+  fuse_variables::Orientation3DStamped x1(ros::Time(1, 0));
+  x1.w() = 0.842614977;
+  x1.x() = 0.2;
+  x1.y() = 0.3;
+  x1.z() = 0.4;
+  variables.push_back(x1);
+
+  std::vector<fuse_core::MatrixXd> A;
+  fuse_core::MatrixXd A1(1, 3);
+  A1 << 5.0, 6.0, 7.0;
+  A.push_back(A1);
+
+  fuse_core::Vector1d b;
+  b << 8.0;
+
+  auto constraint = fuse_constraints::MarginalConstraint(variables.begin(),
+                                                         variables.end(),
+                                                         A.begin(),
+                                                         A.end(),
+                                                         b);
+  auto cost_function = constraint.costFunction();
+
+  // Update the variable value
+  // This is a delta of (0.15, -0.2, 0.433012702);
+  x1.w() = 0.745561;
+  x1.x() = 0.360184;
+  x1.y() = 0.194124;
+  x1.z() = 0.526043;
+
+  // Compute the actual residuals and jacobians
+  std::vector<const double*> variable_values = {x1.data()};
+  fuse_core::Vector1d actual_residuals;
+  fuse_core::MatrixXd actual_jacobian1(1, 4);
+  std::vector<double*> actual_jacobians = {actual_jacobian1.data()};
+  cost_function->Evaluate(variable_values.data(), actual_residuals.data(), actual_jacobians.data());
+
+  // Define the expected residuals and jacobians
+  fuse_core::Vector1d expected_residuals;
+  expected_residuals << 10.581088914;  // 5.0 * 0.15  +  6.0 * -0.2  +  7.0 * 0.433012702   +   8.0
+  fuse_core::MatrixXd expected_jacobian1(1, 4);
+  expected_jacobian1 << -13.29593, 3.86083, 9.164586, 12.818822;
+  // A1 * J_local
+  // [5.0, 6.0, 7.0] * [-0.720368,  1.491122,  1.052086,  -0.388248]
+  //                   [-0.388248, -1.052086,  1.491122,   0.720368]
+  //                   [-1.052086,  0.388248, -0.720368,   1.491122]
+
+  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
+  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
+      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
+      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
+
+  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
+      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
+      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
+      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
+
+  delete cost_function;
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -33,11 +33,11 @@
  */
 #include <fuse_constraints/marginal_constraint.h>
 #include <fuse_core/eigen.h>
+#include <fuse_core/eigen_gtest.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <ros/time.h>
 
-#include <Eigen/Core>
 #include <gtest/gtest.h>
 
 #include <vector>
@@ -85,16 +85,8 @@ TEST(MarginalConstraint, OneVariable)
   fuse_core::MatrixXd expected_jacobian1(1, 2);
   expected_jacobian1 << 5.0, 8.0;  // Just A1
 
-  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
-  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
-      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
-      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
-
-  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
-      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
-      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
+  EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
+  EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);
 
   delete cost_function;
 }
@@ -156,21 +148,9 @@ TEST(MarginalConstraint, TwoVariables)
   fuse_core::MatrixXd expected_jacobian2(1, 2);
   expected_jacobian2 << 7.0, 8.0;  // Just A2
 
-  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
-  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
-      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
-      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
-
-  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
-      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
-      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
-
-  EXPECT_TRUE(expected_jacobian2.isApprox(actual_jacobian2, 1.0e-5)) <<
-      "Expected is:\n" << expected_jacobian2.format(clean) << "\n" <<
-      "Actual is:\n" << actual_jacobian2.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_jacobian2 - actual_jacobian2).format(clean) << "\n";
+  EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
+  EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);
+  EXPECT_MATRIX_NEAR(expected_jacobian2, actual_jacobian2, 1.0e-5);
 
   delete cost_function;
 }
@@ -225,16 +205,8 @@ TEST(MarginalConstraint, LocalParameterization)
   //                   [-0.388248, -1.052086,  1.491122,   0.720368]
   //                   [-1.052086,  0.388248, -0.720368,   1.491122]
 
-  Eigen::IOFormat clean(4, 0, ", ", "\n", "[", "]");
-  EXPECT_TRUE(expected_residuals.isApprox(actual_residuals, 1.0e-5)) <<
-      "Expected is:\n" << expected_residuals.format(clean) << "\n" <<
-      "Actual is:\n" << actual_residuals.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_residuals - actual_residuals).format(clean) << "\n";
-
-  EXPECT_TRUE(expected_jacobian1.isApprox(actual_jacobian1, 1.0e-5)) <<
-      "Expected is:\n" << expected_jacobian1.format(clean) << "\n" <<
-      "Actual is:\n" << actual_jacobian1.format(clean) << "\n" <<
-      "Difference is:\n" << (expected_jacobian1 - actual_jacobian1).format(clean) << "\n";
+  EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
+  EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);
 
   delete cost_function;
 }

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -186,12 +186,9 @@ std::ostream& operator <<(std::ostream& stream, const Constraint& constraint);
 
 template<typename VariableUuidIterator>
 Constraint::Constraint(VariableUuidIterator first, VariableUuidIterator last) :
-  uuid_(uuid::generate())
+  uuid_(uuid::generate()),
+  variables_(first, last)
 {
-  while (first != last)
-  {
-    variables_.push_back(*first++);
-  }
 }
 
 }  // namespace fuse_core


### PR DESCRIPTION
Added a marginal constraint class. This implements the cost function:
cost = A1 * (x1 - x1_bar) + A2 * (x2 - x2_bar) + ... + An * (xn - xn_bar) + b

The variable subtraction is performed using the recently add `Minus()` method in the local parameterization. If the local parameterization for a given variable class is null, then standard per-element subtraction is used instead.