### PR TITLE
[RST-1949] Added getConnectedVariables() and getConnectedConstraints()

### DIFF
--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -145,6 +145,14 @@ public:
   virtual const_constraint_range getConstraints() const = 0;
 
   /**
+   * @brief Read-only access to the subset of constraints that are connected to the specified variable
+   *
+   * @param[in] variable_uuid The UUID of the variable of interest
+   * @return A read-only iterator range containing all constraints that involve the specified variable
+   */
+  virtual const_constraint_range getConnectedConstraints(const UUID& variable_uuid) const = 0;
+
+  /**
    * @brief Check if the variable already exists in the graph
    *
    * @param[in] variable_uuid The UUID of the variable being searched for
@@ -187,6 +195,14 @@ public:
    * @return A read-only iterator range containing all variables
    */
   virtual const_variable_range getVariables() const = 0;
+
+  /**
+   * @brief Read-only access to the subset of variables that are connected to the specified constraint
+   *
+   * @param[in] constraint_uuid The UUID of the constraint of interest
+   * @return A read-only iterator range containing all variables that involve the specified constraint
+   */
+  virtual const_variable_range getConnectedVariables(const UUID& constraint_uuid) const;
 
   /**
    * @brief Configure a variable to hold its current value constant during optimization

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -37,6 +37,7 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 
+#include <functional>
 #include <vector>
 
 

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -32,13 +32,32 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_core/graph.h>
+
 #include <fuse_core/transaction.h>
+
+#include <boost/iterator/transform_iterator.hpp>
 
 #include <vector>
 
 
 namespace fuse_core
 {
+
+Graph::const_variable_range Graph::getConnectedVariables(const UUID& constraint_uuid) const
+{
+  std::function<const fuse_core::Variable&(const UUID& variable_uuid)> uuid_to_variable_ref =
+    [this](const UUID& variable_uuid) -> const Variable&
+    {
+      return this->getVariable(variable_uuid);
+    };
+
+  const auto& constraint = getConstraint(constraint_uuid);
+  const auto& variable_uuids = constraint.variables();
+
+  return const_variable_range(
+    boost::make_transform_iterator(variable_uuids.cbegin(), uuid_to_variable_ref),
+    boost::make_transform_iterator(variable_uuids.cend(), uuid_to_variable_ref));
+}
 
 void Graph::update(const Transaction& transaction)
 {

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -168,6 +168,14 @@ public:
   fuse_core::Graph::const_constraint_range getConstraints() const noexcept override;
 
   /**
+   * @brief Read-only access to the subset of constraints that are connected to the specified variable
+   *
+   * @param[in] variable_uuid The UUID of the variable of interest
+   * @return A read-only iterator range containing all constraints that involve the specified variable
+   */
+  fuse_core::Graph::const_constraint_range getConnectedConstraints(const fuse_core::UUID& variable_uuid) const override;
+
+  /**
    * @brief Check if the variable already exists in the graph
    *
    * Exceptions: None

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -188,15 +188,7 @@ fuse_core::Graph::const_constraint_range HashGraph::getConnectedConstraints(cons
   else if (variableExists(variable_uuid))
   {
     // User requested a valid variable, but there are no attached constraints. Return an empty range.
-    std::function<const fuse_core::Constraint&(const Constraints::value_type& uuid__constraint)> to_constraint_ref =
-      [](const Constraints::value_type& uuid__constraint) -> const fuse_core::Constraint&
-      {
-        return *uuid__constraint.second;
-      };
-
-    return fuse_core::Graph::const_constraint_range(
-      boost::make_transform_iterator(constraints_.cend(), to_constraint_ref),
-      boost::make_transform_iterator(constraints_.cend(), to_constraint_ref));
+    return fuse_core::Graph::const_constraint_range();
   }
   else
   {

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -169,6 +169,43 @@ fuse_core::Graph::const_constraint_range HashGraph::getConstraints() const noexc
     boost::make_transform_iterator(constraints_.cend(), to_constraint_ref));
 }
 
+fuse_core::Graph::const_constraint_range HashGraph::getConnectedConstraints(const fuse_core::UUID& variable_uuid) const
+{
+  auto cross_reference_iter = constraints_by_variable_uuid_.find(variable_uuid);
+  if (cross_reference_iter != constraints_by_variable_uuid_.end())
+  {
+    std::function<const fuse_core::Constraint&(const fuse_core::UUID& constraint_uuid)> uuid_to_constraint_ref =
+      [this](const fuse_core::UUID& constraint_uuid) -> const fuse_core::Constraint&
+      {
+        return this->getConstraint(constraint_uuid);
+      };
+
+    const auto& constraints = cross_reference_iter->second;
+    return fuse_core::Graph::const_constraint_range(
+      boost::make_transform_iterator(constraints.cbegin(), uuid_to_constraint_ref),
+      boost::make_transform_iterator(constraints.cend(), uuid_to_constraint_ref));
+  }
+  else if (variableExists(variable_uuid))
+  {
+    // User requested a valid variable, but there are no attached constraints. Return an empty range.
+    std::function<const fuse_core::Constraint&(const Constraints::value_type& uuid__constraint)> to_constraint_ref =
+      [](const Constraints::value_type& uuid__constraint) -> const fuse_core::Constraint&
+      {
+        return *uuid__constraint.second;
+      };
+
+    return fuse_core::Graph::const_constraint_range(
+      boost::make_transform_iterator(constraints_.cend(), to_constraint_ref),
+      boost::make_transform_iterator(constraints_.cend(), to_constraint_ref));
+  }
+  else
+  {
+    // We only want to throw if the requested variable does not exist.
+    throw std::logic_error("Attempting to access constraints connected to variable ("
+        + fuse_core::uuid::to_string(variable_uuid) + "), but that variable does not exist in this graph.");
+  }
+}
+
 bool HashGraph::variableExists(const fuse_core::UUID& variable_uuid) const noexcept
 {
   auto variables_iter = variables_.find(variable_uuid);

--- a/fuse_graphs/test/test_hash_graph.cpp
+++ b/fuse_graphs/test/test_hash_graph.cpp
@@ -314,6 +314,70 @@ TEST(HashGraph, GetVariables)
   }
 }
 
+TEST(HashGraph, GetConnectedVariables)
+{
+  // Test accessing the variables connected to a specific constraint
+
+  // Create the graph
+  fuse_graphs::HashGraph graph;
+
+  // Create a few variables
+  auto variable1 = ExampleVariable::make_shared();
+  variable1->data()[0] = 1.0;
+  graph.addVariable(variable1);
+
+  auto variable2 = ExampleVariable::make_shared();
+  variable2->data()[0] = 2.5;
+  graph.addVariable(variable2);
+
+  auto variable3 = ExampleVariable::make_shared();
+  variable3->data()[0] = -1.2;
+  graph.addVariable(variable3);
+
+  // Create a few constraints
+  auto constraint1 = ExampleConstraint::make_shared(variable1->uuid());
+  graph.addConstraint(constraint1);
+
+  auto constraint2 = ExampleConstraint::make_shared(variable2->uuid());
+  graph.addConstraint(constraint2);
+
+  {
+    auto actual_variables = graph.getConnectedVariables(constraint1->uuid());
+    ASSERT_EQ(1, std::distance(actual_variables.begin(), actual_variables.end()));
+    for (const auto& actual : actual_variables)
+    {
+      if (actual.uuid() == variable1->uuid())
+      {
+        EXPECT_TRUE(compareVariables(*variable1, actual)) << failure_description;
+        continue;
+      }
+      // The constraint was not one of the expected constraints. Fail the test.
+      FAIL() << "The actual variable '" << actual.uuid() << "' was not in the expected collection.";
+    }
+  }
+
+  {
+    auto actual_variables = graph.getConnectedVariables(constraint2->uuid());
+    ASSERT_EQ(1, std::distance(actual_variables.begin(), actual_variables.end()));
+    for (const auto& actual : actual_variables)
+    {
+      if (actual.uuid() == variable2->uuid())
+      {
+        EXPECT_TRUE(compareVariables(*variable2, actual)) << failure_description;
+        continue;
+      }
+      // The constraint was not one of the expected constraints. Fail the test.
+      FAIL() << "The actual variable '" << actual.uuid() << "' was not in the expected collection.";
+    }
+  }
+
+  {
+    // Don't add constraint3 to the graph
+    auto constraint3 = ExampleConstraint::make_shared(variable3->uuid());
+    EXPECT_THROW(graph.getConnectedVariables(constraint3->uuid()), std::logic_error);
+  }
+}
+
 TEST(HashGraph, AddConstraint)
 {
   // Test adding constraints to the graph
@@ -497,6 +561,83 @@ TEST(HashGraph, GetConstraints)
     }
     // The constraint was not one of the expected constraints. Fail the test.
     FAIL() << "The actual constraint '" << actual.uuid() << "' was not in the expected collection.";
+  }
+}
+
+TEST(HashGraph, GetConnectedConstraints)
+{
+  // Test accessing the constraints connected to a specific variable
+
+  // Create the graph
+  fuse_graphs::HashGraph graph;
+
+  // Create a few variables
+  auto variable1 = ExampleVariable::make_shared();
+  variable1->data()[0] = 1.0;
+  graph.addVariable(variable1);
+
+  auto variable2 = ExampleVariable::make_shared();
+  variable2->data()[0] = 2.5;
+  graph.addVariable(variable2);
+
+  auto variable3 = ExampleVariable::make_shared();
+  variable3->data()[0] = -1.2;
+  graph.addVariable(variable3);
+
+  // Create a few constraints
+  auto constraint1 = ExampleConstraint::make_shared(variable1->uuid());
+  graph.addConstraint(constraint1);
+
+  auto constraint2 = ExampleConstraint::make_shared(variable2->uuid());
+  graph.addConstraint(constraint2);
+
+  auto constraint3 = ExampleConstraint::make_shared(variable1->uuid());
+  graph.addConstraint(constraint3);
+
+  {
+    auto actual_constraints = graph.getConnectedConstraints(variable1->uuid());
+    ASSERT_EQ(2, std::distance(actual_constraints.begin(), actual_constraints.end()));
+    for (const auto& actual : actual_constraints)
+    {
+      if (actual.uuid() == constraint1->uuid())
+      {
+        EXPECT_TRUE(compareConstraints(*constraint1, actual)) << failure_description;
+        continue;
+      }
+      if (actual.uuid() == constraint3->uuid())
+      {
+        EXPECT_TRUE(compareConstraints(*constraint3, actual)) << failure_description;
+        continue;
+      }
+      // The constraint was not one of the expected constraints. Fail the test.
+      FAIL() << "The actual constraint '" << actual.uuid() << "' was not in the expected collection.";
+    }
+  }
+
+  {
+    auto actual_constraints = graph.getConnectedConstraints(variable2->uuid());
+    ASSERT_EQ(1, std::distance(actual_constraints.begin(), actual_constraints.end()));
+    for (const auto& actual : actual_constraints)
+    {
+      if (actual.uuid() == constraint2->uuid())
+      {
+        EXPECT_TRUE(compareConstraints(*constraint2, actual)) << failure_description;
+        continue;
+      }
+      // The constraint was not one of the expected constraints. Fail the test.
+      FAIL() << "The actual constraint '" << actual.uuid() << "' was not in the expected collection.";
+    }
+  }
+
+  {
+    auto actual_constraints = graph.getConnectedConstraints(variable3->uuid());
+    ASSERT_EQ(0, std::distance(actual_constraints.begin(), actual_constraints.end()));
+  }
+
+  {
+    // Don't add variable4 to the graph
+    auto variable4 = ExampleVariable::make_shared();
+    EXPECT_THROW(graph.getConnectedConstraints(variable4->uuid()), std::logic_error);
   }
 }
 


### PR DESCRIPTION
Added the getConnectedVariables() and getConnectedConstraints() methods to the Graph class. These allow the user to easily query the graph connectivity, either from variable->constraints, or from constraint->variables.