### PR TITLE
[RST-2144] Support proper Eigen memory alignment

### DIFF
--- a/fuse_constraints/include/fuse_constraints/absolute_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint.h
@@ -67,7 +67,7 @@ template<class Variable>
 class AbsoluteConstraint final : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(AbsoluteConstraint<Variable>);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteConstraint<Variable>);
 
   /**
    * @brief Create a constraint using a measurement/prior of all dimensions of the target variable
@@ -134,15 +134,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
@@ -114,12 +114,6 @@ void AbsoluteConstraint<Variable>::print(std::ostream& stream) const
 }
 
 template<class Variable>
-fuse_core::Constraint::UniquePtr AbsoluteConstraint<Variable>::clone() const
-{
-  return AbsoluteConstraint<Variable>::make_unique(*this);
-}
-
-template<class Variable>
 ceres::CostFunction* AbsoluteConstraint<Variable>::costFunction() const
 {
   // Ceres ships with a "prior" cost function. Just use that here.

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
@@ -60,7 +60,7 @@ namespace fuse_constraints
 class AbsoluteOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(AbsoluteOrientation3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsoluteOrientation3DStampedConstraint);
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -130,15 +130,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -61,7 +61,7 @@ namespace fuse_constraints
 class AbsoluteOrientation3DStampedEulerConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(AbsoluteOrientation3DStampedEulerConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteOrientation3DStampedEulerConstraint);
 
   using Euler = fuse_variables::Orientation3DStamped::Euler;
 
@@ -121,15 +121,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -63,7 +63,7 @@ namespace fuse_constraints
 class AbsolutePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsolutePose2DStampedConstraint);
 
   /**
    * @brief Create a constraint using a measurement/prior of the 2D pose

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -63,7 +63,7 @@ namespace fuse_constraints
 class AbsolutePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(AbsolutePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose2DStampedConstraint);
 
   /**
    * @brief Create a constraint using a measurement/prior of the 2D pose
@@ -129,15 +129,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
@@ -63,7 +63,7 @@ namespace fuse_constraints
 class AbsolutePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(AbsolutePose3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose3DStampedConstraint);
 
   /**
    * @brief Create a constraint using a measurement/prior of the 3D pose
@@ -111,15 +111,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -65,7 +65,7 @@ namespace fuse_constraints
 class MarginalConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(MarginalConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(MarginalConstraint);
 
   /**
    * @brief Create a linear/marginal constraint
@@ -124,15 +124,6 @@ public:
   void print(std::ostream& stream = std::cout) const override;
 
   /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
-
-  /**
    * @brief Construct an instance of this constraint's cost function
    *
    * The function caller will own the new cost function instance. It is the responsibility of the caller to delete
@@ -186,14 +177,16 @@ MarginalConstraint::MarginalConstraint(
   MatrixIterator first_A,
   MatrixIterator last_A,
   const fuse_core::VectorXd& b) :
-    Constraint(boost::make_transform_iterator(first_variable, &detail::getUuid),
-               boost::make_transform_iterator(last_variable, &detail::getUuid)),
+    Constraint(boost::make_transform_iterator(first_variable, &fuse_constraints::detail::getUuid),
+               boost::make_transform_iterator(last_variable, &fuse_constraints::detail::getUuid)),
     A_(first_A, last_A),
     b_(b),
-    local_parameterizations_(boost::make_transform_iterator(first_variable, &detail::getLocalParameterization),
-                             boost::make_transform_iterator(last_variable, &detail::getLocalParameterization)),
-    x_bar_(boost::make_transform_iterator(first_variable, &detail::getCurrentValue),
-           boost::make_transform_iterator(last_variable, &detail::getCurrentValue))
+    local_parameterizations_(boost::make_transform_iterator(first_variable,
+                                                            &fuse_constraints::detail::getLocalParameterization),
+                             boost::make_transform_iterator(last_variable,
+                                                            &fuse_constraints::detail::getLocalParameterization)),
+    x_bar_(boost::make_transform_iterator(first_variable, &fuse_constraints::detail::getCurrentValue),
+           boost::make_transform_iterator(last_variable, &fuse_constraints::detail::getCurrentValue))
 {
   assert(!A_.empty());
   assert(A_.size() == x_bar_.size());

--- a/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_ORIENTATION_3D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
@@ -68,6 +69,8 @@ namespace fuse_constraints
 class NormalDeltaOrientation3DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Construct a cost function instance
    *

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
@@ -73,8 +73,6 @@ namespace fuse_constraints
 class NormalDeltaPose2DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
-
   /**
    * @brief Constructor
    *

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_POSE_2D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>
@@ -72,6 +73,8 @@ namespace fuse_constraints
 class NormalDeltaPose2DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Constructor
    *

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
@@ -35,8 +35,8 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_POSE_3D_COST_FUNCTOR_H
 
 #include <fuse_constraints/normal_delta_orientation_3d_cost_functor.h>
-
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 
 #include <ceres/rotation.h>
@@ -68,6 +68,8 @@ namespace fuse_constraints
 class NormalDeltaPose3DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Constructor
    *

--- a/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_ORIENTATION_3D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
@@ -68,6 +69,8 @@ namespace fuse_constraints
 class NormalPriorOrientation3DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Construct a cost function instance
    *

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
@@ -35,6 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_2D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>
@@ -66,6 +67,8 @@ namespace fuse_constraints
 class NormalPriorPose2DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Construct a cost function instance
    *

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
@@ -67,8 +67,6 @@ namespace fuse_constraints
 class NormalPriorPose2DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
-
   /**
    * @brief Construct a cost function instance
    *

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
@@ -35,8 +35,8 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_3D_COST_FUNCTOR_H
 
 #include <fuse_constraints/normal_prior_orientation_3d_cost_functor.h>
-
 #include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>
@@ -68,6 +68,8 @@ namespace fuse_constraints
 class NormalPriorPose3DCostFunctor
 {
 public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
   /**
    * @brief Construct a cost function instance
    *

--- a/fuse_constraints/include/fuse_constraints/relative_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint.h
@@ -70,7 +70,7 @@ template<class Variable>
 class RelativeConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(RelativeConstraint<Variable>);
+  FUSE_CONSTRAINT_DEFINITIONS(RelativeConstraint<Variable>);
 
   /**
    * @brief Create a constraint on the change of all dimensions between the two target variables
@@ -143,15 +143,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
@@ -119,12 +119,6 @@ void RelativeConstraint<Variable>::print(std::ostream& stream) const
 }
 
 template<class Variable>
-fuse_core::Constraint::UniquePtr RelativeConstraint<Variable>::clone() const
-{
-  return RelativeConstraint<Variable>::make_unique(*this);
-}
-
-template<class Variable>
 ceres::CostFunction* RelativeConstraint<Variable>::costFunction() const
 {
   // Create a Gaussian/Normal Delta constraint

--- a/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
@@ -59,7 +59,7 @@ namespace fuse_constraints
 class RelativeOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(RelativeOrientation3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativeOrientation3DStampedConstraint);
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -135,15 +135,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Construct an instance of this constraint's cost function

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -61,7 +61,7 @@ namespace fuse_constraints
 class RelativePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(RelativePose2DStampedConstraint);
 
   /**
    * @brief Constructor

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -61,7 +61,7 @@ namespace fuse_constraints
 class RelativePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(RelativePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose2DStampedConstraint);
 
   /**
    * @brief Constructor
@@ -131,15 +131,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Access the cost function for this constraint

--- a/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
@@ -60,7 +60,7 @@ namespace fuse_constraints
 class RelativePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(RelativePose3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose3DStampedConstraint);
 
   /**
    * @brief Constructor
@@ -106,15 +106,6 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
-
-  /**
-   * @brief Perform a deep copy of the constraint and return a unique pointer to the copy
-   *
-   * Unique pointers can be implicitly upgraded to shared pointers if needed.
-   *
-   * @return A unique pointer to a new instance of the most-derived constraint
-   */
-  fuse_core::Constraint::UniquePtr clone() const override;
 
   /**
    * @brief Access the cost function for this constraint

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
@@ -81,11 +81,6 @@ void AbsoluteOrientation3DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr AbsoluteOrientation3DStampedConstraint::clone() const
-{
-  return AbsoluteOrientation3DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* AbsoluteOrientation3DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalPriorOrientation3DCostFunctor, 3, 4>(

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -72,11 +72,6 @@ void AbsoluteOrientation3DStampedEulerConstraint::print(std::ostream& stream) co
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr AbsoluteOrientation3DStampedEulerConstraint::clone() const
-{
-  return AbsoluteOrientation3DStampedEulerConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* AbsoluteOrientation3DStampedEulerConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalPriorOrientation3DEulerCostFunctor, ceres::DYNAMIC, 4>(

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -109,11 +109,6 @@ void AbsolutePose2DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr AbsolutePose2DStampedConstraint::clone() const
-{
-  return AbsolutePose2DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* AbsolutePose2DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalPriorPose2DCostFunctor, ceres::DYNAMIC, 2, 1>(

--- a/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
@@ -62,11 +62,6 @@ void AbsolutePose3DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr AbsolutePose3DStampedConstraint::clone() const
-{
-  return AbsolutePose3DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* AbsolutePose3DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalPriorPose3DCostFunctor, 6, 3, 4>(

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -62,11 +62,6 @@ void MarginalConstraint::print(std::ostream& stream) const
   stream << "  b:\n" << b_.format(indent) << "\n";
 }
 
-fuse_core::Constraint::UniquePtr MarginalConstraint::clone() const
-{
-  return MarginalConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* MarginalConstraint::costFunction() const
 {
   return new MarginalCostFunction(A_, b_, x_bar_, local_parameterizations_);

--- a/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
@@ -86,11 +86,6 @@ void RelativeOrientation3DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr RelativeOrientation3DStampedConstraint::clone() const
-{
-  return RelativeOrientation3DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* RelativeOrientation3DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalDeltaOrientation3DCostFunctor, 3, 4, 4>(

--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -113,11 +113,6 @@ void RelativePose2DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr RelativePose2DStampedConstraint::clone() const
-{
-  return RelativePose2DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* RelativePose2DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalDeltaPose2DCostFunctor, ceres::DYNAMIC, 2, 1, 2, 1>(

--- a/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
@@ -65,11 +65,6 @@ void RelativePose3DStampedConstraint::print(std::ostream& stream) const
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
-fuse_core::Constraint::UniquePtr RelativePose3DStampedConstraint::clone() const
-{
-  return RelativePose3DStampedConstraint::make_unique(*this);
-}
-
 ceres::CostFunction* RelativePose3DStampedConstraint::costFunction() const
 {
   return new ceres::AutoDiffCostFunction<NormalDeltaPose3DCostFunctor, 6, 3, 4, 3, 4>(

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -82,7 +82,7 @@ protected:
 class GenericConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(GenericConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint);
 
   GenericConstraint(std::initializer_list<fuse_core::UUID> variable_uuids) : Constraint(variable_uuids) {}
 
@@ -95,8 +95,6 @@ public:
   void print(std::ostream& stream = std::cout) const override {}
 
   ceres::CostFunction* costFunction() const override { return nullptr; }
-
-  fuse_core::Constraint::UniquePtr clone() const override { return GenericConstraint::make_unique(*this); }
 };
 
 

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -58,19 +58,49 @@
 #include <memory>
 #include <string>
 
+// Required by make_aligned_shared, that uses Eigen::aligned_allocator<T>().
+#include <Eigen/Core>
+
+#if __cpp_aligned_new
+  #define FUSE_MAKE_ALIGNED_OPERATOR_NEW()
+#else
+  #define FUSE_MAKE_ALIGNED_OPERATOR_NEW() EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+#endif
 
 /**
- * Defines aliases and static functions for using the Class with smart pointers.
+ * Defines smart pointer aliases and static functions for a typical class.
  *
  * Use in the public section of the class.
  */
 #define SMART_PTR_DEFINITIONS(...) \
-  SHARED_PTR_DEFINITIONS(__VA_ARGS__) \
-  WEAK_PTR_DEFINITIONS(__VA_ARGS__) \
-  UNIQUE_PTR_DEFINITIONS(__VA_ARGS__)
+  __SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __MAKE_SHARED_DEFINITION(__VA_ARGS__) \
+  __WEAK_PTR_ALIAS(__VA_ARGS__) \
+  __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+  __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 
 /**
- * Defines aliases only for using the Class with smart pointers.
+ * Defines smart pointer aliases and static functions for a class that contains fixed-sized Eigen member variables.
+ *
+ * Same as SMART_PTR_DEFINITIONS except it ensure that shared ptr memory is allocated with proper byte alignment.
+ *
+ * Use in the public section of the class.
+ */
+#if __cpp_aligned_new
+  #define SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
+    SMART_PTR_DEFINITIONS(__VA_ARGS__)
+#else
+  #define SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
+    __SHARED_PTR_ALIAS(__VA_ARGS__) \
+    __MAKE_SHARED_ALIGNED_DEFINITION(__VA_ARGS__) \
+    __WEAK_PTR_ALIAS(__VA_ARGS__) \
+    __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+    __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
+#endif
+
+/**
+ * Defines smart pointers aliases only for abstract classes.
  *
  * Same as SMART_PTR_DEFINITIONS except it excludes the static
  * method definitions which do not work on pure virtual classes and classes
@@ -82,11 +112,6 @@
   __SHARED_PTR_ALIAS(__VA_ARGS__) \
   __WEAK_PTR_ALIAS(__VA_ARGS__) \
   __UNIQUE_PTR_ALIAS(__VA_ARGS__)
-
-/// Defines aliases and static functions for using the Class with shared_ptrs.
-#define SHARED_PTR_DEFINITIONS(...) \
-  __SHARED_PTR_ALIAS(__VA_ARGS__) \
-  __MAKE_SHARED_DEFINITION(__VA_ARGS__)
 
 #define __SHARED_PTR_ALIAS(...) \
   using SharedPtr = std::shared_ptr<__VA_ARGS__>; \
@@ -100,18 +125,17 @@
     return std::make_shared<__VA_ARGS__>(std::forward<Args>(args) ...); \
   }
 
-/// Defines aliases and static functions for using the Class with weak_ptrs.
-#define WEAK_PTR_DEFINITIONS(...) \
-  __WEAK_PTR_ALIAS(__VA_ARGS__)
+#define __MAKE_SHARED_ALIGNED_DEFINITION(...) \
+  template<typename ... Args> \
+  static std::shared_ptr<__VA_ARGS__> \
+  make_shared(Args && ... args) \
+  { \
+    return std::allocate_shared<__VA_ARGS__>(Eigen::aligned_allocator<__VA_ARGS__>(), std::forward<Args>(args) ...); \
+  }
 
 #define __WEAK_PTR_ALIAS(...) \
   using WeakPtr = std::weak_ptr<__VA_ARGS__>; \
   using ConstWeakPtr = std::weak_ptr<const __VA_ARGS__>;
-
-/// Defines aliases and static functions for using the Class with unique_ptrs.
-#define UNIQUE_PTR_DEFINITIONS(...) \
-  __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
-  __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 
 #define __UNIQUE_PTR_ALIAS(...) \
   using UniquePtr = std::unique_ptr<__VA_ARGS__>;

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -61,6 +61,15 @@
 // Required by make_aligned_shared, that uses Eigen::aligned_allocator<T>().
 #include <Eigen/Core>
 
+/**
+ * Creates a custom new() implementation that ensures memory is allocated with proper byte alignment. This should
+ * be added to the public section of classes or structs that contain fixed-sized vectorable Eigen objects.
+ *
+ * For examples of vectorable types, see: https://eigen.tuxfamily.org/dox-devel/group__TopicFixedSizeVectorizable.html
+ *
+ * This function is called internally by the SMART_PTR_DEFINITIONS_WITH_EIGEN below. You only need to call this
+ * function manually if the class or struct is not adding the smart pointer definitions.
+ */
 #if __cpp_aligned_new
   #define FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 #else
@@ -80,9 +89,11 @@
   __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 
 /**
- * Defines smart pointer aliases and static functions for a class that contains fixed-sized Eigen member variables.
+ * Defines smart pointer aliases and static functions for a class that contains fixed-sized vectorable Eigen member
+ * variables.
  *
- * Same as SMART_PTR_DEFINITIONS except it ensure that shared ptr memory is allocated with proper byte alignment.
+ * Same as SMART_PTR_DEFINITIONS except it ensures that shared ptr memory is allocated with proper byte alignment.
+ * For examples of vectorable types, see: https://eigen.tuxfamily.org/dox-devel/group__TopicFixedSizeVectorizable.html
  *
  * Use in the public section of the class.
  */

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -99,7 +99,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_DEFINITION(Derived);
+ *   FUSE_VARIABLE_DEFINITIONS(Derived);
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -107,7 +107,26 @@
 #define FUSE_VARIABLE_DEFINITIONS(...) \
   SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)
+
+/**
+ * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
+ *        for derived Variable classes that have fixed-sized Eigen member objects.
+ *
+ * Usage:
+ * @code{.cpp}
+ * class Derived : public Variable
+ * {
+ * public:
+ *   FUSE_VARIABLE_DEFINITIONS_WTIH_EIGEN(Derived);
+ *   // The rest of the derived variable implementation
+ * }
+ * @endcode
+ */
+#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...) \
+  SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)
 
 
 namespace fuse_core

--- a/fuse_core/test/example_constraint.h
+++ b/fuse_core/test/example_constraint.h
@@ -47,7 +47,7 @@
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
 
   ExampleConstraint(std::initializer_list<fuse_core::UUID> variable_uuid_list) :
     fuse_core::Constraint(variable_uuid_list),
@@ -64,7 +64,6 @@ public:
 
   void print(std::ostream& stream = std::cout) const override {}
   ceres::CostFunction* costFunction() const override { return nullptr; }
-  fuse_core::Constraint::UniquePtr clone() const override { return ExampleConstraint::make_unique(*this); }
 
   double data;  // Public member variable just for testing
 };

--- a/fuse_graphs/test/covariance_constraint.h
+++ b/fuse_graphs/test/covariance_constraint.h
@@ -137,7 +137,7 @@ public:
 class CovarianceConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(CovarianceConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(CovarianceConstraint);
 
   CovarianceConstraint(
     const fuse_core::UUID& variable1_uuid,
@@ -148,7 +148,6 @@ public:
   }
 
   void print(std::ostream& stream = std::cout) const override {}
-  fuse_core::Constraint::UniquePtr clone() const override { return CovarianceConstraint::make_unique(*this); }
   ceres::CostFunction* costFunction() const override { return new CovarianceCostFunction(); }
 };
 

--- a/fuse_graphs/test/example_constraint.h
+++ b/fuse_graphs/test/example_constraint.h
@@ -69,7 +69,7 @@ private:
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
 
   explicit ExampleConstraint(const fuse_core::UUID& variable_uuid) :
     fuse_core::Constraint{variable_uuid},
@@ -78,7 +78,6 @@ public:
   }
 
   void print(std::ostream& stream = std::cout) const override {}
-  fuse_core::Constraint::UniquePtr clone() const override { return ExampleConstraint::make_unique(*this); }
   ceres::CostFunction* costFunction() const override
   {
     return new ceres::AutoDiffCostFunction<ExampleFunctor, 1, 1>(new ExampleFunctor(data));

--- a/fuse_optimizers/test/test_variable_stamp_index.cpp
+++ b/fuse_optimizers/test/test_variable_stamp_index.cpp
@@ -128,7 +128,7 @@ protected:
 class GenericConstraint : public fuse_core::Constraint
 {
 public:
-  SMART_PTR_DEFINITIONS(GenericConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint);
 
   GenericConstraint(std::initializer_list<fuse_core::UUID> variable_uuids) :
     Constraint(variable_uuids)
@@ -162,11 +162,6 @@ public:
   ceres::CostFunction* costFunction() const override
   {
     return nullptr;
-  }
-
-  fuse_core::Constraint::UniquePtr clone() const override
-  {
-    return GenericConstraint::make_unique(*this);
   }
 };
 


### PR DESCRIPTION
This is my proposal to fix the Eigen memory alignment errors indicated in PR #62. The basic problem is Eigen objects need to be aligned on specific memory barriers to support SSE and similar CPU optimizations. Eigen already handles most of this internally...except for classes and structs that contain fixed-sized Eigen objects. Such classes have two problems.
1. These objects need to implement a custom `new()` operator that properly aligns the Eigen objects in memory. To make this easy, Eigen provides a macro to do this (`EIGEN_MAKE_ALIGNED_OPERATOR_NEW`), it just needs to be called in the public region of the class definition.
2. The `std::make_shared` call does not use the class-defined `new()` operator for whatever reason. Instead, you need to use `std::allocate_shared`.

For more details on Eigen memory alignment, see [here](https://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html).

This PR:
* Creates a new macro `SMART_PTR_DEFINITIONS_WITH_EIGEN()` that (a) calls the `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` macro to create the required `new()` operator that allocates memory correctly, and (b) implements an alternative definition of `make_shared` that uses `std::allocate_shared` and some Eigen calls. By naming the alternative version identically to the normal version, client code can call `Derived::make_shared` regardless of whether a class contains Eigen objects or not.
* Creates a `FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN` that is the parallel of the existing `FUSE_VARIABLE_DEFINITIONS` but uses `SMART_PTR_DEFINITIONS_WITH_EIGEN` instead of `SMART_PTR_DEFINITIONS`.
* Creates `FUSE_CONSTRAINT_DEFINITIONS` and `FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN` that are the parallel of the `FUSE_VARIABLE_DEFINITIONS` macros, but for Constraints. These macros implement the `std::string type() const` and `Constraint::SharedPtr clone() const` methods of the Constraint class. This is something I've been meaning to do anyway. And since I have to touch most of the constraints anyway, this seemed like a good time to sneak it in.
* Starting with C++17, the standard `new()` operator accepts an alignment size. With this feature, all of the above gymnastics are not required. The defined macros check for "aligned new" support and disable all of the additional code when appropriate. To allow this to happen in all cases, a `FUSE_MAKE_ALIGNED_OPERATOR_NEW` is provided, which calls the Eigen version or not, depending on the availability of "aligned new" support.
* Updates all of the fuse classes with the correct macro commands.

In summary:
* If you have a class that contains fixed-sized Eigen objects, then:
  * Add `FUSE_MAKE_ALIGNED_OPERATOR_NEW()` if you do not need any other smart pointer definitions.
  * Add `SMART_PTR_DEFINITIONS_WITH_EIGEN` if you do want all of the smart pointer definitions, including `Derived::make_shared()`. (Or `FUSE_CONSTRAINT_DEFINTIONS_WITH_EIGEN` if this is derived Constraint class. Or `FUSE_VARIABLE_DEFINTIONS_WITH_EIGEN` if this is derived Variable class)
* If you are creating smart pointers to fuse objects, then:
  * Always use the `Derived::make_shared()` implementation instead of the `std::make_shared<Derived>` formulation. The static member function will ensure the memory is properly aligned.

I have tested with Enrique's bagfile data using gcc-5.5, gcc-7.4, and gcc-7.4 with the `-faligned-new` flag. The bag data runs without error in all cases. All tests used the `-mavx` flag to trigger the alignment errors.