### PR TITLE
Stamp merged transaction

### DIFF
--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -182,6 +182,7 @@ void Transaction::removeVariable(const UUID& variable_uuid)
 
 void Transaction::merge(const Transaction& other, bool overwrite)
 {
+  stamp_ = std::max(stamp_, other.stamp_);
   involved_stamps_.insert(other.involved_stamps_.begin(), other.involved_stamps_.end());
   for (const auto& added_constraint : other.added_constraints_)
   {

--- a/fuse_core/test/test_transaction.cpp
+++ b/fuse_core/test/test_transaction.cpp
@@ -666,6 +666,7 @@ TEST(Transaction, Merge)
   UUID removed_variable3 = fuse_core::uuid::generate();
 
   Transaction transaction1;
+  transaction1.stamp(involved_stamp2);
   transaction1.addInvolvedStamp(involved_stamp1);
   transaction1.addInvolvedStamp(involved_stamp2);
   transaction1.addConstraint(added_constraint1);
@@ -677,6 +678,7 @@ TEST(Transaction, Merge)
   transaction1.removeVariable(removed_variable3);
 
   Transaction transaction2;
+  transaction2.stamp(involved_stamp3);
   transaction2.addInvolvedStamp(involved_stamp2);
   transaction2.addInvolvedStamp(involved_stamp3);
   transaction2.addConstraint(added_constraint2);
@@ -721,6 +723,8 @@ TEST(Transaction, Merge)
   expected_removed_variables.push_back(removed_variable2);
   expected_removed_variables.push_back(removed_variable3);
   EXPECT_TRUE(testRemovedVariables(expected_removed_variables, transaction1));
+
+  EXPECT_EQ(std::max(involved_stamp2, involved_stamp3), transaction1.stamp());
 }
 
 TEST(Transaction, Clone)

--- a/fuse_core/test/test_transaction.cpp
+++ b/fuse_core/test/test_transaction.cpp
@@ -38,6 +38,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <initializer_list>
 #include <vector>
 


### PR DESCRIPTION
This sets the transaction's timestamp to the maximum stamp of the merged transactions.

Otherwise, the merged transaction keeps the stamp from `this` transaction. This means that if we merge `other` transactions into `this`, which is originally empty, the timestamp would be zero: `ros::Time(0)`. This actually happens in https://github.com/locusrobotics/fuse/blob/devel/fuse_optimizers/src/fixed_lag_smoother.cpp#L167, where the merged transaction `new_transaction` always have a zero stamp.

Probably not very important, but looks a bit unexpected.

I also wonder if instead of having a `stamp_` attribute we should just use `*involved_stamps_.crbegin()`, as long as `!involved_stamps_.empty()`.

I've created this PR because the changes are trivial, but feel free to consider this a discussion and close with no action or in favour of a different change.