### PR TITLE
[RST-2185] Fix "fixed-lag crash on reset" bug

### DIFF
--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -158,6 +158,7 @@ protected:
                                                //!< until the origin constraint has been received.
   ros::Duration lag_duration_;  //!< Parameter that controls the time window of the fixed lag smoother. Variables
                                 //!< older than the lag duration will be marginalized out
+  fuse_core::Transaction marginal_transaction_;  //!< The marginals to add during the next optimization cycle
   ros::Time optimization_deadline_;  //!< The deadline for the optimization to complete. Triggers a warning if exceeded.
   std::mutex optimization_mutex_;  //!< Mutex held while the graph is begin optimized
   ros::Duration optimization_period_;  //!< The expected time between optimization cycles


### PR DESCRIPTION
After a reset() service call is issued, the fixed-lag smoother crashes. The graph complains that a transaction is added without the corresponding variables.
```
terminate called after throwing an instance of 'std::logic_error'
  what():  Attempting to add a constraint (77fe5f19-01d9-4951-883d-b939c07f159d) that uses an unknown variable (23243784-bdce-5e94-90ed-40a50b0ecfbd)
```

The issue was the local "marginal transaction" variable was not being cleared when reset() was called. This PR makes the marginal_transaction variable a class member (so t could be accessed by the reset() function), and clears it during reset().