### PR TITLE
Comment unused parameters

### DIFF
--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -138,7 +138,7 @@ protected:
    * @param[in] transaction A Transaction object, describing the set of variables that have been added and/or removed
    * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
    */
-  virtual void notifyCallback(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph) {}
+  virtual void notifyCallback(Transaction::ConstSharedPtr /*transaction*/, Graph::ConstSharedPtr /*graph*/) {}
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -173,7 +173,7 @@ protected:
    * 
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  virtual void onGraphUpdate(Graph::ConstSharedPtr graph) {}
+  virtual void onGraphUpdate(Graph::ConstSharedPtr /*graph*/) {}
 
   /**
    * @brief Perform any required initialization for the sensor model

--- a/fuse_core/include/fuse_core/motion_model.h
+++ b/fuse_core/include/fuse_core/motion_model.h
@@ -89,7 +89,7 @@ public:
    *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  virtual void graphCallback(Graph::ConstSharedPtr graph) {}
+  virtual void graphCallback(Graph::ConstSharedPtr /*graph*/) {}
 
   /**
    * @brief Augment a transaction object such that all involved timestamps are connected by motion model constraints.

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -87,7 +87,7 @@ public:
    *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  virtual void graphCallback(Graph::ConstSharedPtr graph) {}
+  virtual void graphCallback(Graph::ConstSharedPtr /*graph*/) {}
 
    /**
    * @brief Perform any required post-construction initialization, such as subscribing to topics or reading from the


### PR DESCRIPTION
Otherwise the compilation fails with: `-Werror=unused-parameter`
This happens with these flags: `-Wall -Wextra`