### PR TITLE
Return variable UUID by const reference

### DIFF
--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -180,7 +180,7 @@ public:
   /**
    * @brief Returns a UUID for this variable.
    */
-  UUID uuid() const { return uuid_; }
+  const UUID& uuid() const { return uuid_; }
 
   /**
    * @brief Returns a unique name for this variable type.


### PR DESCRIPTION
In principle, returning by const reference instead of copy should be faster for the `UUID`, but there's also RVO in all modern compilers. I'm not completely sure about what would be faster, but this makes the `uuid()` method of the `Variable` class equivalent to the `Constraint` one: https://github.com/locusrobotics/fuse/blob/devel/fuse_core/include/fuse_core/constraint.h#L198