### PR TITLE
Fix const-correctness for the loadDeviceId() function

### DIFF
--- a/fuse_variables/include/fuse_variables/stamped.h
+++ b/fuse_variables/include/fuse_variables/stamped.h
@@ -105,7 +105,7 @@ protected:
  * @param[in] node_handle A node handle in the desired parameter namespace
  * @return                A device UUID
  */
-fuse_core::UUID loadDeviceId(ros::NodeHandle& node_handle);
+fuse_core::UUID loadDeviceId(const ros::NodeHandle& node_handle);
 
 }  // namespace fuse_variables
 

--- a/fuse_variables/src/stamped.cpp
+++ b/fuse_variables/src/stamped.cpp
@@ -41,7 +41,7 @@
 namespace fuse_variables
 {
 
-fuse_core::UUID loadDeviceId(ros::NodeHandle& node_handle)
+fuse_core::UUID loadDeviceId(const ros::NodeHandle& node_handle)
 {
   fuse_core::UUID device_id;
   std::string device_str;


### PR DESCRIPTION
The node handle in the loadDeviceId() function does not need to be mutable