### PR TITLE
Modified Variable class to make the UUID immutable

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -3,6 +3,7 @@ project(fuse_constraints)
 
 set(build_depends
   fuse_core
+  fuse_graphs
   fuse_variables
   geometry_msgs
   roscpp
@@ -94,7 +95,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
-  find_package(fuse_graphs REQUIRED)
 
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
@@ -227,13 +227,12 @@ if(CATKIN_ENABLE_TESTING)
   target_include_directories(test_marginalize_variables
     PRIVATE
       include
+      ${catkin_INCLUDE_DIRS}
       ${CERES_INCLUDE_DIRS}
-      ${fuse_graphs_INCLUDE_DIRS}
   )
   target_link_libraries(test_marginalize_variables
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
-    ${fuse_graphs_LIBRARIES}
   )
 
   # Relative Constraint Tests

--- a/fuse_constraints/package.xml
+++ b/fuse_constraints/package.xml
@@ -15,11 +15,11 @@
   <depend>ceres-solver</depend>
   <depend>eigen</depend>
   <depend>fuse_core</depend>
+  <depend>fuse_graphs</depend>
   <depend>fuse_variables</depend>
   <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
   <depend>suitesparse</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
-  <test_depend>fuse_graphs</test_depend>
 </package>

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -58,15 +58,12 @@
 class GenericVariable : public fuse_core::Variable
 {
 public:
-  SMART_PTR_DEFINITIONS(GenericVariable);
+  FUSE_VARIABLE_DEFINITIONS(GenericVariable);
 
   GenericVariable() :
-    Variable(),
-    data_{},
-    uuid_{fuse_core::uuid::generate()}
+    fuse_core::Variable(fuse_core::uuid::generate()),
+    data_{}
   {}
-
-  fuse_core::UUID uuid() const override { return uuid_; }
 
   size_t size() const override { return 1; }
 
@@ -75,11 +72,8 @@ public:
 
   void print(std::ostream& stream = std::cout) const override {}
 
-  fuse_core::Variable::UniquePtr clone() const override { return GenericVariable::make_unique(*this); }
-
 protected:
   double data_;
-  fuse_core::UUID uuid_;
 };
 
 /**

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -56,6 +56,8 @@
 #define FUSE_CORE_MACROS_H
 
 #include <memory>
+#include <string>
+
 
 /**
  * Defines aliases and static functions for using the Class with smart pointers.

--- a/fuse_core/src/variable.cpp
+++ b/fuse_core/src/variable.cpp
@@ -39,6 +39,11 @@
 namespace fuse_core
 {
 
+Variable::Variable(const UUID& uuid) :
+  uuid_(uuid)
+{
+}
+
 std::ostream& operator <<(std::ostream& stream, const Variable& variable)
 {
   variable.print(stream);

--- a/fuse_core/test/example_variable.h
+++ b/fuse_core/test/example_variable.h
@@ -45,24 +45,21 @@
 class ExampleVariable : public fuse_core::Variable
 {
 public:
-  SMART_PTR_DEFINITIONS(ExampleVariable);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
 
   ExampleVariable() :
-    data_(0.0),
-    uuid_(fuse_core::uuid::generate())
+    fuse_core::Variable(fuse_core::uuid::generate()),
+    data_(0.0)
   {
   }
 
-  fuse_core::UUID uuid() const override { return uuid_; }
   size_t size() const override { return 1; }
   const double* data() const override { return &data_; };
   double* data() override { return &data_; };
   void print(std::ostream& stream = std::cout) const override {}
-  fuse_core::Variable::UniquePtr clone() const override { return ExampleVariable::make_unique(*this); }
 
 private:
   double data_;
-  fuse_core::UUID uuid_;
 };
 
 #endif  // FUSE_CORE_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}

--- a/fuse_graphs/test/example_variable.h
+++ b/fuse_graphs/test/example_variable.h
@@ -34,7 +34,6 @@
 #ifndef FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 #define FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 
@@ -47,24 +46,21 @@
 class ExampleVariable : public fuse_core::Variable
 {
 public:
-  SMART_PTR_DEFINITIONS(ExampleVariable);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
 
   explicit ExampleVariable(size_t N = 1) :
-    data_(N, 0.0),
-    uuid_(fuse_core::uuid::generate())
+    fuse_core::Variable(fuse_core::uuid::generate()),
+    data_(N, 0.0)
   {
   }
 
-  fuse_core::UUID uuid() const override { return uuid_; }
   size_t size() const override { return data_.size(); }
   const double* data() const override { return data_.data(); };
   double* data() override { return data_.data(); };
   void print(std::ostream& stream = std::cout) const override {}
-  fuse_core::Variable::UniquePtr clone() const override { return ExampleVariable::make_unique(*this); }
 
 private:
   std::vector<double> data_;
-  fuse_core::UUID uuid_;
 };
 
 #endif  // FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}

--- a/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_ACCELERATION_ANGULAR_2D_STAMPED_H
 #define FUSE_VARIABLES_ACCELERATION_ANGULAR_2D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -52,10 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's acceleration. The UUID of this class is constant after construction.
  * As such, the timestamp and device id cannot be modified. The value of the acceleration can be modified.
  */
-class AccelerationAngular2DStamped final : public FixedSizeVariable<1>, public Stamped
+class AccelerationAngular2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(AccelerationAngular2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -86,28 +86,11 @@ public:
   const double& yaw() const { return data_[YAW]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_ACCELERATION_ANGULAR_3D_STAMPED_H
 #define FUSE_VARIABLES_ACCELERATION_ANGULAR_3D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -53,10 +53,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's acceleration. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the acceleration can be modified.
  */
-class AccelerationAngular3DStamped final : public FixedSizeVariable<3>, public Stamped
+class AccelerationAngular3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(AccelerationAngular3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -109,28 +109,11 @@ public:
   const double& yaw() const { return data_[YAW]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_ACCELERATION_LINEAR_2D_STAMPED_H
 #define FUSE_VARIABLES_ACCELERATION_LINEAR_2D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -52,10 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's acceleration. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the acceleration can be modified.
  */
-class AccelerationLinear2DStamped final : public FixedSizeVariable<2>, public Stamped
+class AccelerationLinear2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(AccelerationLinear2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -97,28 +97,11 @@ public:
   const double& y() const { return data_[Y]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_ACCELERATION_LINEAR_3D_STAMPED_H
 #define FUSE_VARIABLES_ACCELERATION_LINEAR_3D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -52,10 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's acceleration. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the acceleration can be modified.
  */
-class AccelerationLinear3DStamped final : public FixedSizeVariable<3>,  public Stamped
+class AccelerationLinear3DStamped : public FixedSizeVariable<3>,  public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(AccelerationLinear3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -108,28 +108,11 @@ public:
   const double& z() const { return data_[Z]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/fixed_size_variable.h
+++ b/fuse_variables/include/fuse_variables/fixed_size_variable.h
@@ -53,7 +53,7 @@ namespace fuse_variables
  * where the size of the state vector is known at compile time...which should be almost all variable types. The
  * dimension of typical variable types (points, poses, calibration parameters) are all known at design/compile time.
  */
-template<size_t N>
+template <size_t N>
 class FixedSizeVariable : public fuse_core::Variable
 {
 public:
@@ -67,8 +67,8 @@ public:
   /**
    * @brief Constructor
    */
-  FixedSizeVariable() :
-    Variable(),
+  explicit FixedSizeVariable(const fuse_core::UUID& uuid) :
+    fuse_core::Variable(uuid),
     data_{}  // zero-initialize the data array
   {}
 
@@ -108,8 +108,8 @@ protected:
   std::array<double, N> data_;  //!< Fixed-sized, contiguous memory for holding the variable data members
 };
 
-// Define the constant that was decalred above
-template<size_t N>
+// Define the constant that was declared above
+template <size_t N>
 constexpr size_t FixedSizeVariable<N>::SIZE;
 }  // namespace fuse_variables
 

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -35,8 +35,8 @@
 #define FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H
 
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -53,10 +53,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's orientation within a map. The UUID of this class is static after
  * construction. As such, the timestamp and device id cannot be modified. The value of the orientation can be modified.
  */
-class Orientation2DStamped final : public FixedSizeVariable<1>, public Stamped
+class Orientation2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(Orientation2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Orientation2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -71,7 +71,6 @@ public:
    *
    * @param[in] stamp     The timestamp attached to this orientation.
    * @param[in] device_id An optional device id, for use when variables originate from multiple robots or devices
-   *
    */
   explicit Orientation2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id = fuse_core::uuid::NIL);
 
@@ -86,25 +85,11 @@ public:
   const double& yaw() const { return data_[YAW]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
 
   /**
    * @brief Returns the number of elements of the local parameterization space.
@@ -123,9 +108,6 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   fuse_core::LocalParameterization* localParameterization() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -35,9 +35,9 @@
 #define FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H
 
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -59,10 +59,10 @@ namespace fuse_variables
  * The internal representation for this is different from the typical ROS representation, as w is the first component.
  * This is necessary to use the Ceres local parameterization for quaternions.
  */
-class Orientation3DStamped final : public FixedSizeVariable<4>, public Stamped
+class Orientation3DStamped : public FixedSizeVariable<4>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(Orientation3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Orientation3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the quaternion
@@ -149,25 +149,11 @@ public:
   double yaw() { return fuse_core::getYaw(w(), x(), y(), z()); }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param  stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
 
   /**
    * @brief Returns the number of elements of the local parameterization space.
@@ -183,9 +169,6 @@ public:
    * @return A pointer to a local parameterization object that indicates how to "add" increments to the quaternion
    */
   fuse_core::LocalParameterization* localParameterization() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/position_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_2d_stamped.h
@@ -34,14 +34,13 @@
 #ifndef FUSE_VARIABLES_POSITION_2D_STAMPED_H
 #define FUSE_VARIABLES_POSITION_2D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
 #include <ostream>
-#include <string>
 
 
 namespace fuse_variables
@@ -53,15 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's position within a map. The UUID of this class is static after
  * construction. As such, the timestamp and device id cannot be modified. The value of the position can be modified.
  */
-class Position2DStamped final : public FixedSizeVariable<2>, public Stamped
+class Position2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(Position2DStamped);
-
-  /**
-   * @brief The unique name for this variable type.
-   */
-  static const std::string TYPE;
+  FUSE_VARIABLE_DEFINITIONS(Position2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -102,28 +96,11 @@ public:
   const double& y() const { return data_[Y]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/position_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_3d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_POSITION_3D_STAMPED_H
 #define FUSE_VARIABLES_POSITION_3D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -54,10 +54,10 @@ namespace fuse_variables
  * static after construction. As such, the timestamp and device ID cannot be modified. The value of the position
  * can be modified.
  */
-class Position3DStamped final : public FixedSizeVariable<3>, public Stamped
+class Position3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(Position3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Position3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -108,28 +108,11 @@ public:
   const double& z() const { return data_[Z]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param  stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/stamped.h
+++ b/fuse_variables/include/fuse_variables/stamped.h
@@ -79,7 +79,7 @@ public:
    */
   const fuse_core::UUID& deviceId() const { return device_id_; }
 
-protected:
+private:
   fuse_core::UUID device_id_;  //!< The UUID associated with this specific device or hardware
   ros::Time stamp_;  //!< The timestamp associated with this variable instance
 };

--- a/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_VELOCITY_ANGULAR_2D_STAMPED_H
 #define FUSE_VARIABLES_VELOCITY_ANGULAR_2D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -52,10 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's velocity. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the velocity can be modified.
  */
-class VelocityAngular2DStamped final : public FixedSizeVariable<1>, public Stamped
+class VelocityAngular2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(VelocityAngular2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityAngular2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -84,28 +84,11 @@ public:
   const double& yaw() const { return data_[YAW]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_VELOCITY_ANGULAR_3D_STAMPED_H
 #define FUSE_VARIABLES_VELOCITY_ANGULAR_3D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -56,7 +56,7 @@ namespace fuse_variables
 class VelocityAngular3DStamped final : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(VelocityAngular3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityAngular3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -107,28 +107,11 @@ public:
   const double& yaw() const { return data_[YAW]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_VELOCITY_LINEAR_2D_STAMPED_H
 #define FUSE_VARIABLES_VELOCITY_LINEAR_2D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -52,10 +52,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's velocity. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the velocity can be modified.
  */
-class VelocityLinear2DStamped final : public FixedSizeVariable<2>, public Stamped
+class VelocityLinear2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(VelocityLinear2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityLinear2DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -96,28 +96,11 @@ public:
   const double& y() const { return data_[Y]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_VARIABLES_VELOCITY_LINEAR_3D_STAMPED_H
 #define FUSE_VARIABLES_VELOCITY_LINEAR_3D_STAMPED_H
 
-#include <fuse_core/macros.h>
 #include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -53,10 +53,10 @@ namespace fuse_variables
  * This is commonly used to represent a robot's velocity. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the velocity can be modified.
  */
-class VelocityLinear3DStamped final : public FixedSizeVariable<3>, public Stamped
+class VelocityLinear3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  SMART_PTR_DEFINITIONS(VelocityLinear3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityLinear3DStamped);
 
   /**
    * @brief Can be used to directly index variables in the data array
@@ -108,28 +108,11 @@ public:
   const double& z() const { return data_[Z]; }
 
   /**
-   * @brief Read-only access to the unique ID of this variable instance.
-   *
-   * All variables of this type with identical timestamps will return the same UUID.
-   */
-  fuse_core::UUID uuid() const override { return uuid_; }
-
-  /**
    * @brief Print a human-readable description of the variable to the provided stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
-   *
-   * @return A unique pointer to a new instance of the most-derived Variable
-   */
-  fuse_core::Variable::UniquePtr clone() const override;
-
-protected:
-  fuse_core::UUID uuid_;  //!< The UUID for this instance, computed during construction
 };
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_2d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 AccelerationAngular2DStamped::AccelerationAngular2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable<1>(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -53,11 +59,6 @@ void AccelerationAngular2DStamped::print(std::ostream& stream) const
          << "  size: " << size() << "\n"
          << "  data:\n"
          << "  - yaw: " << yaw() << "\n";
-}
-
-fuse_core::Variable::UniquePtr AccelerationAngular2DStamped::clone() const
-{
-  return AccelerationAngular2DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_3d_stamped.cpp
@@ -31,8 +31,14 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_3d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
@@ -41,8 +47,8 @@ namespace fuse_variables
 AccelerationAngular3DStamped::AccelerationAngular3DStamped(
   const ros::Time& stamp,
   const fuse_core::UUID& device_id) :
-    Stamped(stamp, device_id),
-    uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+    FixedSizeVariable<3>(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+    Stamped(stamp, device_id)
 {
 }
 
@@ -57,11 +63,6 @@ void AccelerationAngular3DStamped::print(std::ostream& stream) const
          << "  - roll: " << roll() << "\n"
          << "  - pitch: " << pitch() << "\n"
          << "  - yaw: " << yaw() << "\n";
-}
-
-fuse_core::Variable::UniquePtr AccelerationAngular3DStamped::clone() const
-{
-  return AccelerationAngular3DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_2d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 AccelerationLinear2DStamped::AccelerationLinear2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -54,11 +60,6 @@ void AccelerationLinear2DStamped::print(std::ostream& stream) const
          << "  data:\n"
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n";
-}
-
-fuse_core::Variable::UniquePtr AccelerationLinear2DStamped::clone() const
-{
-  return AccelerationLinear2DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_3d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_linear_3d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 AccelerationLinear3DStamped::AccelerationLinear3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -55,11 +61,6 @@ void AccelerationLinear3DStamped::print(std::ostream& stream) const
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n"
          << "  - z: " << z() << "\n";
-}
-
-fuse_core::Variable::UniquePtr AccelerationLinear3DStamped::clone() const
-{
-  return AccelerationLinear3DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/util.h>
 #include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
@@ -103,8 +104,8 @@ public:
 };
 
 Orientation2DStamped::Orientation2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -117,11 +118,6 @@ void Orientation2DStamped::print(std::ostream& stream) const
          << "  size: " << size() << "\n"
          << "  data:\n"
          << "  - yaw: " << yaw() << "\n";
-}
-
-fuse_core::Variable::UniquePtr Orientation2DStamped::clone() const
-{
-  return Orientation2DStamped::make_unique(*this);
 }
 
 fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() const

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -34,7 +34,9 @@
 #include <fuse_variables/orientation_3d_stamped.h>
 
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/util.h>
 #include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
@@ -132,8 +134,8 @@ public:
 };
 
 Orientation3DStamped::Orientation3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable<4>(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -149,11 +151,6 @@ void Orientation3DStamped::print(std::ostream& stream) const
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n"
          << "  - z: " << z() << "\n";
-}
-
-fuse_core::Variable::UniquePtr Orientation3DStamped::clone() const
-{
-  return Orientation3DStamped::make_unique(*this);
 }
 
 fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const

--- a/fuse_variables/src/position_2d_stamped.cpp
+++ b/fuse_variables/src/position_2d_stamped.cpp
@@ -31,22 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/position_2d_stamped.h>
 
-#include <boost/core/demangle.hpp>
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
 
-#include <string>
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
-const std::string Position2DStamped::TYPE = boost::core::demangle(typeid(Position2DStamped).name());
-
 Position2DStamped::Position2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -60,11 +60,6 @@ void Position2DStamped::print(std::ostream& stream) const
          << "  data:\n"
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n";
-}
-
-fuse_core::Variable::UniquePtr Position2DStamped::clone() const
-{
-  return Position2DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/position_3d_stamped.cpp
+++ b/fuse_variables/src/position_3d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/position_3d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 Position3DStamped::Position3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -55,11 +61,6 @@ void Position3DStamped::print(std::ostream& stream) const
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n"
          << "  - z: " << z() << "\n";
-}
-
-fuse_core::Variable::UniquePtr Position3DStamped::clone() const
-{
-  return Position3DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/stamped.cpp
+++ b/fuse_variables/src/stamped.cpp
@@ -31,8 +31,9 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/stamped.h>
+
+#include <fuse_core/uuid.h>
 #include <ros/node_handle.h>
 
 #include <string>

--- a/fuse_variables/src/velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_2d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 VelocityAngular2DStamped::VelocityAngular2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -53,11 +59,6 @@ void VelocityAngular2DStamped::print(std::ostream& stream) const
          << "  size: " << size() << "\n"
          << "  data:\n"
          << "  - yaw: " << yaw() << "\n";
-}
-
-fuse_core::Variable::UniquePtr VelocityAngular2DStamped::clone() const
-{
-  return VelocityAngular2DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_3d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/velocity_angular_3d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 VelocityAngular3DStamped::VelocityAngular3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -55,11 +61,6 @@ void VelocityAngular3DStamped::print(std::ostream& stream) const
          << "  - roll: " << roll() << "\n"
          << "  - pitch: " << pitch() << "\n"
          << "  - yaw: " << yaw() << "\n";
-}
-
-fuse_core::Variable::UniquePtr VelocityAngular3DStamped::clone() const
-{
-  return VelocityAngular3DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_2d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 VelocityLinear2DStamped::VelocityLinear2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -54,11 +60,6 @@ void VelocityLinear2DStamped::print(std::ostream& stream) const
          << "  data:\n"
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n";
-}
-
-fuse_core::Variable::UniquePtr VelocityLinear2DStamped::clone() const
-{
-  return VelocityLinear2DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/src/velocity_linear_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_3d_stamped.cpp
@@ -31,16 +31,22 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/uuid.h>
 #include <fuse_variables/velocity_linear_3d_stamped.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ostream>
 
 
 namespace fuse_variables
 {
 
 VelocityLinear3DStamped::VelocityLinear3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  Stamped(stamp, device_id),
-  uuid_(fuse_core::uuid::generate(type(), stamp, device_id))
+  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
+  Stamped(stamp, device_id)
 {
 }
 
@@ -55,11 +61,6 @@ void VelocityLinear3DStamped::print(std::ostream& stream) const
          << "  - x: " << x() << "\n"
          << "  - y: " << y() << "\n"
          << "  - z: " << z() << "\n";
-}
-
-fuse_core::Variable::UniquePtr VelocityLinear3DStamped::clone() const
-{
-  return VelocityLinear3DStamped::make_unique(*this);
 }
 
 }  // namespace fuse_variables

--- a/fuse_variables/test/test_fixed_size_variable.cpp
+++ b/fuse_variables/test/test_fixed_size_variable.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/macros.h>
+#include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 
 #include <gtest/gtest.h>
@@ -40,18 +40,14 @@
 class TestVariable : public fuse_variables::FixedSizeVariable<2>
 {
 public:
-  SMART_PTR_DEFINITIONS(TestVariable);
+  FUSE_VARIABLE_DEFINITIONS(TestVariable);
 
   TestVariable() :
-    uuid_(fuse_core::uuid::generate())
+    fuse_variables::FixedSizeVariable<2>(fuse_core::uuid::generate())
   {}
   virtual ~TestVariable() = default;
 
-  fuse_core::UUID uuid() const override { return uuid_; }
   void print(std::ostream& stream = std::cout) const override {}
-  fuse_core::Variable::UniquePtr clone() const override { return TestVariable::make_unique(*this); }
-private:
-  fuse_core::UUID uuid_;
 };
 
 


### PR DESCRIPTION
Modified Variable class to make the UUID immutable.
Such a trivial thing. Instead of having each derived class store a UUID and implement the `uuid()` method, just move that logic to the base class, and accept the UUID at construction.

However...
The UUID generator function uses the derived variable type string as the namespace. The type() method is virtual, and so it cannot be called before construction is complete, but I can't even start construction until I can access the type name. This all seems silly because the typename is knowable at compile time.

So...
I created a macro that generates a static version of the type() method, and uses the static version to implement the virtual method. Something conceptually similar to:
```
namespace detail
{
  std::string type() { return boost::get_type_name<Derived>();
}
std::string type() const override { return detail::type(); }
```
And this allows me to use the static function in the constructor:
```
Derived::Derived() :
  fuse_core::Variable(fuse_core::generate_uuid(detail::type()))
{}
```
While I was making a macro for that, I thought I might as well do the same for the `clone()` function, which has a fixed implementation but requires the derived type, so it cannot be provided by the base class. Then I wrapped both of those, along with the smart pointer definitions into a `FUSE_VARIABLES_DEFINITIONS(Derived)` macro.

That was way too much work for a mindless task I started because I was on an airplane for a few hours.