### PR TITLE
Added fuse SerializedXXX messages

### DIFF
--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>fuse_core</exec_depend>
   <exec_depend>fuse_graphs</exec_depend>
   <exec_depend>fuse_models</exec_depend>
+  <exec_depend>fuse_msgs</exec_depend>
   <exec_depend>fuse_optimizers</exec_depend>
   <exec_depend>fuse_publishers</exec_depend>
   <exec_depend>fuse_variables</exec_depend>

--- a/fuse_msgs/CMakeLists.txt
+++ b/fuse_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  std_msgs
+)
+
+add_message_files(
+  DIRECTORY
+    msg
+  FILES
+    SerializedGraph.msg
+    SerializedTransaction.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+)

--- a/fuse_msgs/msg/SerializedGraph.msg
+++ b/fuse_msgs/msg/SerializedGraph.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header  # A timestamp associated with the graph
+string plugin_name      # The fully-qualified name of the plugin used to serialize/deserialize this graph
+uint8[] data            # The serialized graph as a raw data buffer

--- a/fuse_msgs/msg/SerializedTransaction.msg
+++ b/fuse_msgs/msg/SerializedTransaction.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header  # A timestamp associated with this transaction
+uint8[] data            # The serialized transaction as a raw data buffer

--- a/fuse_msgs/package.xml
+++ b/fuse_msgs/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse_msgs</name>
+  <version>0.0.0</version>
+  <description>
+    The fuse_msgs package contains messages capable of holding serialized fuse objects
+  </description>
+
+  <maintainer email="swilliams@locusrobotics.com">Stephen Williams</maintainer>
+  <author email="swilliams@locusrobotics.com">Stephen Williams</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>std_msgs</depend>
+
+  <build_depend>message_generation</build_depend>
+
+  <build_export_depend>message_runtime</build_export_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+</package>

--- a/fuse_msgs/package.xml
+++ b/fuse_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>fuse_msgs</name>
-  <version>0.0.0</version>
+  <version>0.4.0</version>
   <description>
     The fuse_msgs package contains messages capable of holding serialized fuse objects
   </description>


### PR DESCRIPTION
Added fuse SerializedXXX messages. The intent is to serialize a graph or transaction into the message buffer, send it across the ROS Comms wire, and deserialize it on the other end. The down side being the graph/transaction data will look like garbage if you echo it.