### PR TITLE
[RST-1745] constraint list container

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(${PROJECT_NAME}
   src/relative_pose_2d_stamped_constraint.cpp
   src/relative_pose_3d_stamped_constraint.cpp
   src/uuid_ordering.cpp
+  src/variable_constraints.cpp
 )
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
@@ -275,5 +276,17 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_uuid_ordering
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
+  )
+
+  # VariableConstraints Tests
+  catkin_add_gtest(test_variable_constraints
+    test/test_variable_constraints.cpp
+  )
+  target_include_directories(test_variable_constraints
+    PRIVATE
+      include
+  )
+  target_link_libraries(test_variable_constraints
+    ${PROJECT_NAME}
   )
 endif()

--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -1,0 +1,133 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CONSTRAINTS_VARIABLE_CONSTRAINTS_H
+#define FUSE_CONSTRAINTS_VARIABLE_CONSTRAINTS_H
+
+#include <fuse_core/graph.h>
+
+#include <boost/range.hpp>
+
+#include <algorithm>
+#include <initializer_list>
+#include <unordered_set>
+#include <vector>
+
+
+namespace fuse_constraints
+{
+
+/**
+ * @brief Holds the per-variable constraint list
+ * 
+ * Each variable is represented by a unique index. The indices are expected to be "small and compact",
+ * i.e. sequentially numbered starting from zero. Failure to meet this expectation will result in excess memory
+ * allocation.
+ */
+class VariableConstraints
+{
+public:
+  /**
+   * @brief Pre-allocate enough memory to hold a specified number of variables
+   */
+  void reserve(const size_t variable_count);
+
+  /**
+   * @brief Return true if no variables or edges have been added
+   */
+  bool empty() const;
+
+  /**
+   * @brief The total number of unique (variable id, edge id) pairs
+   */
+  size_t size() const;
+
+  /**
+   * @brief The next available variable index
+   *
+   * This is one larger than the current maximum variable index
+   */
+  const unsigned int nextVariableIndex() const;
+
+  /**
+   * @brief Add this constraint to a single variable
+   */
+  void insert(const unsigned int constraint, const unsigned int variable);
+
+  /**
+   * @brief Add this constraint to all variables in the provided list
+   */
+  void insert(const unsigned int constraint, std::initializer_list<unsigned int> variable_list);
+
+  /**
+   * @brief Add this constraint to all variables in the provided range
+   */
+  template <typename VariableIndexIterator>
+  void insert(const unsigned int constraint, VariableIndexIterator first, VariableIndexIterator last);
+
+  /**
+   * @brief Insert all of the constraints connected to the requested variable into the provided container
+   *
+   * Accessing a variable id that is not part of this container results in undefined behavior
+   */
+  template <typename OutputIterator>
+  void getConstraints(const unsigned int variable_id, OutputIterator result) const;
+
+private:
+  using ConstraintCollection = std::unordered_set<unsigned int>;
+  using ConstraintsByVariable = std::vector<ConstraintCollection>;
+
+  ConstraintsByVariable variable_constraints_;  //!< The collection of constraints for each variable
+};
+
+template <typename VariableIndexIterator>
+void VariableConstraints::insert(const unsigned int constraint, VariableIndexIterator first, VariableIndexIterator last)
+{
+  for (; first != last; ++first)
+  {
+    insert(constraint, *first);
+  }
+}
+
+template<class OutputIterator>
+void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
+{
+  // Query the range of adjacent vertices
+  const auto& constraints = variable_constraints_[variable_id];
+  // Copy the list of adjacent vertices to the output container
+  std::copy(std::begin(constraints), std::end(constraints), result);
+}
+
+}  // namespace fuse_constraints
+
+#endif  // FUSE_CONSTRAINTS_VARIABLE_CONSTRAINTS_H

--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -34,12 +34,9 @@
 #ifndef FUSE_CONSTRAINTS_VARIABLE_CONSTRAINTS_H
 #define FUSE_CONSTRAINTS_VARIABLE_CONSTRAINTS_H
 
-#include <fuse_core/graph.h>
-
-#include <boost/range.hpp>
-
 #include <algorithm>
 #include <initializer_list>
+#include <iterator>
 #include <unordered_set>
 #include <vector>
 
@@ -63,12 +60,12 @@ public:
   void reserve(const size_t variable_count);
 
   /**
-   * @brief Return true if no variables or edges have been added
+   * @brief Return true if no variables or constraints have been added
    */
   bool empty() const;
 
   /**
-   * @brief The total number of unique (variable id, edge id) pairs
+   * @brief The total number of unique (variable id, constraint id) pairs
    */
   size_t size() const;
 
@@ -122,9 +119,7 @@ void VariableConstraints::insert(const unsigned int constraint, VariableIndexIte
 template<class OutputIterator>
 void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
 {
-  // Query the range of adjacent vertices
   const auto& constraints = variable_constraints_[variable_id];
-  // Copy the list of adjacent vertices to the output container
   std::copy(std::begin(constraints), std::end(constraints), result);
 }
 

--- a/fuse_constraints/src/variable_constraints.cpp
+++ b/fuse_constraints/src/variable_constraints.cpp
@@ -1,0 +1,81 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/variable_constraints.h>
+
+#include <initializer_list>
+#include <numeric>
+
+
+namespace fuse_constraints
+{
+
+void VariableConstraints::reserve(const size_t variable_count)
+{
+  variable_constraints_.reserve(variable_count);
+}
+
+bool VariableConstraints::empty() const
+{
+  return variable_constraints_.empty();
+}
+
+size_t VariableConstraints::size() const
+{
+  auto sum_edges = [](const size_t input, const ConstraintCollection& edges)
+  {
+    return input + edges.size();
+  };
+  return std::accumulate(variable_constraints_.begin(), variable_constraints_.end(), 0u, sum_edges);
+}
+
+const unsigned int VariableConstraints::nextVariableIndex() const
+{
+  return variable_constraints_.size();
+}
+
+void VariableConstraints::insert(const unsigned int constraint, const unsigned int variable)
+{
+  if (variable >= variable_constraints_.size())
+  {
+    variable_constraints_.resize(variable + 1);
+  }
+  variable_constraints_[variable].insert(constraint);
+}
+
+void VariableConstraints::insert(const unsigned int constraint, std::initializer_list<unsigned int> variable_list)
+{
+  return insert(constraint, variable_list.begin(), variable_list.end());
+}
+
+}  // namespace fuse_constraints

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -1,0 +1,110 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/variable_constraints.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+
+using fuse_constraints::VariableConstraints;
+
+TEST(VariableConstraints, Size)
+{
+  auto vars = VariableConstraints();
+
+  EXPECT_TRUE(vars.empty());
+  EXPECT_EQ(0u, vars.size());
+
+  vars.insert(0u, {0u, 1u});  // NOLINT
+  vars.insert(1u, {0u, 1u});  // NOLINT
+  vars.insert(2u, {0u, 1u});  // NOLINT
+
+  EXPECT_FALSE(vars.empty());
+  EXPECT_EQ(6u, vars.size());
+}
+
+TEST(VariableConstraints, NextVariableIndex)
+{
+  auto vars = VariableConstraints();
+  EXPECT_EQ(0u, vars.nextVariableIndex());
+
+  vars.insert(0u, {9u, 10u});  // NOLINT
+
+  EXPECT_EQ(11u, vars.nextVariableIndex());
+}
+
+TEST(VariableConstraints, GetConstraints)
+{
+  auto vars = VariableConstraints();
+
+  vars.insert(0u, {0u, 1u, 2u});  // NOLINT
+  vars.insert(1u, {0u, 2u});      // NOLINT
+  vars.insert(2u, {1u, 2u});      // NOLINT
+  vars.insert(3u, {2u, 3u});      // NOLINT
+
+  auto expected0 = std::vector<size_t>{0u, 1u};          // NOLINT
+  auto expected1 = std::vector<size_t>{0u, 2u};          // NOLINT
+  auto expected2 = std::vector<size_t>{0u, 1u, 2u, 3u};  // NOLINT
+  auto expected3 = std::vector<size_t>{3u};              // NOLINT
+
+  std::vector<size_t> actual0;
+  vars.getConstraints(0u, std::back_inserter(actual0));
+  std::sort(actual0.begin(), actual0.end());
+
+  std::vector<size_t> actual1;
+  vars.getConstraints(1u, std::back_inserter(actual1));
+  std::sort(actual1.begin(), actual1.end());
+
+  std::vector<size_t> actual2;
+  vars.getConstraints(2u, std::back_inserter(actual2));
+  std::sort(actual2.begin(), actual2.end());
+
+  std::vector<size_t> actual3;
+  vars.getConstraints(3u, std::back_inserter(actual3));
+  std::sort(actual3.begin(), actual3.end());
+
+  EXPECT_EQ(expected0, actual0);
+  EXPECT_EQ(expected1, actual1);
+  EXPECT_EQ(expected2, actual2);
+  EXPECT_EQ(expected3, actual3);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added a container that holds the list of constraints, organized by variable.

This is designed as a helper structure for the variable marginalization code. As such, the variables and constraints are assigned sequential indexes instead of UUIDs.