### PR TITLE
Default private ~reset service name

### DIFF
--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -48,7 +48,7 @@ public:
   /**
    * @brief The topic name of the advertised reset service
    */
-  std::string reset_service { "reset" };
+  std::string reset_service { "~reset" };
 
   /**
    * @brief The maximum time to wait for motion models to be generated for a received transaction.


### PR DESCRIPTION
This makes the service name be `/<NODE_NAME>/reset` by default, instead of just `/reset`.
If a namespace is use it'll prefix any of the cases above, so with `~reset` we'll get `/<NAMESPACE>/<NODE_NAME>/reset`.