### PR TITLE
Added deserializers for the Graph and Transaction messages

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(fuse_core)
 
 set(build_depends
+  fuse_msgs
+  pluginlib
   roscpp
 )
 
@@ -38,8 +40,11 @@ add_library(${PROJECT_NAME}
   src/async_sensor_model.cpp
   src/constraint.cpp
   src/graph.cpp
+  src/graph_deserializer.cpp
+  src/serialization.cpp
   src/timestamp_manager.cpp
   src/transaction.cpp
+  src/transaction_deserializer.cpp
   src/variable.cpp
 )
 add_dependencies(${PROJECT_NAME}
@@ -59,6 +64,23 @@ target_link_libraries(${PROJECT_NAME}
   ${CERES_LIBRARIES}
 )
 
+# fuse_echo executable
+add_executable(fuse_echo
+  src/fuse_echo.cpp
+)
+add_dependencies(fuse_echo
+  ${catkin_EXPORTED_TARGETS}
+)
+target_include_directories(fuse_echo
+  PUBLIC
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(fuse_echo
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
 #############
 ## Install ##
 #############
@@ -68,6 +90,11 @@ install(
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(
+  TARGETS fuse_echo
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 install(

--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -75,18 +75,18 @@ public:
    * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
    * an exception is thrown.
    *
-   * @param[IN]  msg  The SerializedGraph message to be deserialized
+   * @param[in]  msg  The SerializedGraph message to be deserialized
    * @return          A unique_ptr to a derived Graph object
    */
   fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg);
 
   /**
-   * @brief Deserialize a graph
+   * @brief Deserialize a SerializedGraph message into a fuse Graph object.
    *
    * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
    * an exception is thrown.
    *
-   * @param[IN]  msg  The SerializedGraph message to be deserialized
+   * @param[in]  msg  The SerializedGraph message to be deserialized
    * @return          A unique_ptr to a derived Graph object
    */
   fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg);

--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_GRAPH_DESERIALIZER_H
+#define FUSE_CORE_GRAPH_DESERIALIZER_H
+
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_core/constraint.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/variable.h>
+#include <pluginlib/class_loader.h>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief Serialize a graph into a message
+ */
+void serializeGraph(const fuse_core::Graph& graph, fuse_msgs::SerializedGraph& msg);
+
+/**
+ * @brief Deserialize a graph
+ *
+ * The deserializer object loads all of the known Variable and Constraint libraries, allowing derived types contained
+ * within the graph to be properly deserialized. The libraries will be unloaded on destruction. As a consequence, the
+ * deserializer object must outlive any created graph instances.
+ */
+class GraphDeserializer
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  GraphDeserializer();
+
+  /**
+   * @brief Destructor
+   */
+  ~GraphDeserializer();
+
+  /**
+   * @brief Deserialize a SerializedGraph message into a fuse Graph object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedGraph message to be deserialized
+   * @return          A unique_ptr to a derived Graph object
+   */
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg);
+
+  /**
+   * @brief Deserialize a graph
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedGraph message to be deserialized
+   * @return          A unique_ptr to a derived Graph object
+   */
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg);
+
+private:
+  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
+  pluginlib::ClassLoader<fuse_core::Graph> graph_loader_;  //!< Pluginlib class loader for Graph types
+  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
+};
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_GRAPH_DESERIALIZER_H

--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -65,11 +65,6 @@ public:
   GraphDeserializer();
 
   /**
-   * @brief Destructor
-   */
-  ~GraphDeserializer();
-
-  /**
    * @brief Deserialize a SerializedGraph message into a fuse Graph object.
    *
    * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
@@ -92,9 +87,9 @@ public:
   fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg);
 
 private:
+  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
   pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
   pluginlib::ClassLoader<fuse_core::Graph> graph_loader_;  //!< Pluginlib class loader for Graph types
-  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/serialization.h
+++ b/fuse_core/include/fuse_core/serialization.h
@@ -50,6 +50,9 @@
 #include <boost/uuid/uuid_serialize.hpp>
 #include <Eigen/Core>
 
+#include <sstream>
+#include <vector>
+
 
 namespace fuse_core
 {
@@ -57,7 +60,17 @@ namespace fuse_core
   using BinaryOutputArchive = boost::archive::binary_oarchive;
   using TextInputArchive = boost::archive::text_iarchive;
   using TextOutputArchive = boost::archive::text_oarchive;
-}
+
+  /**
+   * @brief Copy the contents of the stream into a vector of bytes
+   *
+   * This function inserts additional data into the \p destination vector. Any existing contents will remain.
+   *
+   * @param[IN]  source       Populated stringstream object
+   * @param[OUT] destination  Byte vector where stream data should be copied
+   */
+  void copyStream(std::stringstream& source, std::vector<uint8_t>& destination);
+}  // namespace fuse_core
 
 namespace boost
 {

--- a/fuse_core/include/fuse_core/serialization.h
+++ b/fuse_core/include/fuse_core/serialization.h
@@ -50,26 +50,95 @@
 #include <boost/uuid/uuid_serialize.hpp>
 #include <Eigen/Core>
 
-#include <sstream>
+#include <boost/iostreams/categories.hpp>
+
 #include <vector>
 
 
 namespace fuse_core
 {
-  using BinaryInputArchive = boost::archive::binary_iarchive;
-  using BinaryOutputArchive = boost::archive::binary_oarchive;
-  using TextInputArchive = boost::archive::text_iarchive;
-  using TextOutputArchive = boost::archive::text_oarchive;
+using BinaryInputArchive = boost::archive::binary_iarchive;
+using BinaryOutputArchive = boost::archive::binary_oarchive;
+using TextInputArchive = boost::archive::text_iarchive;
+using TextOutputArchive = boost::archive::text_oarchive;
+
+/**
+ * @brief A Boost IOStreams source device designed to read bytes directly from a ROS message byte array ('uint8[]')
+ */
+class MessageBufferStreamSource
+{
+public:
+  typedef char char_type;
+  typedef boost::iostreams::source_tag category;
 
   /**
-   * @brief Copy the contents of the stream into a vector of bytes
+   * @brief Construct a stream source from a previously populated data vector
    *
-   * This function inserts additional data into the \p destination vector. Any existing contents will remain.
+   * The input vector type is designed to work with ROS message fields of type 'uint8[]'
    *
-   * @param[IN]  source       Populated stringstream object
-   * @param[OUT] destination  Byte vector where stream data should be copied
+   * @param[in] data A byte vector from a ROS message
    */
-  void copyStream(std::stringstream& source, std::vector<uint8_t>& destination);
+  explicit MessageBufferStreamSource(const std::vector<unsigned char>& data);
+
+  /**
+   * @brief The stream source is non-copyable
+   */
+  MessageBufferStreamSource operator=(const MessageBufferStreamSource&) = delete;
+
+  /**
+   * @brief Read up to n characters from the data vector
+   *
+   * This fulfills the Boost IOStreams source concept.
+   *
+   * @param[in] s The destination location
+   * @param[in] n The number of bytes to read from the stream
+   * @return The number of bytes read, or -1 to indicate EOF
+   */
+  std::streamsize read(char_type* s, std::streamsize n);
+
+private:
+  const std::vector<unsigned char>& data_;  //!< Reference to the source container
+  size_t index_;  //!< The next vector index to read
+};
+
+/**
+ * @brief A Boost IOStreams sink device designed to write bytes directly from a ROS message byte array ('uint8[]')
+ */
+class MessageBufferStreamSink
+{
+public:
+  typedef char char_type;
+  typedef boost::iostreams::sink_tag category;
+
+  /**
+   * @brief Construct a stream sink from a data vector
+   *
+   * The input vector type is designed to work with ROS message fields of type 'uint8[]'
+   *
+   * @param[in] data A byte vector from a ROS message
+   */
+  explicit MessageBufferStreamSink(std::vector<unsigned char>& data);
+
+  /**
+   * @brief The stream sink is non-copyable
+   */
+  MessageBufferStreamSink operator=(const MessageBufferStreamSink&) = delete;
+
+  /**
+   * @brief Write n characters to the data vector
+   *
+   * This fulfills the Boost IOStreams sink concept.
+   *
+   * @param[in] s The source location
+   * @param[in] n The number of bytes to write to the stream
+   * @return The number of bytes written
+   */
+  std::streamsize write(const char_type* s, std::streamsize n);
+
+private:
+  std::vector<unsigned char>& data_;  //!< Reference to the destination container
+};
+
 }  // namespace fuse_core
 
 namespace boost

--- a/fuse_core/include/fuse_core/transaction_deserializer.h
+++ b/fuse_core/include/fuse_core/transaction_deserializer.h
@@ -1,0 +1,101 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_TRANSACTION_DESERIALIZER_H
+#define FUSE_CORE_TRANSACTION_DESERIALIZER_H
+
+#include <fuse_msgs/SerializedTransaction.h>
+#include <fuse_core/constraint.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/variable.h>
+#include <pluginlib/class_loader.h>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief Serialize a transaction into a message
+ */
+void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::SerializedTransaction& msg);
+
+/**
+ * @brief Deserialize a Transaction
+ *
+ * The deserializer object loads all of the known Variable and Constraint libraries, allowing derived types contained
+ * within the transaction to be properly deserialized. The libraries will be unloaded on destruction. As a consequence,
+ * the deserializer object must outlive any created transaction instances.
+ */
+class TransactionDeserializer
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  TransactionDeserializer();
+
+  /**
+   * @brief Destructor
+   */
+  ~TransactionDeserializer();
+
+  /**
+   * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedTransaction message to be deserialized
+   * @return          A fuse Transaction object
+   */
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg);
+
+  /**
+   * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedTransaction message to be deserialized
+   * @return          A fuse Transaction object
+   */
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction& msg);
+
+private:
+  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
+  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
+};
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_TRANSACTION_DESERIALIZER_H

--- a/fuse_core/include/fuse_core/transaction_deserializer.h
+++ b/fuse_core/include/fuse_core/transaction_deserializer.h
@@ -65,11 +65,6 @@ public:
   TransactionDeserializer();
 
   /**
-   * @brief Destructor
-   */
-  ~TransactionDeserializer();
-
-  /**
    * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
    *
    * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
@@ -92,8 +87,8 @@ public:
   fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction& msg);
 
 private:
-  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
   pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
+  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
 };
 
 }  // namespace fuse_core

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -14,6 +14,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>
+  <depend>fuse_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>

--- a/fuse_core/src/fuse_echo.cpp
+++ b/fuse_core/src/fuse_echo.cpp
@@ -1,0 +1,94 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_msgs/SerializedTransaction.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/transaction_deserializer.h>
+#include <ros/ros.h>
+
+
+/**
+ * Class that subscribes to the 'graph' and 'transaction' topic and prints the objects to stdout
+ */
+class FuseEcho
+{
+public:
+  explicit FuseEcho(const ros::NodeHandle& node_handle = ros::NodeHandle()) :
+    node_handle_(node_handle)
+  {
+    // Subscribe to the constraint topic
+    graph_subscriber_ = node_handle_.subscribe("graph", 1, &FuseEcho::graphCallback, this);
+    transaction_subscriber_ = node_handle_.subscribe("transaction", 1, &FuseEcho::transactionCallback, this);
+  }
+
+private:
+  fuse_core::GraphDeserializer graph_deserializer_;
+  fuse_core::TransactionDeserializer transaction_deserializer_;
+  ros::NodeHandle node_handle_;
+  ros::Subscriber graph_subscriber_;
+  ros::Subscriber transaction_subscriber_;
+
+  void graphCallback(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+  {
+    std::cout << "-------------------------" << std::endl;
+    std::cout << "GRAPH:" << std::endl;
+    std::cout << "received at: " << ros::Time::now() << std::endl;
+    auto graph = graph_deserializer_.deserialize(msg);
+    graph->print();
+  }
+
+  void transactionCallback(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+  {
+    std::cout << "-------------------------" << std::endl;
+    std::cout << "TRANSACTION:" << std::endl;
+    std::cout << "received at: " << ros::Time::now() << std::endl;
+    auto transaction = transaction_deserializer_.deserialize(msg);
+    transaction.print();
+  }
+};
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "fuse_echo", ros::init_options::AnonymousName);
+
+  // Object that subscribes to the 'transaction' topic and prints the constraints and variables to stdout
+  FuseEcho echoer;
+
+  // Wait for an exit signal
+  ros::spin();
+
+  return 0;
+}

--- a/fuse_core/src/fuse_echo.cpp
+++ b/fuse_core/src/fuse_echo.cpp
@@ -41,7 +41,7 @@
 
 
 /**
- * Class that subscribes to the 'graph' and 'transaction' topic and prints the objects to stdout
+ * Class that subscribes to the 'graph' and 'transaction' topics and prints the objects to stdout
  */
 class FuseEcho
 {
@@ -50,8 +50,8 @@ public:
     node_handle_(node_handle)
   {
     // Subscribe to the constraint topic
-    graph_subscriber_ = node_handle_.subscribe("graph", 1, &FuseEcho::graphCallback, this);
-    transaction_subscriber_ = node_handle_.subscribe("transaction", 1, &FuseEcho::transactionCallback, this);
+    graph_subscriber_ = node_handle_.subscribe("graph", 100, &FuseEcho::graphCallback, this);
+    transaction_subscriber_ = node_handle_.subscribe("transaction", 100, &FuseEcho::transactionCallback, this);
   }
 
 private:
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "fuse_echo", ros::init_options::AnonymousName);
 
-  // Object that subscribes to the 'transaction' topic and prints the constraints and variables to stdout
+  // Object that subscribes to the 'graph' and 'transaction' topics and prints the objects to stdout
   FuseEcho echoer;
 
   // Wait for an exit signal

--- a/fuse_core/src/graph_deserializer.cpp
+++ b/fuse_core/src/graph_deserializer.cpp
@@ -1,0 +1,118 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/graph_deserializer.h>
+
+#include <fuse_core/serialization.h>
+#include <fuse_msgs/SerializedGraph.h>
+
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+
+namespace fuse_core
+{
+
+void serializeGraph(const fuse_core::Graph& graph, fuse_msgs::SerializedGraph& msg)
+{
+  std::stringstream stream;
+  // Serialize graph into the stream
+  // The archive to not flushed until it goes out of scope
+  {
+    BinaryOutputArchive archive(stream);
+    graph.serialize(archive);
+  }
+  // Copy the stream into the message's data[] variable
+  copyStream(stream, msg.data);
+  // Set the plugin name using the variable's type() member function (blindly assuming these are the same thing)
+  msg.plugin_name = graph.type();
+}
+
+GraphDeserializer::GraphDeserializer() :
+  constraint_loader_("fuse_core", "fuse_core::Constraint"),
+  graph_loader_("fuse_core", "fuse_core::Graph"),
+  variable_loader_("fuse_core", "fuse_core::Variable")
+{
+  // Load all known plugin libraries
+  // I believe the library containing a given Variable or Constraint type must be loaded in order to deserialize
+  // an object of that type. But I haven't actually tested that theory.
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.loadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.loadLibraryForClass(class_name);
+  }
+}
+
+GraphDeserializer::~GraphDeserializer()
+{
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.unloadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : graph_loader_.getDeclaredClasses())
+  {
+    graph_loader_.unloadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.unloadLibraryForClass(class_name);
+  }
+}
+
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+{
+  return deserialize(*msg);
+}
+
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph& msg)
+{
+  // Create a Graph object using pluginlib. This will throw if the plugin name is not found.
+  // The unique ptr returned by pluginlib has a custom deleter. This makes it annoying to return
+  // back to the user as the output is not equivalent to fuse_core::Graph::UniquePtr. Instead, wrap an
+  // unmanaged raw pointer in a unique_ptr, and handle the library unloading in the destructor.
+  auto graph = fuse_core::Graph::UniquePtr(graph_loader_.createUnmanagedInstance(msg.plugin_name));
+  // Deserialize the message into the Graph. This will throw if something goes wrong during deserialization.
+  std::stringstream stream;
+  std::copy(msg.data.begin(), msg.data.end(), std::ostream_iterator<char>(stream));
+  {
+    BinaryInputArchive archive(stream);
+    graph->deserialize(archive);
+  }
+  return graph;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/graph_deserializer.cpp
+++ b/fuse_core/src/graph_deserializer.cpp
@@ -60,36 +60,20 @@ void serializeGraph(const fuse_core::Graph& graph, fuse_msgs::SerializedGraph& m
 }
 
 GraphDeserializer::GraphDeserializer() :
+  variable_loader_("fuse_core", "fuse_core::Variable"),
   constraint_loader_("fuse_core", "fuse_core::Constraint"),
-  graph_loader_("fuse_core", "fuse_core::Graph"),
-  variable_loader_("fuse_core", "fuse_core::Variable")
+  graph_loader_("fuse_core", "fuse_core::Graph")
 {
   // Load all known plugin libraries
   // I believe the library containing a given Variable or Constraint type must be loaded in order to deserialize
   // an object of that type. But I haven't actually tested that theory.
-  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
-  {
-    constraint_loader_.loadLibraryForClass(class_name);
-  }
   for (const auto& class_name : variable_loader_.getDeclaredClasses())
   {
     variable_loader_.loadLibraryForClass(class_name);
   }
-}
-
-GraphDeserializer::~GraphDeserializer()
-{
-  for (const auto& class_name : variable_loader_.getDeclaredClasses())
-  {
-    variable_loader_.unloadLibraryForClass(class_name);
-  }
-  for (const auto& class_name : graph_loader_.getDeclaredClasses())
-  {
-    graph_loader_.unloadLibraryForClass(class_name);
-  }
   for (const auto& class_name : constraint_loader_.getDeclaredClasses())
   {
-    constraint_loader_.unloadLibraryForClass(class_name);
+    constraint_loader_.loadLibraryForClass(class_name);
   }
 }
 

--- a/fuse_core/src/serialization.cpp
+++ b/fuse_core/src/serialization.cpp
@@ -1,0 +1,59 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/serialization.h>
+
+#include <sstream>
+#include <vector>
+
+
+namespace fuse_core
+{
+
+void copyStream(std::stringstream& source, std::vector<uint8_t>& destination)
+{
+  // Reserve the required memory in the vector. This prevents unnecessary memory reallocations if tellp is accurate.
+  int source_length = source.tellp();
+  if (source_length > 0)
+  {
+    destination.reserve(destination.size() + source_length);
+  }
+  // Copy the data from the stream into the vector, byte by byte
+  char c;
+  while (source.get(c))
+  {
+    destination.push_back(static_cast<uint8_t>(c));
+  }
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/transaction_deserializer.cpp
+++ b/fuse_core/src/transaction_deserializer.cpp
@@ -1,0 +1,109 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/transaction_deserializer.h>
+
+#include <fuse_core/serialization.h>
+#include <fuse_msgs/SerializedTransaction.h>
+
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+
+namespace fuse_core
+{
+
+void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::SerializedTransaction& msg)
+{
+  std::stringstream stream;
+  // Serialize graph into the stream
+  // The archive to not flushed until it goes out of scope
+  {
+    BinaryOutputArchive archive(stream);
+    transaction.serialize(archive);
+  }
+  // Copy the stream into the message's data[] variable
+  copyStream(stream, msg.data);
+}
+
+TransactionDeserializer::TransactionDeserializer() :
+  constraint_loader_("fuse_core", "fuse_core::Constraint"),
+  variable_loader_("fuse_core", "fuse_core::Variable")
+{
+  // Load all known plugin libraries
+  // I believe the library containing a given Variable or Constraint must be loaded in order to deserialize
+  // an object of that type. But I haven't actually tested that theory.
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.loadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.loadLibraryForClass(class_name);
+  }
+}
+
+TransactionDeserializer::~TransactionDeserializer()
+{
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.unloadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.unloadLibraryForClass(class_name);
+  }
+}
+
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+{
+  return deserialize(*msg);
+}
+
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction& msg)
+{
+  // The Transaction object is not a plugin and has no derived types. That makes it much easier to use.
+  auto transaction = fuse_core::Transaction();
+  // Deserialize the message into the Variable. This will throw if something goes wrong in the deserialization.
+  std::stringstream stream;
+  std::copy(msg.data.begin(), msg.data.end(), std::ostream_iterator<char>(stream));
+  {
+    BinaryInputArchive archive(stream);
+    transaction.deserialize(archive);
+  }
+  // Return the populated variable. UniquePtrs are automatically promoted to SharedPtrs.
+  return transaction;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/transaction_deserializer.cpp
+++ b/fuse_core/src/transaction_deserializer.cpp
@@ -47,8 +47,8 @@ namespace fuse_core
 void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::SerializedTransaction& msg)
 {
   std::stringstream stream;
-  // Serialize graph into the stream
-  // The archive to not flushed until it goes out of scope
+  // Serialize the transaction into the stream
+  // Scope the archive object. The archive is not guaranteed to write to the stream until the archive goes out of scope.
   {
     BinaryOutputArchive archive(stream);
     transaction.serialize(archive);

--- a/fuse_core/src/transaction_deserializer.cpp
+++ b/fuse_core/src/transaction_deserializer.cpp
@@ -58,31 +58,19 @@ void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::
 }
 
 TransactionDeserializer::TransactionDeserializer() :
-  constraint_loader_("fuse_core", "fuse_core::Constraint"),
-  variable_loader_("fuse_core", "fuse_core::Variable")
+  variable_loader_("fuse_core", "fuse_core::Variable"),
+  constraint_loader_("fuse_core", "fuse_core::Constraint")
 {
   // Load all known plugin libraries
   // I believe the library containing a given Variable or Constraint must be loaded in order to deserialize
   // an object of that type. But I haven't actually tested that theory.
-  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
-  {
-    constraint_loader_.loadLibraryForClass(class_name);
-  }
   for (const auto& class_name : variable_loader_.getDeclaredClasses())
   {
     variable_loader_.loadLibraryForClass(class_name);
   }
-}
-
-TransactionDeserializer::~TransactionDeserializer()
-{
-  for (const auto& class_name : variable_loader_.getDeclaredClasses())
-  {
-    variable_loader_.unloadLibraryForClass(class_name);
-  }
   for (const auto& class_name : constraint_loader_.getDeclaredClasses())
   {
-    constraint_loader_.unloadLibraryForClass(class_name);
+    constraint_loader_.loadLibraryForClass(class_name);
   }
 }
 

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -36,6 +36,7 @@ add_compile_options(-std=c++14 -Wall -Werror)
 add_library(${PROJECT_NAME}
   src/path_2d_publisher.cpp
   src/pose_2d_publisher.cpp
+  src/serialized_publisher.cpp
 )
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}

--- a/fuse_publishers/fuse_plugins.xml
+++ b/fuse_publishers/fuse_plugins.xml
@@ -11,4 +11,9 @@
       including tf.
     </description>
   </class>
+  <class type="fuse_publishers::SerializedPublisher" base_class_type="fuse_core::Publisher">
+    <description>
+      Publisher plugin that publishes the transaction and graph as serialized messages.
+    </description>
+  </class>
 </library>

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -1,0 +1,88 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H
+#define FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H
+
+#include <fuse_core/async_publisher.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/transaction.h>
+#include <ros/ros.h>
+
+
+namespace fuse_publishers
+{
+
+/**
+ * @brief Publisher plugin that publishes the transaction and graph as serialized messages
+ */
+class SerializedPublisher : public fuse_core::AsyncPublisher
+{
+public:
+  SMART_PTR_DEFINITIONS(SerializedPublisher);
+
+  /**
+   * @brief Constructor
+   */
+  SerializedPublisher();
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~SerializedPublisher() = default;
+
+  /**
+   * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the
+   * parameter server.
+   */
+  void onInit() override;
+
+  /**
+   * @brief Notify the publisher about variables that have been added or removed
+   *
+   * @param[in] transaction A Transaction object, describing the set of variables that have been added and/or removed
+   * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
+   */
+  void notifyCallback(
+    fuse_core::Transaction::ConstSharedPtr transaction,
+    fuse_core::Graph::ConstSharedPtr graph) override;
+
+protected:
+  ros::Publisher graph_publisher_;
+  ros::Publisher transaction_publisher_;
+};
+
+}  // namespace fuse_publishers
+
+#endif  // FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -1,0 +1,87 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_publishers/serialized_publisher.h>
+
+#include <fuse_core/async_publisher.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/transaction_deserializer.h>
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_msgs/SerializedTransaction.h>
+#include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+
+
+// Register this publisher with ROS as a plugin.
+PLUGINLIB_EXPORT_CLASS(fuse_publishers::SerializedPublisher, fuse_core::Publisher);
+
+namespace fuse_publishers
+{
+
+SerializedPublisher::SerializedPublisher() :
+  fuse_core::AsyncPublisher(1)
+{
+}
+
+void SerializedPublisher::onInit()
+{
+  // Advertise the topics
+  graph_publisher_ = node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
+  transaction_publisher_ = node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
+}
+
+void SerializedPublisher::notifyCallback(
+  fuse_core::Transaction::ConstSharedPtr transaction,
+  fuse_core::Graph::ConstSharedPtr graph)
+{
+  auto stamp = ros::Time::now();
+  if (graph_publisher_.getNumSubscribers() > 0)
+  {
+    fuse_msgs::SerializedGraph msg;
+    msg.header.stamp = stamp;
+    fuse_core::serializeGraph(*graph, msg);
+    graph_publisher_.publish(msg);
+  }
+
+  if (transaction_publisher_.getNumSubscribers() > 0)
+  {
+    fuse_msgs::SerializedTransaction msg;
+    msg.header.stamp = stamp;
+    fuse_core::serializeTransaction(*transaction, msg);
+    transaction_publisher_.publish(msg);
+  }
+}
+
+}  // namespace fuse_publishers

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -58,8 +58,8 @@ SerializedPublisher::SerializedPublisher() :
 void SerializedPublisher::onInit()
 {
   // Advertise the topics
-  graph_publisher_ = node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
-  transaction_publisher_ = node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
+  graph_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
+  transaction_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
 }
 
 void SerializedPublisher::notifyCallback(


### PR DESCRIPTION
Added deserializers for the Graph and Transaction messages, and a few other toys.

Alright. I believe this is the last of the bunch. I ran a quick integration test, and everything _appears_ to be running as expected.

The integration test contained a SerializedPublisher, which provides `/graph` and `/transaction` topics. Echoing the topics provides the expected mostly unhelpful information:
```
$ rostopic echo /graph --noarr
header: 
  seq: 0
  stamp: 
    secs: 4062
    nsecs: 570341615
  frame_id: ''
plugin_name: "fuse_graphs::HashGraph"
data: "<array type: uint8, length: 8031>"
---
header: 
  seq: 1
  stamp: 
    secs: 4062
    nsecs: 620715955
  frame_id: ''
plugin_name: "fuse_graphs::HashGraph"
data: "<array type: uint8, length: 11907>"
```

If you fire up a `fuse_echo` node instead, the graph and transaction are printed in a somewhat human-readable form:
```
$ rosrun fuse_core fuse_echo 
-------------------------
GRAPH:
received at: 4062.570195672
HashGraph
  constraints:
   - fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint
  uuid: 53f42a3a-83b4-4769-9232-a82838ec2f30
  variable: 2b49ac71-6d10-5ff9-9b11-7d0b0c8859af
  mean: -0.000278797  2.84778e-12
  sqrt_info:   121.02 0.179513
       0  31621.8

   - fuse_constraints::AbsolutePose2DStampedConstraint
  uuid: 5aee3f68-3299-4e5c-88ba-5ff566601f26
  position variable: 3541141d-2136-56ec-854d-0209bc5c8628
  orientation variable: c077f205-a644-5afe-96b6-a4ba1c23530f
  mean:     0.182583 -0.000140056 -0.000355377
  sqrt_info:     19.0258   0.0750849 2.33595e-05
          0     52.0892     1.80317
          0           0     5.36031

...
```

I'm not going to pretend everything is perfect. In particular, I'm using pluginlib in a slightly unusual way. That may bite me in the future and require a refactor. But at least for this simple test, everything does seem to run as expected.