### PR TITLE
[RST-2128] fixed lag smoother reset

### DIFF
--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -94,6 +94,13 @@ public:
   virtual ~Graph() = default;
 
   /**
+   * @brief Clear all variables and constraints from the graph object.
+   *
+   * The object should be equivalent to a newly constructed object after clear() has been called.
+   */
+  virtual void clear() = 0;
+
+  /**
    * @brief Return a deep copy of the graph object.
    *
    * This should include deep copies of all variables and constraints; not pointer copies.

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -97,6 +97,13 @@ public:
   HashGraph& operator=(const HashGraph& other);
 
   /**
+   * @brief Clear all variables and constraints from the graph object.
+   *
+   * The object should be equivalent to a newly constructed object after clear() has been called.
+   */
+  void clear() override;
+
+  /**
    * @brief Return a deep copy of the graph object.
    *
    * This should include deep copies of all variables and constraints; not pointer copies.

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -88,6 +88,14 @@ HashGraph& HashGraph::operator=(const HashGraph& other)
   return *this;
 }
 
+void HashGraph::clear()
+{
+  constraints_.clear();
+  constraints_by_variable_uuid_.clear();
+  variables_.clear();
+  variables_on_hold_.clear();
+}
+
 fuse_core::Graph::UniquePtr HashGraph::clone() const
 {
   return HashGraph::make_unique(*this);

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(build_depends
   fuse_graphs
   pluginlib
   roscpp
+  std_srvs
 )
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -251,7 +251,7 @@ protected:
   /**
    * @brief Service callback that resets the optimizer to its original state
    */
-  bool resetServiceCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
+  bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 
   /**
    * @brief Callback fired every time the SensorModel plugin creates a new transaction

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -182,6 +182,11 @@ protected:
   ros::ServiceServer reset_service_server_;  //!< Service that resets the optimizer to its initial state
 
   /**
+   * @brief Automatically start the smoother if no ignition sensors are specified
+   */
+  void autostart();
+
+  /**
    * @brief Perform any required preprocessing steps before \p computeVariablesToMarginalize() is called
    *
    * All new transactions that will be applied to the graph are provided. This does not include the marginal

--- a/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
+++ b/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
@@ -88,6 +88,15 @@ public:
   }
 
   /**
+   * @brief Clear all tracked state
+   */
+  void clear()
+  {
+    stamped_index_.clear();
+    unstamped_index_.clear();
+  }
+
+  /**
    * @brief Returns the most recent timestamp associated with any variable
    */
   ros::Time currentStamp() const;

--- a/fuse_optimizers/include/fuse_optimizers/vector_queue.h
+++ b/fuse_optimizers/include/fuse_optimizers/vector_queue.h
@@ -165,6 +165,14 @@ public:
     container_.pop_back();
   }
 
+  /**
+   * @brief Remove all elements from the vector
+   */
+  void clear()
+  {
+    container_.clear();
+  }
+
 protected:
   using Container = std::vector<std::pair<key_type, value_type>>;
 

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -19,6 +19,7 @@
   <depend>fuse_graphs</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
+  <depend>std_srvs</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -117,6 +117,9 @@ FixedLagSmoother::FixedLagSmoother(
     optimization_period_,
     &FixedLagSmoother::optimizerTimerCallback,
     this);
+
+  // Advertise a service that resets the optimizer to its initial state
+  reset_service_server_ = private_node_handle_.advertiseService("reset", &FixedLagSmoother::resetServiceCallback, this);
 }
 
 FixedLagSmoother::~FixedLagSmoother()
@@ -179,27 +182,31 @@ void FixedLagSmoother::optimizationLoop()
     // Apply motion models
     auto new_transaction = fuse_core::Transaction::make_shared();
     processQueue(*new_transaction);
-    // Prepare for selecting the marginal variables
-    preprocessMarginalization(*new_transaction);
-    // Combine the new transactions with any marginal transaction from the end of the last cycle
-    new_transaction->merge(marginal_transaction);
-    // Update the graph
-    graph_->update(*new_transaction);
-    // Optimize the entire graph
-    graph_->optimize();
-    // Optimization is complete. Notify all the things about the graph changes.
-    notify(std::move(new_transaction), graph_->clone());
-    // Compute a transaction that marginalizes out those variables.
-    marginal_transaction = fuse_constraints::marginalizeVariables(computeVariablesToMarginalize(), *graph_);
-    // Perform any post-marginal cleanup
-    postprocessMarginalization(marginal_transaction);
-    // Note: The marginal transaction will not be applied until the next optimization iteration
-    // Log a warning if the optimization took too long
-    auto optimization_complete = ros::Time::now();
-    if (optimization_complete > optimization_deadline)
+    // Optimize
     {
-      ROS_WARN_STREAM("Optimization exceeded the configured duration by " <<
-                      (optimization_complete - optimization_deadline) << "s");
+      std::lock_guard<std::mutex> lock(optimization_mutex_);
+      // Prepare for selecting the marginal variables
+      preprocessMarginalization(*new_transaction);
+      // Combine the new transactions with any marginal transaction from the end of the last cycle
+      new_transaction->merge(marginal_transaction);
+      // Update the graph
+      graph_->update(*new_transaction);
+      // Optimize the entire graph
+      graph_->optimize();
+      // Optimization is complete. Notify all the things about the graph changes.
+      notify(std::move(new_transaction), graph_->clone());
+      // Compute a transaction that marginalizes out those variables.
+      marginal_transaction = fuse_constraints::marginalizeVariables(computeVariablesToMarginalize(), *graph_);
+      // Perform any post-marginal cleanup
+      postprocessMarginalization(marginal_transaction);
+      // Note: The marginal transaction will not be applied until the next optimization iteration
+      // Log a warning if the optimization took too long
+      auto optimization_complete = ros::Time::now();
+      if (optimization_complete > optimization_deadline)
+      {
+        ROS_WARN_STREAM("Optimization exceeded the configured duration by " <<
+                        (optimization_complete - optimization_deadline) << "s");
+      }
     }
     // Clear the request flag now that this optimization cycle is complete
     optimization_request_ = false;
@@ -266,6 +273,26 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
     transaction.merge(*element.transaction, true);
     pending_transactions_.pop_back();
   }
+}
+
+bool FixedLagSmoother::resetServiceCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res)
+{
+  started_ = false;
+  start_time_ = ros::Time(0, 0);
+  optimization_request_ = false;
+  // Clear all pending transactions
+  {
+    std::lock_guard<std::mutex> lock(pending_transactions_mutex_);
+    pending_transactions_.clear();
+  }
+  // Clear the graph and marginal tracking states
+  {
+    std::lock_guard<std::mutex> lock(optimization_mutex_);
+    graph_->clear();
+    timestamp_tracking_.clear();
+  }
+  ROS_INFO_STREAM("resetCallback() complete");
+  return true;
 }
 
 void FixedLagSmoother::transactionCallback(

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -279,7 +279,7 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
   }
 }
 
-bool FixedLagSmoother::resetServiceCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res)
+bool FixedLagSmoother::resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
 {
   started_ = false;
   start_time_ = ros::TIME_MAX;


### PR DESCRIPTION
Added a "reset" service to the fixed-lag smoother. This reverts the smoother back to its original state, waiting for a transaction from the configured ignition sensors.