### PR TITLE
Depend on libceres-dev instead of ceres-solver

### DIFF
--- a/fuse_constraints/package.xml
+++ b/fuse_constraints/package.xml
@@ -12,7 +12,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>eigen</depend>
   <depend>fuse_core</depend>
   <depend>fuse_graphs</depend>

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -12,7 +12,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>eigen</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>

--- a/fuse_graphs/package.xml
+++ b/fuse_graphs/package.xml
@@ -11,7 +11,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>

--- a/fuse_variables/package.xml
+++ b/fuse_variables/package.xml
@@ -13,7 +13,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>


### PR DESCRIPTION
There's no `ceres-solver` rosdep entry in the official rosdistro files.
Indeed there's one entry for Ceres solver, but it's called `libceres-dev`:

https://github.com/ros/rosdistro/blob/9cd7f875f62ee774789893da025f0322783c0fc6/rosdep/base.yaml#L1633