### PR TITLE
[RST-2148] reset all the things

### DIFF
--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -104,7 +104,7 @@ public:
    * @param[in,out] transaction The transaction object that should be augmented with motion model constraints
    * @return                    True if the motion models were generated successfully, false otherwise
    */
-  bool apply(Transaction& transaction) final;
+  bool apply(Transaction& transaction) override;
 
   /**
    * @brief Function to be executed whenever the optimizer has completed a Graph update
@@ -118,7 +118,7 @@ public:
    *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  void graphCallback(Graph::ConstSharedPtr graph) final;
+  void graphCallback(Graph::ConstSharedPtr graph) override;
 
   /**
    * @brief Perform any required post-construction initialization, such as subscribing to topics or reading from the
@@ -130,12 +130,12 @@ public:
    *
    * @param[in] name A unique name to give this plugin instance
    */
-  void initialize(const std::string& name) final;
+  void initialize(const std::string& name) override;
 
   /**
    * @brief Get the unique name of this motion model
    */
-  const std::string& name() const final { return name_; }
+  const std::string& name() const override { return name_; }
 
   /**
    * @brief Function to be executed whenever the optimizer is ready to receive transactions
@@ -151,7 +151,7 @@ public:
    * motion model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void start() final;
+  void start() override;
 
   /**
    * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
@@ -167,7 +167,7 @@ public:
    * motion model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void stop() final;
+  void stop() override;
 
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -79,12 +79,12 @@ public:
    *
    * @param[in] name A unique name to give this plugin instance
    */
-  void initialize(const std::string& name) final;
+  void initialize(const std::string& name) override;
 
   /**
    * @brief Get the unique name of this publisher
    */
-  const std::string& name() const final { return name_; }
+  const std::string& name() const override { return name_; }
 
   /**
    * @brief Notify the publisher that an optimization cycle is complete, and about changes to the Graph.
@@ -98,7 +98,7 @@ public:
    * @param[in] transaction A Transaction object, describing the set of variables that have been added and/or removed
    * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
    */
-  void notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph) final;
+  void notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph) override;
 
   /**
    * @brief Function to be executed whenever the optimizer is ready to receive transactions
@@ -114,7 +114,7 @@ public:
    * publisher uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void start() final;
+  void start() override;
 
   /**
    * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
@@ -130,7 +130,7 @@ public:
    * publisher uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void stop() final;
+  void stop() override;
 
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -100,6 +100,38 @@ public:
    */
   void notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph) final;
 
+  /**
+   * @brief Function to be executed whenever the optimizer is ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, once the optimizer has been initialized
+   * and is ready to receive transactions. It may also be called as part of a stop-start cycle when the optimizer
+   * has been requested to reset itself. This allows the publisher to reset any internal state before the
+   * optimizer begins processing after a reset. No calls to notify() will happen before the optimizer calls start().
+   *
+   * This implementation inserts a call to onStart() into this publisher's callback queue. This method then blocks
+   * until the call to onStart() has completed. This is meant to simplify thread synchronization. If this publisher
+   * uses a single-threaded spinner, then all callbacks will fire sequentially and no semaphores are needed. If this
+   * publisher uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
+   * one place should be guarded.
+   */
+  void start() final;
+
+  /**
+   * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, before the optimizer shutdowns. It may
+   * also be called as part of a stop-start cycle when the optimizer has been requested to reset itself. This allows
+   * the publisher to reset any internal state before the optimizer begins processing after a reset. No calls
+   * to notify() will happen until start() has been called again.
+   *
+   * This implementation inserts a call to onStop() into this publisher's callback queue. This method then blocks
+   * until the call to onStop() has completed. This is meant to simplify thread synchronization. If this publisher
+   * uses a single-threaded spinner, then all callbacks will fire sequentially and no semaphores are needed. If this
+   * publisher uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
+   * one place should be guarded.
+   */
+  void stop() final;
+
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this publisher instance
@@ -139,6 +171,22 @@ protected:
    * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
    */
   virtual void notifyCallback(Transaction::ConstSharedPtr /*transaction*/, Graph::ConstSharedPtr /*graph*/) {}
+
+  /**
+   * @brief Perform any required operations to prepare for servicing calls to notify()
+   *
+   * This function will be called once after initialize() but before any calls to notify(). It may also be called
+   * at any time after a call to stop().
+   */
+  virtual void onStart() {}
+
+  /**
+   * @brief Perform any required operations to clean up the internal state
+   *
+   * This function will be called once before destruction. It may also be called at any time after a call to start().
+   * No calls to notify() will occur after stop() is called, but before start() is called.
+   */
+  virtual void onStop() {}
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -142,6 +142,37 @@ public:
    */
   const std::string& name() const final { return name_; }
 
+  /**
+   * @brief Function to be executed whenever the optimizer is ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, once the optimizer has been initialized
+   * and is ready to receive transactions. It may also be called as part of a stop-start cycle when the optimizer
+   * has been requested to reset itself. This allows the sensor model to reset any internal state before the
+   * optimizer begins processing after a reset.
+   *
+   * This implementation inserts a call to onStart() into this sensor model's callback queue. This method then blocks
+   * until the call to onStart() has completed. This is meant to simplify thread synchronization. If this sensor model
+   * uses a single-threaded spinner, then all callbacks will fire sequentially and no semaphores are needed. If this
+   * sensor model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
+   * one place should be guarded.
+   */
+  void start() final;
+
+  /**
+   * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, before the optimizer shutdowns. It may
+   * also be called as part of a stop-start cycle when the optimizer has been requested to reset itself. This allows
+   * the sensor model to reset any internal state before the optimizer begins processing after a reset.
+   *
+   * This implementation inserts a call to onStop() into this sensor model's callback queue. This method then blocks
+   * until the call to onStop() has completed. This is meant to simplify thread synchronization. If this sensor model
+   * uses a single-threaded spinner, then all callbacks will fire sequentially and no semaphores are needed. If this
+   * sensor model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
+   * one place should be guarded.
+   */
+  void stop() final;
+
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this sensor model instance
@@ -186,6 +217,24 @@ protected:
    * sensor model would actually do anything.
    */
   virtual void onInit() {}
+
+  /**
+   * @brief Perform any required operations to prepare for sending transactions to the optimizer
+   *
+   * This function will be called once after initialize(). It may also be called at any time after a call to stop().
+   *
+   * The sensor model must not send any transactions to the optimizer before onStart() is called.
+   */
+  virtual void onStart() {}
+
+  /**
+   * @brief Perform any required operations to stop sending transactions to the optimizer
+   *
+   * This function will be called once before destruction. It may also be called at any time after a call to start().
+   *
+   * The sensor model must not send any transactions to the optimizer after stop() is called.
+   */
+  virtual void onStop() {}
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -105,7 +105,7 @@ public:
    *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  void graphCallback(Graph::ConstSharedPtr graph) final;
+  void graphCallback(Graph::ConstSharedPtr graph) override;
 
   /**
    * @brief Perform any required post-construction initialization, such as subscribing to topics or reading from the
@@ -120,7 +120,7 @@ public:
    */
   void initialize(
     const std::string& name,
-    TransactionCallback transaction_callback) final;
+    TransactionCallback transaction_callback) override;
 
   /**
    * @brief Send a transaction to the Optimizer
@@ -140,7 +140,7 @@ public:
   /**
    * @brief Get the unique name of this sensor
    */
-  const std::string& name() const final { return name_; }
+  const std::string& name() const override { return name_; }
 
   /**
    * @brief Function to be executed whenever the optimizer is ready to receive transactions
@@ -156,7 +156,7 @@ public:
    * sensor model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void start() final;
+  void start() override;
 
   /**
    * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
@@ -171,7 +171,7 @@ public:
    * sensor model uses a multithreaded spinner, then normal multithreading rules apply and data accessed in more than
    * one place should be guarded.
    */
-  void stop() final;
+  void stop() override;
 
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions

--- a/fuse_core/include/fuse_core/publisher.h
+++ b/fuse_core/include/fuse_core/publisher.h
@@ -72,11 +72,6 @@ public:
   virtual ~Publisher() = default;
 
   /**
-   * @brief Get the unique name of this publisher
-   */
-  virtual const std::string& name() const = 0;
-
-  /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the
    * parameter server.
    *
@@ -87,6 +82,11 @@ public:
    * @param[in] name A unique name to give this plugin instance
    */
   virtual void initialize(const std::string& name) = 0;
+
+  /**
+   * @brief Get the unique name of this publisher
+   */
+  virtual const std::string& name() const = 0;
 
   /**
    * @brief Notify the publisher that an optimization cycle is complete, and about changes to the Graph.
@@ -101,6 +101,26 @@ public:
    * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
    */
   virtual void notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph) = 0;
+
+  /**
+   * @brief Function to be executed whenever the optimizer is ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, once the optimizer has been initialized
+   * and is ready to receive transactions. It may also be called as part of a stop-start cycle when the optimizer
+   * has been requested to reset itself. This allows the publisher to reset any internal state before the
+   * optimizer begins processing after a reset. No calls to notify() will happen before the optimizer calls start().
+   */
+  virtual void start() {}
+
+  /**
+   * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, before the optimizer shutdowns. It may
+   * also be called as part of a stop-start cycle when the optimizer has been requested to reset itself. This allows
+   * the publisher to reset any internal state before the optimizer begins processing after a reset. No calls
+   * to notify() will happen until start() has been called again.
+   */
+  virtual void stop() {}
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -109,6 +109,29 @@ public:
    */
   virtual const std::string& name() const = 0;
 
+  /**
+   * @brief Function to be executed whenever the optimizer is ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, once the optimizer has been initialized
+   * and is ready to receive transactions. It may also be called as part of a stop-start cycle when the optimizer
+   * has been requested to reset itself. This allows the sensor model to reset any internal state before the
+   * optimizer begins processing after a reset.
+   *
+   * The sensor model must not send any transactions to the optimizer before start() is called.
+   */
+  virtual void start() {}
+
+  /**
+   * @brief Function to be executed whenever the optimizer is no longer ready to receive transactions
+   *
+   * This method will be called by the optimizer, in the optimizer's thread, before the optimizer shutdowns. It may
+   * also be called as part of a stop-start cycle when the optimizer has been requested to reset itself. This allows
+   * the sensor model to reset any internal state before the optimizer begins processing after a reset.
+   *
+   * The sensor model must not send any transactions to the optimizer after stop() is called.
+   */
+  virtual void stop() {}
+
 protected:
   /**
    * @brief Default Constructor

--- a/fuse_core/include/fuse_core/timestamp_manager.h
+++ b/fuse_core/include/fuse_core/timestamp_manager.h
@@ -164,6 +164,14 @@ public:
   }
 
   /**
+   * @brief Clear all timestamps from the motion model history
+   */
+  void clear()
+  {
+    motion_model_history_.clear();
+  }
+
+  /**
    * @brief Update a transaction structure such that the involved timestamps are connected by motion model constraints.
    *
    * This is not as straightforward as it would seem. Depending on the history of previously generated constraints,

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -64,15 +64,16 @@ bool AsyncMotionModel::apply(Transaction& transaction)
   auto callback = boost::make_shared<CallbackWrapper<bool>>(
     std::bind(&AsyncMotionModel::applyCallback, this, std::ref(transaction)));
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback);
+  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
   result.wait();
   return result.get();
 }
 
 void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
 {
-  callback_queue_.addCallback(boost::make_shared<CallbackWrapper<void>>(
-    std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))));
+  callback_queue_.addCallback(
+    boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))),
+    reinterpret_cast<uint64_t>(this));
 }
 
 void AsyncMotionModel::initialize(const std::string& name)
@@ -88,6 +89,22 @@ void AsyncMotionModel::initialize(const std::string& name)
 
   // Start the async spinner to service the local callback queue
   spinner_.start();
+}
+
+void AsyncMotionModel::start()
+{
+  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStart, this));
+  auto result = callback->getFuture();
+  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  result.wait();
+}
+
+void AsyncMotionModel::stop()
+{
+  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStop, this));
+  auto result = callback->getFuture();
+  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  result.wait();
 }
 
 }  // namespace fuse_core

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -82,4 +82,20 @@ void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
   transaction_callback_(std::move(transaction));
 }
 
+void AsyncSensorModel::start()
+{
+  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStart, this));
+  auto result = callback->getFuture();
+  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  result.wait();
+}
+
+void AsyncSensorModel::stop()
+{
+  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStop, this));
+  auto result = callback->getFuture();
+  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  result.wait();
+}
+
 }  // namespace fuse_core

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -55,8 +55,9 @@ AsyncSensorModel::AsyncSensorModel(size_t thread_count) :
 
 void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)
 {
-  callback_queue_.addCallback(boost::make_shared<CallbackWrapper<void>>(
-    std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))));
+  callback_queue_.addCallback(
+    boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))),
+    reinterpret_cast<uint64_t>(this));
 }
 
 void AsyncSensorModel::initialize(

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -208,6 +208,11 @@ protected:
   void injectCallback(
     const std::string& sensor_name,
     fuse_core::Transaction::SharedPtr transaction);
+
+  /**
+   * @brief Clear all of the callbacks inserted into the callback queue by the injectCallback() method
+   */
+  void clearCallbacks();
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -109,7 +109,7 @@ public:
   /**
    * @brief Destructor
    */
-  virtual ~Optimizer() = default;
+  virtual ~Optimizer();
 
 protected:
   // The unique ptrs returned by pluginlib have a custom deleter. This makes specifying the type rather annoying
@@ -213,6 +213,16 @@ protected:
    * @brief Clear all of the callbacks inserted into the callback queue by the injectCallback() method
    */
   void clearCallbacks();
+
+  /**
+   * @brief Start all configured plugins (motion models, publishers, and sensor models)
+   */
+  void startPlugins();
+
+  /**
+   * @brief Stop all configured plugins (motion models, publishers, and sensor models)
+   */
+  void stopPlugins();
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -294,8 +294,15 @@ void Optimizer::injectCallback(
   // We are going to insert a call to the derived class's transactionCallback() method into the global callback queue.
   // This returns execution to the sensor's thread quickly by moving the transaction processing to the optimizer's
   // thread. And by using the existing ROS callback queue, we simplify the threading model of the optimizer.
-  ros::getGlobalCallbackQueue()->addCallback(boost::make_shared<fuse_core::CallbackWrapper<void>>(
-    std::bind(&Optimizer::transactionCallback, this, sensor_name, std::move(transaction))));
+  ros::getGlobalCallbackQueue()->addCallback(
+    boost::make_shared<fuse_core::CallbackWrapper<void>>(
+      std::bind(&Optimizer::transactionCallback, this, sensor_name, std::move(transaction))),
+    reinterpret_cast<uint64_t>(this));
+}
+
+void Optimizer::clearCallbacks()
+{
+  ros::getGlobalCallbackQueue()->removeByID(reinterpret_cast<uint64_t>(this));
 }
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -68,6 +68,15 @@ Optimizer::Optimizer(
   loadMotionModels();
   loadSensorModels();
   loadPublishers();
+
+  // Start all the plugins
+  startPlugins();
+}
+
+Optimizer::~Optimizer()
+{
+  // Stop all the plugins
+  stopPlugins();
 }
 
 void Optimizer::loadMotionModels()
@@ -303,6 +312,39 @@ void Optimizer::injectCallback(
 void Optimizer::clearCallbacks()
 {
   ros::getGlobalCallbackQueue()->removeByID(reinterpret_cast<uint64_t>(this));
+}
+
+void Optimizer::startPlugins()
+{
+  for (const auto& name_plugin : motion_models_)
+  {
+    name_plugin.second->start();
+  }
+  for (const auto& name_plugin : sensor_models_)
+  {
+    name_plugin.second->start();
+  }
+  for (const auto& name_plugin : publishers_)
+  {
+    name_plugin.second->start();
+  }
+}
+
+void Optimizer::stopPlugins()
+{
+  // Tell all the plugins to stop
+  for (const auto& name_plugin : publishers_)
+  {
+    name_plugin.second->stop();
+  }
+  for (const auto& name_plugin : sensor_models_)
+  {
+    name_plugin.second->stop();
+  }
+  for (const auto& name_plugin : motion_models_)
+  {
+    name_plugin.second->stop();
+  }
 }
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -332,7 +332,6 @@ void Optimizer::startPlugins()
 
 void Optimizer::stopPlugins()
 {
-  // Tell all the plugins to stop
   for (const auto& name_plugin : publishers_)
   {
     name_plugin.second->stop();

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -116,6 +116,16 @@ public:
   void onInit() override;
 
   /**
+   * @brief Perform any required operations before the first call to notify() occurs
+   */
+  void onStart() override;
+
+  /**
+   * @brief Perform any required operations to stop publications
+   */
+  void onStop() override;
+
+  /**
    * @brief Notify the publisher about variables that have been added or removed
    *
    * This publisher publishes only the most recent pose. By analyzing the added and removed variables, the most

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -172,6 +172,7 @@ TEST_F(Path2DPublisherTestFixture, PublishPath)
   private_node_handle_.setParam("test_publisher/frame_id", "test_map");
   fuse_publishers::Path2DPublisher publisher;
   publisher.initialize("test_publisher");
+  publisher.start();
 
   // Subscribe to the "path" topic
   ros::Subscriber subscriber1 = private_node_handle_.subscribe(

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -200,6 +200,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPose)
   private_node_handle_.setParam("test_publisher/publish_to_tf", false);
   fuse_publishers::Pose2DPublisher publisher;
   publisher.initialize("test_publisher");
+  publisher.start();
 
   // Subscribe to the "pose" topic
   ros::Subscriber subscriber = private_node_handle_.subscribe(
@@ -238,6 +239,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPoseWithCovariance)
   private_node_handle_.setParam("test_publisher/publish_to_tf", false);
   fuse_publishers::Pose2DPublisher publisher;
   publisher.initialize("test_publisher");
+  publisher.start();
 
   // Subscribe to the "pose_with_covariance" topic
   ros::Subscriber subscriber = private_node_handle_.subscribe(
@@ -289,6 +291,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithoutOdom)
   private_node_handle_.setParam("test_publisher/publish_to_tf", true);
   fuse_publishers::Pose2DPublisher publisher;
   publisher.initialize("test_publisher");
+  publisher.start();
 
   // Subscribe to the "pose" topic
   ros::Subscriber subscriber = private_node_handle_.subscribe(
@@ -328,6 +331,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithOdom)
   private_node_handle_.setParam("test_publisher/publish_to_tf", true);
   fuse_publishers::Pose2DPublisher publisher;
   publisher.initialize("test_publisher");
+  publisher.start();
 
   // Subscribe to the "pose" topic
   ros::Subscriber subscriber = private_node_handle_.subscribe(


### PR DESCRIPTION
The fixed-lag smoother has a reset() service call. There is a desire to propagate the reset signal to all of the fuse plugins (motion models, sensor models, and publishers). This is being done by adding `start()` and `stop()` methods to the API of all the fuse plugins. Separate `start()` and `stop()` are used, instead of a single `reset()` method to make threading issues easier. All of the plugins are stopped, the internal optimizer state is modified, then all of the plugins are started. This ensures we never get a mix of pre-reset and post-reset information at the same time.

This PR:
* Adds `start()` and `stop()` methods to the MotionModel, SensorModel, and Publisher base classes. A default empty implementation is provided for cases when nothing special needs to be done.
* Adds `onStart()` and `onStop()` methods to the AsyncMotionModel, AsyncSensorModel, and AsyncPublisher. These methods are called from the plugin's spinner thread instead of in the optimizer's thread. The Async classes provide an implementation of `start()` and `stop()` that insert calls to `onStart()` and `onStop()`, respectively, into the spinner's callback queue. They then block until those callbacks have been executed.
* Updates the Optimizer base class to call `start()` on all plugins after initialization, and to call `stop()` on all plugins before destruction.
* Updates the FixedLagSmoother reset service callback to use the `start()` and `stop()` methods.
* Fixes a race condition in the FixedLagSmoother reset service callback. Previously the pending queue was locked, work moved to a local variable, then unlocked. And then the graph was locked, the local work was applied to the graph, and the graph was unlocked. However, it is possible (though unlikely) for the work to be moved to the local variable, then have the reset callback execute between the time the pending queue is unlocked and the graph is locked. This would result in the local work variable being applied to the newly reset graph, which is wrong. All of that work was from a time that pre-dates the reset. I believe I have solved this issue by changing the locking strategy a bit.
* Adds an ID number when inserting function calls into the ROS callback queues. This allows the function calls to be removed later, if needed.

Misc changes:
* Alphabetizes some function names in the header, if I happened to be thinking about it at the time.
* Adds a clear() method to the  TimestampManager
* Changes the AsyncXXX function implementations from `final` to merely `override`. No real reason to prevent people from tweaking things when needed.

This PR description is now almost as long as the actual changes included in the PR. :)