### PR TITLE
Add print method to Graph and HashGraph

### DIFF
--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -44,6 +44,7 @@
 #include <ceres/covariance.h>
 #include <ceres/solver.h>
 
+#include <ostream>
 #include <utility>
 #include <vector>
 
@@ -262,7 +263,19 @@ public:
    * @return            A Ceres Solver Summary structure containing information about the optimization process
    */
   virtual ceres::Solver::Summary optimize(const ceres::Solver::Options& options = ceres::Solver::Options()) = 0;
+
+  /**
+   * @brief Print a human-readable description of the graph to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  virtual void print(std::ostream& stream = std::cout) const = 0;
 };
+
+/**
+ * Stream operator for printing Graph objects.
+ */
+std::ostream& operator <<(std::ostream& stream, const Graph& graph);
 
 }  // namespace fuse_core
 

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -44,6 +44,12 @@
 namespace fuse_core
 {
 
+std::ostream& operator <<(std::ostream& stream, const Graph& graph)
+{
+  graph.print(stream);
+  return stream;
+}
+
 Graph::const_variable_range Graph::getConnectedVariables(const UUID& constraint_uuid) const
 {
   std::function<const fuse_core::Variable&(const UUID& variable_uuid)> uuid_to_variable_ref =

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -301,6 +301,13 @@ public:
    */
   ceres::Solver::Summary optimize(const ceres::Solver::Options& options = ceres::Solver::Options()) override;
 
+  /**
+   * @brief Print a human-readable description of the graph to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  void print(std::ostream& stream = std::cout) const override;
+
 protected:
   // Define some helpful typedefs
   using Constraints = std::unordered_map<fuse_core::UUID, fuse_core::Constraint::SharedPtr, fuse_core::uuid::hash>;

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -409,6 +409,22 @@ ceres::Solver::Summary HashGraph::optimize(const ceres::Solver::Options& options
   return summary;
 }
 
+void HashGraph::print(std::ostream& stream) const
+{
+  stream << "HashGraph\n"
+         << "  constraints:\n";
+  for (const auto& constraint : constraints_)
+  {
+    stream << "   - " << *constraint.second << "\n";
+  }
+  stream << "  variables:\n";
+  for (const auto& variable : variables_)
+  {
+    const auto is_on_hold = variables_on_hold_.find(variable.first) != variables_on_hold_.end();
+    stream << "   - " << (is_on_hold ? "[H] " : "") << *variable.second << "\n";
+  }
+}
+
 void HashGraph::createProblem(ceres::Problem& problem) const
 {
   // Add all the variables to the problem

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -421,7 +421,9 @@ void HashGraph::print(std::ostream& stream) const
   for (const auto& variable : variables_)
   {
     const auto is_on_hold = variables_on_hold_.find(variable.first) != variables_on_hold_.end();
-    stream << "   - " << (is_on_hold ? "[H] " : "") << *variable.second << "\n";
+
+    stream << "   - " << *variable.second << "\n"
+           << "     on_hold: " << std::boolalpha << is_on_hold << "\n";
   }
 }
 


### PR DESCRIPTION
This allows to print the `HashGraph`, which is useful for debugging purposes.