### PR TITLE
[RST-1746] Remove the marginalizeVariable() methods from the Graph class

### DIFF
--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -201,37 +201,6 @@ public:
   virtual void holdVariable(const UUID& variable_uuid, bool hold_constant = true) = 0;
 
   /**
-   * @brief Marginalize out the provided variable from the graph
-   *
-   * Perform a marginalization operation, computing a new constraint that represents the remaining information from
-   * all connected constraints on all the adjacent variables. The marginalized variable will be removed from the graph,
-   * along with all constraints connected to the marginalized variable. The new computed constraint will be added to
-   * the graph. Because this new constraint was computed from the linear system, all adjacent variables values will be
-   * held to the current optimal value to ensure the constraint remains consistent.
-   *
-   * @param[in] variable_uuid The UUID of the variable to marginalize out of the problem
-   */
-  virtual void marginalizeVariable(const UUID& variable_uuid) = 0;
-
-  /**
-   * @brief Marginalize out all of the provided variables from the graph
-   *
-   * This performs the same marginalization operation as described in Graph::marginalizeVariable(), but to all of the
-   * provided variables. This is not simply a loop around the wrapper around Graph::marginalizeVariable() function call,
-   * but rather inspects the graph structure to combine several variables into a single marginalization operation when
-   * possible. Thus, when marginalizing out many variables it is likely more efficient to perform a single call to
-   * Graph::marginalizeVariables() than multiple calls to Graph::marginalizeVariable(). However, this call is guaranteed
-   * to leave the graph in the same state as if successive calls were made to Graph::marginalizeVariable(). Namely,
-   * all marginalized variables will be removed from the graph, all constraints connected to at least one marginalized
-   * variable will be removed from the graph, new constraints will be added to the graph that constitute the remaining
-   * information on the adjacent variables from the removed constraints, and all adjacent variables will be held
-   * constant during future optimizations.
-   *
-   * @param[in] variable_uuids The UUIDs of the variables to marginalize out of the problem
-   */
-  virtual void marginalizeVariables(const std::vector<UUID>& variable_uuids);
-
-  /**
    * @brief Compute the marginal covariance blocks for the requested set of variable pairs.
    *
    * To compute the marginal variance of a single variable, simply supply the same variable UUID for both members of

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -40,14 +40,6 @@
 namespace fuse_core
 {
 
-void Graph::marginalizeVariables(const std::vector<UUID>& variable_uuids)
-{
-  for (const auto& variable_uuid : variable_uuids)
-  {
-    marginalizeVariable(variable_uuid);
-  }
-}
-
 void Graph::update(const Transaction& transaction)
 {
   // Update the graph with a new transaction. In order to keep the graph consistent, variables are added first,

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -245,22 +245,6 @@ public:
   void holdVariable(const fuse_core::UUID& variable_uuid, bool hold_constant = true) override;
 
   /**
-   * @brief Marginalize out the provided variable from the graph
-   *
-   * Perform a marginalization operation, computing a new constraint that represents the remaining information from
-   * all connected constraints on all the adjacent variables. The marginalized variable will be removed from the graph,
-   * along with all constraints connected to the marginalized variable. The new computed constraint will be added to
-   * the graph. Because this new constraint was computed from the linear system, all adjacent variables values will be
-   * held to the current optimal value to ensure the constraint remains consistent.
-   *
-   * Exceptions: If the variable does not exist, a std::out_of_range exception will be thrown.
-   * Complexity: O(?) {not implemented yet}
-   *
-   * @param[in] variable_uuid The UUID of the variable to marginalize out of the problem
-   */
-  void marginalizeVariable(const fuse_core::UUID& variable_uuid) override;
-
-  /**
    * @brief Compute the marginal covariance blocks for the requested set of variable pairs.
    *
    * To compute the marginal variance of a single variable, simply supply the same variable UUID for both members of

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -247,11 +247,6 @@ void HashGraph::holdVariable(const fuse_core::UUID& variable_uuid, bool hold_con
   }
 }
 
-void HashGraph::marginalizeVariable(const fuse_core::UUID& variable_uuid)
-{
-  throw std::runtime_error("The function 'marginalizeVariable()' has not been implemented yet.");
-}
-
 void HashGraph::getCovariance(
   const std::vector<std::pair<fuse_core::UUID, fuse_core::UUID>>& covariance_requests,
   std::vector<std::vector<double>>& covariance_matrices,

--- a/fuse_graphs/test/test_hash_graph.cpp
+++ b/fuse_graphs/test/test_hash_graph.cpp
@@ -678,16 +678,6 @@ TEST(HashGraph, GetCovariance)
   }
 }
 
-TEST(HashGraph, MarginalizeVariable)
-{
-  // TODO(swilliams): Write a marginalization unit test after the function has been implemented
-}
-
-TEST(HashGraph, MarginalizeVariables)
-{
-  // TODO(swilliams): Write a marginalization unit test after the function has been implemented
-}
-
 TEST(HashGraph, Copy)
 {
     // Create the graph


### PR DESCRIPTION
Remove the marginalizeVariable() methods from the Graph class. They were never used or implemented.

The new plan is to implement the marginalization code outside of the Graph class, and have that code create a Transaction that removes the required variables and constraints, and adds in the computed marginal constraint. That allows reusability between Graph implementations.