### PR TITLE
Fix -Wall -Wextra warnings

### DIFF
--- a/fuse_constraints/include/fuse_constraints/uuid_ordering.h
+++ b/fuse_constraints/include/fuse_constraints/uuid_ordering.h
@@ -133,7 +133,7 @@ public:
    *
    * Accessing a UUID that does not exist results in the provided UUID being added to the ordering
    */
-  const unsigned int operator[](const fuse_core::UUID& uuid);
+  unsigned int operator[](const fuse_core::UUID& uuid);
 
   /**
    * @brief Access the UUID stored at the provided index
@@ -147,7 +147,7 @@ public:
    *
    * If the requested UUID does not exist, an out_of_range exception will be thrown.
    */
-  const unsigned int at(const fuse_core::UUID& uuid) const;
+  unsigned int at(const fuse_core::UUID& uuid) const;
 
 private:
   using UuidOrderMapping = boost::bimaps::bimap<boost::bimaps::vector_of<unsigned int>,

--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -74,7 +74,7 @@ public:
    *
    * This is one larger than the current maximum variable index
    */
-  const unsigned int nextVariableIndex() const;
+  unsigned int nextVariableIndex() const;
 
   /**
    * @brief Add this constraint to a single variable

--- a/fuse_constraints/src/uuid_ordering.cpp
+++ b/fuse_constraints/src/uuid_ordering.cpp
@@ -74,7 +74,7 @@ const fuse_core::UUID& UuidOrdering::operator[](const unsigned int index) const
   return order_.left[index].second;
 }
 
-const unsigned int UuidOrdering::operator[](const fuse_core::UUID& uuid)
+unsigned int UuidOrdering::operator[](const fuse_core::UUID& uuid)
 {
   auto result = order_.insert(order_.end(), UuidOrderMapping::value_type(order_.size(), uuid));
   return (*result.first).get_left();
@@ -85,7 +85,7 @@ const fuse_core::UUID& UuidOrdering::at(const unsigned int index) const
   return order_.left.at(index).second;
 }
 
-const unsigned int UuidOrdering::at(const fuse_core::UUID& uuid) const
+unsigned int UuidOrdering::at(const fuse_core::UUID& uuid) const
 {
   return order_.right.at(uuid);
 }

--- a/fuse_constraints/src/variable_constraints.cpp
+++ b/fuse_constraints/src/variable_constraints.cpp
@@ -59,7 +59,7 @@ size_t VariableConstraints::size() const
   return std::accumulate(variable_constraints_.begin(), variable_constraints_.end(), 0u, sum_edges);
 }
 
-const unsigned int VariableConstraints::nextVariableIndex() const
+unsigned int VariableConstraints::nextVariableIndex() const
 {
   return variable_constraints_.size();
 }

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -182,7 +182,7 @@ protected:
    * 
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
-  virtual void onGraphUpdate(Graph::ConstSharedPtr graph) {}
+  virtual void onGraphUpdate(Graph::ConstSharedPtr /*graph*/) {}
 
   /**
    * @brief Perform any required initialization for the motion model

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -197,7 +197,7 @@ void BatchOptimizer::optimizationLoop()
   }
 }
 
-void BatchOptimizer::optimizerTimerCallback(const ros::TimerEvent& event)
+void BatchOptimizer::optimizerTimerCallback(const ros::TimerEvent& /*event*/)
 {
   // If an "ignition" transaction hasn't been received, then we can't do anything yet.
   if (!started_)

--- a/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
+++ b/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
@@ -194,7 +194,7 @@ constexpr bool allStampedVariables = all_stamped_variables<Ts...>::value;
 template <typename...>
 struct all_variables_exist
 {
-  static bool value(const fuse_core::Graph& graph, const ros::Time& stamp, const fuse_core::UUID& device_id)
+  static bool value(const fuse_core::Graph& /*graph*/, const ros::Time& /*stamp*/, const fuse_core::UUID& /*device_id*/)
   {
     return true;
   }
@@ -234,7 +234,7 @@ struct all_variables_exist<T, Ts...>
 template <typename...>
 struct is_variable_in_pack
 {
-  static bool value(const fuse_core::Variable& variable)
+  static bool value(const fuse_core::Variable& /*variable*/)
   {
     return false;
   }

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -85,7 +85,7 @@ void Path2DPublisher::onInit()
 }
 
 void Path2DPublisher::notifyCallback(
-  fuse_core::Transaction::ConstSharedPtr transaction,
+  fuse_core::Transaction::ConstSharedPtr /*transaction*/,
   fuse_core::Graph::ConstSharedPtr graph)
 {
   // Exit early if no one is listening

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -77,7 +77,7 @@ public:
   }
 
   bool ComputeJacobian(
-    const double* x,
+    const double* /*x*/,
     double* jacobian) const override
   {
     jacobian[0] = 1.0;
@@ -95,7 +95,7 @@ public:
   }
 
   bool ComputeMinusJacobian(
-    const double* x,
+    const double* /*x*/,
     double* jacobian) const override
   {
     jacobian[0] = 1.0;


### PR DESCRIPTION
Continuation of https://github.com/locusrobotics/fuse/pull/76 because I forgot to `catkin clean -y` and not everything was compiled with those flags. This time I cleaned everything and re-built.

I only had to fixed two types of warnings/errors:
* `unused-parameter`, as in https://github.com/locusrobotics/fuse/pull/76 . I commented the parameters, but if you want I can remove them for all instances, or for specific ones.
* `ignored-qualifiers`, for functions/methods returning by value that had `const`. I removed the `const` for all of them because they were returning POD types. If the intend was to return a const reference instead, please let me know.