### PR TITLE
[RST-2202] Wait for a valid timestamp

### DIFF
--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -61,6 +61,9 @@ Optimizer::Optimizer(
     publisher_loader_("fuse_core", "fuse_core::Publisher"),
     sensor_model_loader_("fuse_core", "fuse_core::SensorModel")
 {
+  // Wait for a valid time before loading any of the plugins
+  ros::Time::waitForValid();
+
   // Load all configured plugins
   loadMotionModels();
   loadSensorModels();


### PR DESCRIPTION
Wait for a valid timestamp before loading the plugins. This prevents the ignition sensor from generating an initial state with the wrong stamp.

Previously the ignition sensor was generating a constraint at time 0, before the clock had been initialized. Once the clock was initialized, the motion model would then generate a constraint from 0 to the current time (~4000s in my test). This results in a large uncertainty for the current state, leading to an ill-conditioned jacobian matrix, leading to numerical errors when computing covariances (and probably other things). I note that had this been real data, the delta between 0 and a real stamp would have been much much much worse.