### PR TITLE
Expose Ceres Solver, Problem and Covariance Options as ROS parameters

### DIFF
--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -1,8 +1,36 @@
-/***************************************************************************
- * Copyright (C) 2019 Clearpath Robotics. All rights reserved.
- * Unauthorized copying of this file, via any medium, is strictly prohibited
- * Proprietary and confidential
- ***************************************************************************/
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019 Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef FUSE_CORE_CERES_OPTIONS_H
 #define FUSE_CORE_CERES_OPTIONS_H
 

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -1,0 +1,188 @@
+/***************************************************************************
+ * Copyright (C) 2019 Clearpath Robotics. All rights reserved.
+ * Unauthorized copying of this file, via any medium, is strictly prohibited
+ * Proprietary and confidential
+ ***************************************************************************/
+#ifndef FUSE_CORE_CERES_OPTIONS_H
+#define FUSE_CORE_CERES_OPTIONS_H
+
+#include <ros/console.h>
+#include <ros/node_handle.h>
+
+#include <ceres/types.h>
+
+#include <string>
+
+/**
+ * Defines ToString overloaded function to Ceres Options.
+ *
+ * For a given Ceres Solver Option <T>, the function ToString calls ceres::<T>ToString
+ */
+#define CERES_OPTION_TO_STRING_DEFINITION(Option) \
+  static inline const char* ToString(ceres::Option value) \
+  { \
+    return ceres::Option##ToString(value); \
+  }
+
+/**
+ * Defines FromString overloaded function to Ceres Options.
+ *
+ * For a given Ceres Solver Option <T>, the function FromString calls ceres::StringTo<T>
+ */
+#define CERES_OPTION_FROM_STRING_DEFINITION(Option) \
+  static inline bool FromString(std::string string_value, ceres::Option* value) \
+  { \
+    return ceres::StringTo##Option(string_value, value); \
+  }
+
+/**
+ * Defines ToString and FromString overloaded functions for Ceres Options.
+ *
+ * See CERES_OPTION_TO_STRING_DEFINITION and CERES_OPTION_FROM_STRING_DEFINITION.
+ */
+#define CERES_OPTION_STRING_DEFINITIONS(Option) \
+  CERES_OPTION_TO_STRING_DEFINITION(Option) \
+  CERES_OPTION_FROM_STRING_DEFINITION(Option)
+
+/**
+ * Check for at least Ceres Solver version x.y.z, where: x = major, y = minor and z = revision.
+ */
+#define CERES_VERSION_AT_LEAST(x, y, z) (CERES_VERSION_MAJOR > x || (CERES_VERSION_MAJOR    >= x && \
+                                        (CERES_VERSION_MINOR > y || (CERES_VERSION_MINOR    >= y && \
+                                                                     CERES_VERSION_REVISION >= z))))
+
+#if !CERES_VERSION_AT_LEAST(2, 0, 0)
+/**
+ * Patch Ceres versions before 2.0.0 that miss the LoggingType and DumpFormatType ToString and StringTo functions.
+ */
+#include <algorithm>
+
+namespace ceres
+{
+
+#define CASESTR(x) case x: return #x
+#define STRENUM(x) if (value == #x) { *type = x; return true;}
+
+static void UpperCase(std::string* input)
+{
+  // The NOLINT below it's because std::transform requires <algorithm>, which is included inside the #if above, but
+  // roslint still complains
+  std::transform(input->begin(), input->end(), input->begin(), ::toupper);  // NOLINT(build/include_what_you_use)
+}
+
+const char* LoggingTypeToString(LoggingType type)
+{
+  switch (type)
+  {
+    CASESTR(SILENT);
+    CASESTR(PER_MINIMIZER_ITERATION);
+    default:
+      return "UNKNOWN";
+  }
+}
+
+bool StringToLoggingType(std::string value, LoggingType* type)
+{
+  UpperCase(&value);
+  STRENUM(SILENT);
+  STRENUM(PER_MINIMIZER_ITERATION);
+  return false;
+}
+
+const char* DumpFormatTypeToString(DumpFormatType type)
+{
+  switch (type)
+  {
+    CASESTR(CONSOLE);
+    CASESTR(TEXTFILE);
+    default:
+      return "UNKNOWN";
+  }
+}
+
+bool StringToDumpFormatType(std::string value, DumpFormatType* type)
+{
+  UpperCase(&value);
+  STRENUM(CONSOLE);
+  STRENUM(TEXTFILE);
+  return false;
+}
+
+#undef CASESTR
+#undef STRENUM
+
+}  // namespace ceres
+#else
+/**
+ * Patch Ceres version 2.0.0 that uses lower case for the LoggingType and DumpFormatType StringTo function.
+ * See https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/types.h
+ */
+namespace ceres
+{
+
+bool StringToLoggingType(std::string value, LoggingType* type)
+{
+  return StringtoLoggingType(value, type);
+}
+
+bool StringToDumpFormatType(std::string value, DumpFormatType* type)
+{
+  return StringtoDumpFormatType(value, type);
+}
+
+}  // namespace ceres
+#endif
+
+namespace fuse_core
+{
+
+/**
+ * String definitions for all Ceres options.
+ */
+CERES_OPTION_STRING_DEFINITIONS(CovarianceAlgorithmType)
+CERES_OPTION_STRING_DEFINITIONS(DenseLinearAlgebraLibraryType)
+CERES_OPTION_STRING_DEFINITIONS(DoglegType)
+CERES_OPTION_STRING_DEFINITIONS(DumpFormatType)
+CERES_OPTION_STRING_DEFINITIONS(LinearSolverType)
+CERES_OPTION_STRING_DEFINITIONS(LineSearchDirectionType)
+CERES_OPTION_STRING_DEFINITIONS(LineSearchInterpolationType)
+CERES_OPTION_STRING_DEFINITIONS(LineSearchType)
+CERES_OPTION_STRING_DEFINITIONS(LoggingType)
+CERES_OPTION_STRING_DEFINITIONS(MinimizerType)
+CERES_OPTION_STRING_DEFINITIONS(NonlinearConjugateGradientType)
+CERES_OPTION_STRING_DEFINITIONS(PreconditionerType)
+CERES_OPTION_STRING_DEFINITIONS(SparseLinearAlgebraLibraryType)
+CERES_OPTION_STRING_DEFINITIONS(TrustRegionStrategyType)
+CERES_OPTION_STRING_DEFINITIONS(VisibilityClusteringType)
+
+/**
+ * @brief Helper function that loads a Ceres Option (e.g. ceres::LinearSolverType) value from the parameter server
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in] default_value - A default value to use if the provided parameter name does not exist
+ * @return The loaded (or default) value
+ */
+template <class T>
+T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, const T& default_value)
+{
+  const std::string default_string_value{ ToString(default_value) };
+
+  std::string string_value;
+  node_handle.param(parameter_name, string_value, default_string_value);
+
+  T value;
+  if (!FromString(string_value, &value))
+  {
+    ROS_WARN_STREAM("The requested " << parameter_name << " (" << string_value
+                                     << ") is not supported. Using the default value (" << default_string_value
+                                     << ") instead.");
+    value = default_value;
+  }
+
+  return value;
+}
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_CERES_OPTIONS_H

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -58,7 +58,7 @@
 #include <memory>
 #include <string>
 
-// Required by make_aligned_shared, that uses Eigen::aligned_allocator<T>().
+// Required by __MAKE_SHARED_ALIGNED_DEFINITION, that uses Eigen::aligned_allocator<T>().
 #include <Eigen/Core>
 
 /**

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -40,9 +40,14 @@
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
-
 #include <fuse_graphs/hash_graph_params.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/unordered_set.hpp>
 #include <ceres/covariance.h>
 #include <ceres/problem.h>
 #include <ceres/solver.h>

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -41,12 +41,8 @@
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#include <boost/serialization/export.hpp>
-#include <boost/serialization/shared_ptr.hpp>
-#include <boost/serialization/unordered_map.hpp>
-#include <boost/serialization/unordered_set.hpp>
+#include <fuse_graphs/hash_graph_params.h>
+
 #include <ceres/covariance.h>
 #include <ceres/problem.h>
 #include <ceres/solver.h>
@@ -79,10 +75,9 @@ public:
   /**
    * @brief Constructor
    *
-   * @param[in] options A configured Ceres Problem::Options object
-   *                    See https://ceres-solver.googlesource.com/ceres-solver/+/master/include/ceres/problem.h#123
+   * @param[in] params HashGraph parameters.
    */
-  explicit HashGraph(const ceres::Problem::Options& options = ceres::Problem::Options());
+  explicit HashGraph(const HashGraphParams& params = HashGraphParams());
 
   /**
    * @brief Copy constructor

--- a/fuse_graphs/include/fuse_graphs/hash_graph_params.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph_params.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ * Copyright (C) 2019 Clearpath Robotics. All rights reserved.
+ * Unauthorized copying of this file, via any medium, is strictly prohibited
+ * Proprietary and confidential
+ ***************************************************************************/
+#ifndef FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
+#define FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
+
+#include <ros/console.h>
+#include <ros/duration.h>
+#include <ros/node_handle.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace fuse_graphs
+{
+
+/**
+ * @brief Defines the set of parameters required by the fuse_graphs::HashGraph class
+ */
+struct HashGraphParams
+{
+public:
+  /**
+   * @brief Ceres Problem::Options object that controls various aspects of the optimization problem.
+   */
+  ceres::Problem::Options problem_options;
+
+  /**
+   * @brief Method for loading parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load parameters
+   */
+  void loadFromROS(const ros::NodeHandle& nh)
+  {
+    loadProblemOptionsFromROS(ros::NodeHandle(nh, "problem_options"));
+  }
+
+private:
+  /**
+   * @brief Method for loading Ceres Problem::Options parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load Ceres Problem::Options parameters
+   */
+  void loadProblemOptionsFromROS(const ros::NodeHandle& nh)
+  {
+    nh.param("enable_fast_removal", problem_options.enable_fast_removal, problem_options.enable_fast_removal);
+    nh.param("disable_all_safety_checks", problem_options.disable_all_safety_checks,
+             problem_options.disable_all_safety_checks);
+  }
+};
+
+}  // namespace fuse_graphs
+
+#endif  // FUSE_GRAPHS_HASH_GRAPH_PARAMS_H

--- a/fuse_graphs/include/fuse_graphs/hash_graph_params.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph_params.h
@@ -1,8 +1,36 @@
-/***************************************************************************
- * Copyright (C) 2019 Clearpath Robotics. All rights reserved.
- * Unauthorized copying of this file, via any medium, is strictly prohibited
- * Proprietary and confidential
- ***************************************************************************/
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019 Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
 #define FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
 

--- a/fuse_graphs/include/fuse_graphs/hash_graph_params.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph_params.h
@@ -10,6 +10,8 @@
 #include <ros/duration.h>
 #include <ros/node_handle.h>
 
+#include <ceres/problem.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -25,6 +27,8 @@ struct HashGraphParams
 public:
   /**
    * @brief Ceres Problem::Options object that controls various aspects of the optimization problem.
+   *
+   * See https://ceres-solver.googlesource.com/ceres-solver/+/master/include/ceres/problem.h#123
    */
   ceres::Problem::Options problem_options;
 

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -50,8 +50,8 @@
 namespace fuse_graphs
 {
 
-HashGraph::HashGraph(const ceres::Problem::Options& options) :
-  problem_options_(options)
+HashGraph::HashGraph(const HashGraphParams& params) :
+  problem_options_(params.problem_options)
 {
 }
 

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -134,7 +134,7 @@ void Odometry2DPublisher::notifyCallback(
       covariance_requests.emplace_back(velocity_angular_uuid, velocity_angular_uuid);
 
       std::vector<std::vector<double>> covariance_matrices;
-      graph->getCovariance(covariance_requests, covariance_matrices);
+      graph->getCovariance(covariance_requests, covariance_matrices, params_.covariance_options);
 
       odom_output_.pose.covariance[0] = covariance_matrices[0][0];
       odom_output_.pose.covariance[1] = covariance_matrices[0][1];

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -10,10 +10,11 @@
 #include <ros/duration.h>
 #include <ros/node_handle.h>
 
+#include <fuse_core/ceres_options.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
-
 
 namespace fuse_optimizers
 {
@@ -57,6 +58,11 @@ public:
    * motion models to be generated. Once the timeout expires, that transaction will be deleted from the queue.
    */
   ros::Duration transaction_timeout { 0.1 };
+
+  /**
+   * @brief Ceres Solver::Options object that controls various aspects of the optimizer.
+   */
+  ceres::Solver::Options solver_options;
 
   /**
    * @brief Helper function that loads strictly positive floating point values from the parameter server
@@ -108,6 +114,144 @@ public:
 
     auto transaction_timeout_sec = getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
     transaction_timeout.fromSec(transaction_timeout_sec);
+
+    loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"));
+  }
+
+private:
+  /**
+   * @brief Method for loading Ceres Solver::Options parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load Ceres Solver::Options parameters
+   */
+  void loadSolverOptionsFromROS(const ros::NodeHandle& nh)
+  {
+    // Minimizer options
+    solver_options.minimizer_type = fuse_core::getParam(nh, "minimizer_type", solver_options.minimizer_type);
+    solver_options.line_search_direction_type =
+        fuse_core::getParam(nh, "line_search_direction_type", solver_options.line_search_direction_type);
+    solver_options.line_search_type = fuse_core::getParam(nh, "line_search_type", solver_options.line_search_type);
+    solver_options.nonlinear_conjugate_gradient_type =
+        fuse_core::getParam(nh, "nonlinear_conjugate_gradient_type", solver_options.nonlinear_conjugate_gradient_type);
+
+    nh.param("max_lbfgs_rank", solver_options.max_lbfgs_rank, solver_options.max_lbfgs_rank);
+    nh.param("use_approximate_eigenvalue_bfgs_scaling", solver_options.use_approximate_eigenvalue_bfgs_scaling,
+             solver_options.use_approximate_eigenvalue_bfgs_scaling);
+
+    solver_options.line_search_interpolation_type =
+        fuse_core::getParam(nh, "line_search_interpolation_type", solver_options.line_search_interpolation_type);
+    nh.param("min_line_search_step_size", solver_options.min_line_search_step_size,
+             solver_options.min_line_search_step_size);
+
+    // Line search parameters
+    nh.param("line_search_sufficient_function_decrease", solver_options.line_search_sufficient_function_decrease,
+             solver_options.line_search_sufficient_function_decrease);
+    nh.param("max_line_search_step_contraction", solver_options.max_line_search_step_contraction,
+             solver_options.max_line_search_step_contraction);
+    nh.param("min_line_search_step_contraction", solver_options.min_line_search_step_contraction,
+             solver_options.min_line_search_step_contraction);
+    nh.param("max_num_line_search_step_size_iterations", solver_options.max_num_line_search_step_size_iterations,
+             solver_options.max_num_line_search_step_size_iterations);
+    nh.param("max_num_line_search_direction_restarts", solver_options.max_num_line_search_direction_restarts,
+             solver_options.max_num_line_search_direction_restarts);
+    nh.param("line_search_sufficient_curvature_decrease", solver_options.line_search_sufficient_curvature_decrease,
+             solver_options.line_search_sufficient_curvature_decrease);
+    nh.param("max_line_search_step_expansion", solver_options.max_line_search_step_expansion,
+             solver_options.max_line_search_step_expansion);
+
+    solver_options.trust_region_strategy_type =
+        fuse_core::getParam(nh, "trust_region_strategy_type", solver_options.trust_region_strategy_type);
+    solver_options.dogleg_type = fuse_core::getParam(nh, "dogleg_type", solver_options.dogleg_type);
+
+    nh.param("use_nonmonotonic_steps", solver_options.use_nonmonotonic_steps, solver_options.use_nonmonotonic_steps);
+    nh.param("max_consecutive_nonmonotonic_steps", solver_options.max_consecutive_nonmonotonic_steps,
+             solver_options.max_consecutive_nonmonotonic_steps);
+
+    nh.param("max_num_iterations", solver_options.max_num_iterations, solver_options.max_num_iterations);
+    nh.param("max_solver_time_in_seconds", solver_options.max_solver_time_in_seconds,
+             solver_options.max_solver_time_in_seconds);
+
+    nh.param("num_threads", solver_options.num_threads, solver_options.num_threads);
+
+    nh.param("initial_trust_region_radius", solver_options.initial_trust_region_radius,
+             solver_options.initial_trust_region_radius);
+    nh.param("max_trust_region_radius", solver_options.max_trust_region_radius, solver_options.max_trust_region_radius);
+    nh.param("min_trust_region_radius", solver_options.min_trust_region_radius, solver_options.min_trust_region_radius);
+
+    nh.param("min_relative_decrease", solver_options.min_relative_decrease, solver_options.min_relative_decrease);
+    nh.param("min_lm_diagonal", solver_options.min_lm_diagonal, solver_options.min_lm_diagonal);
+    nh.param("max_lm_diagonal", solver_options.max_lm_diagonal, solver_options.max_lm_diagonal);
+    nh.param("max_num_consecutive_invalid_steps", solver_options.max_num_consecutive_invalid_steps,
+             solver_options.max_num_consecutive_invalid_steps);
+    nh.param("function_tolerance", solver_options.function_tolerance, solver_options.function_tolerance);
+    nh.param("gradient_tolerance", solver_options.gradient_tolerance, solver_options.gradient_tolerance);
+    nh.param("parameter_tolerance", solver_options.parameter_tolerance, solver_options.parameter_tolerance);
+
+    solver_options.linear_solver_type =
+        fuse_core::getParam(nh, "linear_solver_type", solver_options.linear_solver_type);
+    solver_options.preconditioner_type =
+        fuse_core::getParam(nh, "preconditioner_type", solver_options.preconditioner_type);
+    solver_options.visibility_clustering_type =
+        fuse_core::getParam(nh, "visibility_clustering_type", solver_options.visibility_clustering_type);
+    solver_options.dense_linear_algebra_library_type =
+        fuse_core::getParam(nh, "dense_linear_algebra_library_type", solver_options.dense_linear_algebra_library_type);
+    solver_options.sparse_linear_algebra_library_type = fuse_core::getParam(
+        nh, "sparse_linear_algebra_library_type", solver_options.sparse_linear_algebra_library_type);
+
+    // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> linear_solver_ordering;
+
+    nh.param("use_explicit_schur_complement", solver_options.use_explicit_schur_complement,
+             solver_options.use_explicit_schur_complement);
+    nh.param("use_postordering", solver_options.use_postordering, solver_options.use_postordering);
+    nh.param("dynamic_sparsity", solver_options.dynamic_sparsity, solver_options.dynamic_sparsity);
+
+#if CERES_VERSION_AT_LEAST(2, 0, 0)
+    nh.param("use_mixed_precision_solves", solver_options.use_mixed_precision_solves,
+             solver_options.use_mixed_precision_solves);
+    nh.param("max_num_refinement_iterations", solver_options.max_num_refinement_iterations,
+             solver_options.max_num_refinement_iterations);
+#endif
+
+    nh.param("use_inner_iterations", solver_options.use_inner_iterations, solver_options.use_inner_iterations);
+
+    // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> inner_iteration_ordering;
+
+    nh.param("inner_iteration_tolerance", solver_options.inner_iteration_tolerance,
+             solver_options.inner_iteration_tolerance);
+    nh.param("min_linear_solver_iterations", solver_options.min_linear_solver_iterations,
+             solver_options.min_linear_solver_iterations);
+    nh.param("max_linear_solver_iterations", solver_options.max_linear_solver_iterations,
+             solver_options.max_linear_solver_iterations);
+    nh.param("eta", solver_options.eta, solver_options.eta);
+
+    nh.param("jacobi_scaling", solver_options.jacobi_scaling, solver_options.jacobi_scaling);
+
+    // Logging options
+    solver_options.logging_type = fuse_core::getParam(nh, "logging_type", solver_options.logging_type);
+    nh.param("minimizer_progress_to_stdout", solver_options.minimizer_progress_to_stdout,
+             solver_options.minimizer_progress_to_stdout);
+    nh.param("trust_region_minimizer_iterations_to_dump", solver_options.trust_region_minimizer_iterations_to_dump,
+             solver_options.trust_region_minimizer_iterations_to_dump);
+    nh.param("trust_region_problem_dump_directory", solver_options.trust_region_problem_dump_directory,
+             solver_options.trust_region_problem_dump_directory);
+    solver_options.trust_region_problem_dump_format_type = fuse_core::getParam(
+        nh, "trust_region_problem_dump_format_type", solver_options.trust_region_problem_dump_format_type);
+
+    // Finite differences options
+    nh.param("check_gradients", solver_options.check_gradients, solver_options.check_gradients);
+    nh.param("gradient_check_relative_precision", solver_options.gradient_check_relative_precision,
+             solver_options.gradient_check_relative_precision);
+    nh.param("gradient_check_numeric_derivative_relative_step_size",
+             solver_options.gradient_check_numeric_derivative_relative_step_size,
+             solver_options.gradient_check_numeric_derivative_relative_step_size);
+    nh.param("update_state_every_iteration", solver_options.update_state_every_iteration,
+             solver_options.update_state_every_iteration);
+
+    std::string error;
+    if (!solver_options.IsValid(&error))
+    {
+      throw std::invalid_argument("Invalid solver options in parameter " + nh.getNamespace() + ". Error: " + error);
+    }
   }
 };
 

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -65,16 +65,18 @@ public:
   ceres::Solver::Options solver_options;
 
   /**
-   * @brief Helper function that loads strictly positive floating point values from the parameter server
+   * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
    *
    * @param[in] node_handle - The node handle used to load the parameter
    * @param[in] parameter_name - The parameter name to load
    * @param[in] default_value - A default value to use if the provided parameter name does not exist
    * @return The loaded (or default) value
    */
-  double getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, double default_value)
+  template <typename T,
+            typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type* = nullptr>
+  T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T default_value)
   {
-    double value;
+    T value;
     node_handle.param(parameter_name, value, default_value);
     if (value <= 0)
     {

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -177,7 +177,7 @@ void FixedLagSmoother::optimizationLoop()
       // Update the graph
       graph_->update(*new_transaction);
       // Optimize the entire graph
-      graph_->optimize();
+      graph_->optimize(params_.solver_options);
       // Optimization is complete. Notify all the things about the graph changes.
       notify(std::move(new_transaction), graph_->clone());
       // Compute a transaction that marginalizes out those variables.

--- a/fuse_optimizers/src/fixed_lag_smoother_node.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother_node.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
   ros::NodeHandle private_node_handle("~");
   fuse_graphs::HashGraphParams hash_graph_params;
   hash_graph_params.loadFromROS(private_node_handle);
-  fuse_optimizers::FixedLagSmoother optimizer(fuse_graphs::HashGraph::make_unique(hash_graph_params.problem_options));
+  fuse_optimizers::FixedLagSmoother optimizer(fuse_graphs::HashGraph::make_unique(hash_graph_params));
   ros::spin();
 
   return 0;

--- a/fuse_optimizers/src/fixed_lag_smoother_node.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother_node.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_graphs/hash_graph.h>
+#include <fuse_graphs/hash_graph_params.h>
 #include <fuse_optimizers/fixed_lag_smoother.h>
 #include <ros/ros.h>
 
@@ -39,7 +40,10 @@
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "fixed_lag_smoother_node");
-  fuse_optimizers::FixedLagSmoother optimizer(fuse_graphs::HashGraph::make_unique());
+  ros::NodeHandle private_node_handle("~");
+  fuse_graphs::HashGraphParams hash_graph_params;
+  hash_graph_params.loadFromROS(private_node_handle);
+  fuse_optimizers::FixedLagSmoother optimizer(fuse_graphs::HashGraph::make_unique(hash_graph_params.problem_options));
   ros::spin();
 
   return 0;


### PR DESCRIPTION
This allows to set all `ceres::Solver::Options`, `ceres::Problem::Options` and `ceres::Covariance::Options` using ROS parameters.

The motivation is to tune the solver and problem for better performance or accuracy, after looking at the tuning results shown in the plots at https://github.com/SteveMacenski/slam_toolbox , which was shared with me by @svwilliams . Unfortunately, it looks like the best configuration is almost the same as the default one :laughing: , except for the `preconditioner_type` option, which defaults to `JACOBI` but it's set to `SCHUR_JACOBI`, which indeed make things a little faster for me (from 55 to 49% CPU with my `fuse_rl` configuration).

Either way, I think this is useful to tune things with other goals in mind, like accuracy, debugging, and still performance. TBH I haven't played a lot with the options/parameters, other than confirming things are being set and used internally.

I also suspect the `enable_fast_removal` option doesn't make a big different for the `ceres::Problem` because I think it's built from scratch every time.

I took the list of options from the latest version of Ceres, which will be `2.0.0`, but also supported `1.13.x`:
* https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/solver.h#L59
* https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/problem.h#L124