### PR TITLE
[RST-2340] Add serialization support to fuse

### DIFF
--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>fuse_core</exec_depend>
   <exec_depend>fuse_graphs</exec_depend>
   <exec_depend>fuse_models</exec_depend>
+  <exec_depend>fuse_msgs</exec_depend>
   <exec_depend>fuse_optimizers</exec_depend>
   <exec_depend>fuse_publishers</exec_depend>
   <exec_depend>fuse_variables</exec_depend>

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -39,6 +39,7 @@ add_compile_options(-std=c++14 -Wall -Werror)
 
 # fuse_constraints library
 add_library(${PROJECT_NAME}
+  src/absolute_constraint.cpp
   src/absolute_orientation_3d_stamped_constraint.cpp
   src/absolute_orientation_3d_stamped_euler_constraint.cpp
   src/absolute_pose_2d_stamped_constraint.cpp
@@ -49,6 +50,7 @@ add_library(${PROJECT_NAME}
   src/normal_delta.cpp
   src/normal_delta_orientation_2d.cpp
   src/normal_prior_orientation_2d.cpp
+  src/relative_constraint.cpp
   src/relative_orientation_3d_stamped_constraint.cpp
   src/relative_pose_2d_stamped_constraint.cpp
   src/relative_pose_3d_stamped_constraint.cpp

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -6,6 +6,7 @@ set(build_depends
   fuse_graphs
   fuse_variables
   geometry_msgs
+  pluginlib
   roscpp
 )
 
@@ -88,6 +89,11 @@ install(
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  FILES fuse_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 #############

--- a/fuse_constraints/fuse_plugins.xml
+++ b/fuse_constraints/fuse_plugins.xml
@@ -1,0 +1,121 @@
+<library path="lib/libfuse_constraints">
+  <class type="fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D angular acceleration, or a direct measurement of
+    the 2D angular acceleration.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D linear acceleration, or a direct measurement of
+    the 2D linear acceleration.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteOrientation2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D orientation, or a direct measurement of the
+    2D orientation.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsolutePosition2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D position, or a direct measurement of the
+    2D position.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsolutePosition3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 3D position, or a direct measurement of the
+    3D position.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D angular velocity, or a direct measurement of
+    the 2D angular velocity.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D linear velocity, or a direct measurement of
+    the 2D linear velocity.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteOrientation3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 3D orientation, or a direct measurement of the
+    3D orientation.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsoluteOrientation3DStampedEulerConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 3D orientation, or a direct measurement of the
+    3D orientation as roll-pitch-yaw Euler angles.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsolutePose2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 2D pose, or a direct measurement of the 2D pose.
+    </description>
+  </class>
+  <class type="fuse_constraints::AbsolutePose3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents either prior information about a 3D pose, or a direct measurement of the 3D pose.
+    </description>
+  </class>
+  <class type="fuse_constraints::MarginalConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents remaining marginal information on a set of variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeAccelerationAngular2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D angular acceleration variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeAccelerationLinear2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D linear acceleration variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeOrientation2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D orientation variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativePosition2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D position variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativePosition3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 3D position variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeVelocityAngular2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D angular velocity variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeVelocityLinear2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 2D linear velocity variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativeOrientation3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between 3D orientation variables.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativePose2DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between two 2D poses.
+    </description>
+  </class>
+  <class type="fuse_constraints::RelativePose3DStampedConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A constraint that represents a measurement on the difference between two 3D poses.
+    </description>
+  </class>
+</library>

--- a/fuse_constraints/include/fuse_constraints/absolute_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint.h
@@ -37,6 +37,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -46,6 +47,9 @@
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <ceres/cost_function.h>
 
 #include <ostream>
@@ -64,10 +68,15 @@ namespace fuse_constraints
  * This constraint holds the measured variable value and the measurement uncertainty/covariance.
  */
 template<class Variable>
-class AbsoluteConstraint final : public fuse_core::Constraint
+class AbsoluteConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(AbsoluteConstraint<Variable>);
+
+  /**
+   * @brief Default constructor
+   */
+  AbsoluteConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of all dimensions of the target variable
@@ -149,6 +158,24 @@ public:
 protected:
   fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & mean_;
+    archive & sqrt_information_;
+  }
 };
 
 // Define unique names for the different variations of the absolute constraint
@@ -163,5 +190,13 @@ using AbsoluteVelocityLinear2DStampedConstraint = AbsoluteConstraint<fuse_variab
 
 // Include the template implementation
 #include <fuse_constraints/absolute_constraint_impl.h>
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteOrientation2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsolutePosition2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsolutePosition3DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_ABSOLUTE_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
@@ -108,8 +108,8 @@ void AbsoluteConstraint<Variable>::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  variable: " << variables_.at(0) << "\n"
-         << "  mean: " << mean_.transpose() << "\n"
+         << "  variable: " << variables().at(0) << "\n"
+         << "  mean: " << mean().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 

--- a/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint_impl.h
@@ -39,6 +39,7 @@
 #include <ceres/normal_prior.h>
 #include <Eigen/Dense>
 
+#include <string>
 #include <vector>
 
 
@@ -126,6 +127,49 @@ template<>
 inline ceres::CostFunction* AbsoluteConstraint<fuse_variables::Orientation2DStamped>::costFunction() const
 {
   return new NormalPriorOrientation2D(sqrt_information_(0, 0), mean_(0));
+}
+
+// Specialize the type() method to return the name that is registered with the plugins
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::AccelerationAngular2DStamped>::type() const
+{
+  return "fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::AccelerationLinear2DStamped>::type() const
+{
+  return "fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::Orientation2DStamped>::type() const
+{
+  return "fuse_constraints::AbsoluteOrientation2DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::Position2DStamped>::type() const
+{
+  return "fuse_constraints::AbsolutePosition2DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::Position3DStamped>::type() const
+{
+  return "fuse_constraints::AbsolutePosition3DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::VelocityAngular2DStamped>::type() const
+{
+  return "fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint";
+}
+
+template<>
+inline std::string AbsoluteConstraint<fuse_variables::VelocityLinear2DStamped>::type() const
+{
+  return "fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint";
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
@@ -37,11 +37,15 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <geometry_msgs/PoseWithCovariance.h>
 #include <geometry_msgs/Quaternion.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Geometry>
 
 #include <array>
@@ -61,6 +65,11 @@ class AbsoluteOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsoluteOrientation3DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  AbsoluteOrientation3DStampedConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -166,8 +175,28 @@ protected:
 
   fuse_core::Vector4d mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::Matrix3d sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & mean_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteOrientation3DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_ABSOLUTE_ORIENTATION_3D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -37,12 +37,17 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <geometry_msgs/PoseWithCovariance.h>
 #include <geometry_msgs/Quaternion.h>
 
-#include <array>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/vector.hpp>
+
 #include <ostream>
 #include <vector>
 
@@ -64,6 +69,11 @@ public:
   FUSE_CONSTRAINT_DEFINITIONS(AbsoluteOrientation3DStampedEulerConstraint);
 
   using Euler = fuse_variables::Orientation3DStamped::Euler;
+
+  /**
+   * @brief Default constructor
+   */
+  AbsoluteOrientation3DStampedEulerConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -137,8 +147,29 @@ protected:
   fuse_core::VectorXd mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
   std::vector<Euler> axes_;  //!< Which Euler angle axes we want to measure
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & mean_;
+    archive & sqrt_information_;
+    archive & axes_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsoluteOrientation3DStampedEulerConstraint);
 
 #endif  // FUSE_CONSTRAINTS_ABSOLUTE_ORIENTATION_3D_STAMPED_EULER_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -57,7 +57,7 @@ namespace fuse_constraints
 
 /**
  * @brief A constraint that represents either prior information about a 3D orientation, or a direct measurement of the
- * 3D orientation.
+ * 3D orientation as roll-pitch-yaw Euler angles.
  *
  * This constraint holds the measured 3D orientation and the measurement uncertainty/covariance. The orientation is
  * represented as Euler angles, and the covariance represents the error around each rotational axis. This constraint

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -37,10 +37,14 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Dense>
 
 #include <ostream>
@@ -64,6 +68,11 @@ class AbsolutePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(AbsolutePose2DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  AbsolutePose2DStampedConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of the 2D pose
@@ -144,8 +153,28 @@ public:
 protected:
   fuse_core::Vector3d mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & mean_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsolutePose2DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_ABSOLUTE_POSE_2D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
@@ -37,10 +37,14 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_3d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Dense>
 
 #include <ostream>
@@ -64,6 +68,11 @@ class AbsolutePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose3DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  AbsolutePose3DStampedConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of the 3D pose
@@ -126,8 +135,28 @@ public:
 protected:
   fuse_core::Vector7d mean_;  //!< The measured/prior mean vector for this variable
   fuse_core::Matrix6d sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & mean_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::AbsolutePose3DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_ABSOLUTE_POSE_3D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -38,10 +38,16 @@
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/iterator/zip_iterator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/vector.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <ceres/cost_function.h>
 
@@ -66,6 +72,11 @@ class MarginalConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(MarginalConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  MarginalConstraint() = default;
 
   /**
    * @brief Create a linear/marginal constraint
@@ -139,6 +150,26 @@ protected:
   fuse_core::VectorXd b_;  //!< The b vector of the marginal constraint
   std::vector<fuse_core::LocalParameterization::SharedPtr> local_parameterizations_;  //!< The local parameterizations
   std::vector<fuse_core::VectorXd> x_bar_;  //!< The linearization point of each involved variable
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & A_;
+    archive & b_;
+    archive & local_parameterizations_;
+    archive & x_bar_;
+  }
 };
 
 namespace detail
@@ -202,5 +233,7 @@ MarginalConstraint::MarginalConstraint(
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::MarginalConstraint);
 
 #endif  // FUSE_CONSTRAINTS_MARGINAL_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/relative_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint.h
@@ -37,6 +37,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -46,6 +47,9 @@
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <ceres/cost_function.h>
 
 #include <ostream>
@@ -71,6 +75,11 @@ class RelativeConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(RelativeConstraint<Variable>);
+
+  /**
+   * @brief Default constructor
+   */
+  RelativeConstraint() = default;
 
   /**
    * @brief Create a constraint on the change of all dimensions between the two target variables
@@ -158,6 +167,24 @@ public:
 protected:
   fuse_core::VectorXd delta_;  //!< The measured change between the two variables
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & delta_;
+    archive & sqrt_information_;
+  }
 };
 
 // Define unique names for the different variations of the absolute constraint
@@ -172,5 +199,13 @@ using RelativeVelocityLinear2DStampedConstraint = RelativeConstraint<fuse_variab
 
 // Include the template implementation
 #include <fuse_constraints/relative_constraint_impl.h>
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeAccelerationAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeAccelerationLinear2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeOrientation2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativePosition2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativePosition3DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeVelocityAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeVelocityLinear2DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_RELATIVE_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
@@ -112,9 +112,9 @@ void RelativeConstraint<Variable>::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  variable1: " << variables_.at(0) << "\n"
-         << "  variable2: " << variables_.at(1) << "\n"
-         << "  delta: " << delta_.transpose() << "\n"
+         << "  variable1: " << variables().at(0) << "\n"
+         << "  variable2: " << variables().at(1) << "\n"
+         << "  delta: " << delta().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 

--- a/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint_impl.h
@@ -39,6 +39,7 @@
 
 #include <Eigen/Dense>
 
+#include <string>
 #include <vector>
 
 
@@ -131,6 +132,49 @@ inline ceres::CostFunction* RelativeConstraint<fuse_variables::Orientation2DStam
 {
   // Create a Gaussian/Normal Delta constraint
   return new NormalDeltaOrientation2D(sqrt_information_(0, 0), delta_(0));
+}
+
+// Specialize the type() method to return the name that is registered with the plugins
+template<>
+inline std::string RelativeConstraint<fuse_variables::AccelerationAngular2DStamped>::type() const
+{
+  return "fuse_constraints::RelativeAccelerationAngular2DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::AccelerationLinear2DStamped>::type() const
+{
+  return "fuse_constraints::RelativeAccelerationLinear2DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::Orientation2DStamped>::type() const
+{
+  return "fuse_constraints::RelativeOrientation2DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::Position2DStamped>::type() const
+{
+  return "fuse_constraints::RelativePosition2DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::Position3DStamped>::type() const
+{
+  return "fuse_constraints::RelativePosition3DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::VelocityAngular2DStamped>::type() const
+{
+  return "fuse_constraints::RelativeVelocityAngular2DStampedConstraint";
+}
+
+template<>
+inline std::string RelativeConstraint<fuse_variables::VelocityLinear2DStamped>::type() const
+{
+  return "fuse_constraints::RelativeVelocityLinear2DStampedConstraint";
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
@@ -37,11 +37,15 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <geometry_msgs/PoseWithCovariance.h>
 #include <geometry_msgs/Quaternion.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Geometry>
 
 #include <array>
@@ -60,6 +64,11 @@ class RelativeOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativeOrientation3DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  RelativeOrientation3DStampedConstraint() = default;
 
   /**
    * @brief Create a constraint using a measurement/prior of a 3D orientation
@@ -174,8 +183,28 @@ protected:
 
   fuse_core::Vector4d delta_;  //!< The measured/prior mean vector for this variable
   fuse_core::Matrix3d sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & delta_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativeOrientation3DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_RELATIVE_ORIENTATION_3D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -37,10 +37,14 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Dense>
 
 #include <ostream>
@@ -62,6 +66,11 @@ class RelativePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(RelativePose2DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  RelativePose2DStampedConstraint() = default;
 
   /**
    * @brief Constructor
@@ -146,8 +155,28 @@ public:
 protected:
   fuse_core::Vector3d delta_;  //!< The measured pose change (dx, dy, dyaw)
   fuse_core::MatrixXd sqrt_information_;  //!< The square root information matrix (derived from the covariance matrix)
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & delta_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativePose2DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_RELATIVE_POSE_2D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
@@ -37,10 +37,14 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_3d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <Eigen/Dense>
 
 #include <ostream>
@@ -61,6 +65,11 @@ class RelativePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose3DStampedConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  RelativePose3DStampedConstraint() = default;
 
   /**
    * @brief Constructor
@@ -121,8 +130,28 @@ public:
 protected:
   fuse_core::Vector7d delta_;  //!< The measured pose change (dx, dy, dz, dqw, dqx, dqy, dqz)
   fuse_core::Matrix6d sqrt_information_;  //!< The square root information matrix (derived from the covariance matrix)
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & delta_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_KEY(fuse_constraints::RelativePose3DStampedConstraint);
 
 #endif  // FUSE_CONSTRAINTS_RELATIVE_POSE_3D_STAMPED_CONSTRAINT_H

--- a/fuse_constraints/package.xml
+++ b/fuse_constraints/package.xml
@@ -18,8 +18,13 @@
   <depend>fuse_graphs</depend>
   <depend>fuse_variables</depend>
   <depend>geometry_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>suitesparse</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+
+  <export>
+    <fuse_core plugin="${prefix}/fuse_plugins.xml" />
+  </export>
 </package>

--- a/fuse_constraints/src/absolute_constraint.cpp
+++ b/fuse_constraints/src/absolute_constraint.cpp
@@ -31,49 +31,15 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_variables/orientation_3d_stamped.h>
-
-#include <fuse_core/local_parameterization.h>
-#include <fuse_core/uuid.h>
-#include <fuse_variables/fixed_size_variable.h>
-#include <fuse_variables/stamped.h>
-#include <ros/time.h>
+#include <fuse_constraints/absolute_constraint.h>
 
 #include <boost/serialization/export.hpp>
 
 
-#include <ostream>
-
-
-namespace fuse_variables
-{
-
-Orientation3DStamped::Orientation3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  FixedSizeVariable<4>(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
-  Stamped(stamp, device_id)
-{
-}
-
-void Orientation3DStamped::print(std::ostream& stream) const
-{
-  stream << type() << ":\n"
-         << "  uuid: " << uuid() << "\n"
-         << "  device_id: " << deviceId() << "\n"
-         << "  stamp: " << stamp() << "\n"
-         << "  size: " << size() << "\n"
-         << "  data:\n"
-         << "  - w: " << w() << "\n"
-         << "  - x: " << x() << "\n"
-         << "  - y: " << y() << "\n"
-         << "  - z: " << z() << "\n";
-}
-
-fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const
-{
-  return new Orientation3DLocalParameterization();
-}
-
-}  // namespace fuse_variables
-
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteOrientation2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePosition2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePosition3DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint);

--- a/fuse_constraints/src/absolute_constraint.cpp
+++ b/fuse_constraints/src/absolute_constraint.cpp
@@ -33,6 +33,8 @@
  */
 #include <fuse_constraints/absolute_constraint.h>
 
+#include <pluginlib/class_list_macros.h>
+
 #include <boost/serialization/export.hpp>
 
 
@@ -43,3 +45,11 @@ BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePosition2DStampedConstrai
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePosition3DStampedConstraint);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint);
+
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteOrientation2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsolutePosition2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsolutePosition3DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
@@ -32,7 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_orientation_3d_stamped_constraint.h>
+
 #include <fuse_constraints/normal_prior_orientation_3d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -110,3 +112,4 @@ fuse_core::Matrix3d AbsoluteOrientation3DStampedConstraint::toEigen(const std::a
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteOrientation3DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteOrientation3DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_orientation_3d_stamped_constraint.h>
 #include <fuse_constraints/normal_prior_orientation_3d_cost_functor.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Geometry>
 
@@ -76,8 +77,8 @@ void AbsoluteOrientation3DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  orientation variable: " << variables_.at(0) << "\n"
-         << "  mean: " << mean_.transpose() << "\n"
+         << "  orientation variable: " << variables().at(0) << "\n"
+         << "  mean: " << mean().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -107,3 +108,5 @@ fuse_core::Matrix3d AbsoluteOrientation3DStampedConstraint::toEigen(const std::a
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteOrientation3DStampedConstraint);

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h>
 
 #include <fuse_constraints/normal_prior_orientation_3d_euler_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -83,3 +84,4 @@ ceres::CostFunction* AbsoluteOrientation3DStampedEulerConstraint::costFunction()
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteOrientation3DStampedEulerConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsoluteOrientation3DStampedEulerConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -32,8 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h>
+
 #include <fuse_constraints/normal_prior_orientation_3d_euler_cost_functor.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Dense>
 
@@ -67,8 +69,8 @@ void AbsoluteOrientation3DStampedEulerConstraint::print(std::ostream& stream) co
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  orientation variable: " << variables_.at(0) << "\n"
-         << "  mean: " << mean_.transpose() << "\n"
+         << "  orientation variable: " << variables().at(0) << "\n"
+         << "  mean: " << mean().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -79,3 +81,5 @@ ceres::CostFunction* AbsoluteOrientation3DStampedEulerConstraint::costFunction()
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsoluteOrientation3DStampedEulerConstraint);

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -32,7 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
+
 #include <fuse_constraints/normal_prior_pose_2d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -119,3 +121,4 @@ ceres::CostFunction* AbsolutePose2DStampedConstraint::costFunction() const
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePose2DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsolutePose2DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
 #include <fuse_constraints/normal_prior_pose_2d_cost_functor.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Dense>
 
@@ -103,9 +104,9 @@ void AbsolutePose2DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  position variable: " << variables_.at(0) << "\n"
-         << "  orientation variable: " << variables_.at(1) << "\n"
-         << "  mean: " << mean_.transpose() << "\n"
+         << "  position variable: " << variables().at(0) << "\n"
+         << "  orientation variable: " << variables().at(1) << "\n"
+         << "  mean: " << mean().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -116,3 +117,5 @@ ceres::CostFunction* AbsolutePose2DStampedConstraint::costFunction() const
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePose2DStampedConstraint);

--- a/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
@@ -32,7 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_constraints/absolute_pose_3d_stamped_constraint.h>
+
 #include <fuse_constraints/normal_prior_pose_3d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -72,3 +74,4 @@ ceres::CostFunction* AbsolutePose3DStampedConstraint::costFunction() const
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePose3DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::AbsolutePose3DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_pose_3d_stamped_constraint.h>
 #include <fuse_constraints/normal_prior_pose_3d_cost_functor.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Dense>
 
@@ -56,9 +57,9 @@ void AbsolutePose3DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  position variable: " << variables_.at(0) << "\n"
-         << "  orientation variable: " << variables_.at(1) << "\n"
-         << "  mean: " << mean_.transpose() << "\n"
+         << "  position variable: " << variables().at(0) << "\n"
+         << "  orientation variable: " << variables().at(1) << "\n"
+         << "  mean: " << mean().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -69,3 +70,5 @@ ceres::CostFunction* AbsolutePose3DStampedConstraint::costFunction() const
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::AbsolutePose3DStampedConstraint);

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -35,6 +35,7 @@
 
 #include <fuse_constraints/marginal_cost_function.h>
 #include <fuse_core/constraint.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <Eigen/Core>
@@ -71,3 +72,4 @@ ceres::CostFunction* MarginalConstraint::costFunction() const
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::MarginalConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::MarginalConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -36,6 +36,7 @@
 #include <fuse_constraints/marginal_cost_function.h>
 #include <fuse_core/constraint.h>
 
+#include <boost/serialization/export.hpp>
 #include <Eigen/Core>
 
 #include <ostream>
@@ -49,17 +50,17 @@ void MarginalConstraint::print(std::ostream& stream) const
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
          << "  variable:\n";
-  for (const auto& variable : variables_)
+  for (const auto& variable : variables())
   {
     stream << "   - " << variable << "\n";
   }
   Eigen::IOFormat indent(4, 0, ", ", "\n", "   [", "]");
-  for (size_t i = 0; i < A_.size(); ++i)
+  for (size_t i = 0; i < A().size(); ++i)
   {
-    stream << "  A[" << i << "]:\n" << A_[i].format(indent) << "\n"
-           << "  x_bar[" << i << "]:\n" << x_bar_[i].format(indent) << "\n";
+    stream << "  A[" << i << "]:\n" << A()[i].format(indent) << "\n"
+           << "  x_bar[" << i << "]:\n" << x_bar()[i].format(indent) << "\n";
   }
-  stream << "  b:\n" << b_.format(indent) << "\n";
+  stream << "  b:\n" << b().format(indent) << "\n";
 }
 
 ceres::CostFunction* MarginalConstraint::costFunction() const
@@ -68,3 +69,5 @@ ceres::CostFunction* MarginalConstraint::costFunction() const
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::MarginalConstraint);

--- a/fuse_constraints/src/relative_constraint.cpp
+++ b/fuse_constraints/src/relative_constraint.cpp
@@ -31,49 +31,15 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_variables/orientation_3d_stamped.h>
-
-#include <fuse_core/local_parameterization.h>
-#include <fuse_core/uuid.h>
-#include <fuse_variables/fixed_size_variable.h>
-#include <fuse_variables/stamped.h>
-#include <ros/time.h>
+#include <fuse_constraints/relative_constraint.h>
 
 #include <boost/serialization/export.hpp>
 
 
-#include <ostream>
-
-
-namespace fuse_variables
-{
-
-Orientation3DStamped::Orientation3DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  FixedSizeVariable<4>(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
-  Stamped(stamp, device_id)
-{
-}
-
-void Orientation3DStamped::print(std::ostream& stream) const
-{
-  stream << type() << ":\n"
-         << "  uuid: " << uuid() << "\n"
-         << "  device_id: " << deviceId() << "\n"
-         << "  stamp: " << stamp() << "\n"
-         << "  size: " << size() << "\n"
-         << "  data:\n"
-         << "  - w: " << w() << "\n"
-         << "  - x: " << x() << "\n"
-         << "  - y: " << y() << "\n"
-         << "  - z: " << z() << "\n";
-}
-
-fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const
-{
-  return new Orientation3DLocalParameterization();
-}
-
-}  // namespace fuse_variables
-
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeAccelerationAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeAccelerationLinear2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeOrientation2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePosition2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePosition3DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeVelocityAngular2DStampedConstraint);
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeVelocityLinear2DStampedConstraint);

--- a/fuse_constraints/src/relative_constraint.cpp
+++ b/fuse_constraints/src/relative_constraint.cpp
@@ -33,6 +33,8 @@
  */
 #include <fuse_constraints/relative_constraint.h>
 
+#include <pluginlib/class_list_macros.h>
+
 #include <boost/serialization/export.hpp>
 
 
@@ -43,3 +45,11 @@ BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePosition2DStampedConstrai
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePosition3DStampedConstraint);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeVelocityAngular2DStampedConstraint);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeVelocityLinear2DStampedConstraint);
+
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeAccelerationAngular2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeAccelerationLinear2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeOrientation2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativePosition2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativePosition3DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeVelocityAngular2DStampedConstraint, fuse_core::Constraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeVelocityLinear2DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/relative_orientation_3d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_delta_orientation_3d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -115,3 +116,4 @@ fuse_core::Matrix3d RelativeOrientation3DStampedConstraint::toEigen(const std::a
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeOrientation3DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativeOrientation3DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
@@ -35,6 +35,7 @@
 
 #include <fuse_constraints/normal_delta_orientation_3d_cost_functor.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 #include <Eigen/Geometry>
 
@@ -80,9 +81,9 @@ void RelativeOrientation3DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  orientation variable1: " << variables_.at(0) << "\n"
-         << "  orientation variable2: " << variables_.at(1) << "\n"
-         << "  delta: " << delta_.transpose() << "\n"
+         << "  orientation variable1: " << variables().at(0) << "\n"
+         << "  orientation variable2: " << variables().at(1) << "\n"
+         << "  delta: " << delta().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -112,3 +113,5 @@ fuse_core::Matrix3d RelativeOrientation3DStampedConstraint::toEigen(const std::a
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativeOrientation3DStampedConstraint);

--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -31,8 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_constraints/normal_delta_pose_2d_cost_functor.h>
 #include <fuse_constraints/relative_pose_2d_stamped_constraint.h>
+
+#include <fuse_constraints/normal_delta_pose_2d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -123,3 +125,4 @@ ceres::CostFunction* RelativePose2DStampedConstraint::costFunction() const
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePose2DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativePose2DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/normal_delta_pose_2d_cost_functor.h>
 #include <fuse_constraints/relative_pose_2d_stamped_constraint.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 
 #include <vector>
@@ -105,10 +106,10 @@ void RelativePose2DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  position1 variable: " << variables_.at(0) << "\n"
-         << "  orientation1 variable: " << variables_.at(1) << "\n"
-         << "  position2 variable: " << variables_.at(2) << "\n"
-         << "  orientation2 variable: " << variables_.at(3) << "\n"
+         << "  position1 variable: " << variables().at(0) << "\n"
+         << "  orientation1 variable: " << variables().at(1) << "\n"
+         << "  position2 variable: " << variables().at(2) << "\n"
+         << "  orientation2 variable: " << variables().at(3) << "\n"
          << "  delta: " << delta().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
@@ -120,3 +121,5 @@ ceres::CostFunction* RelativePose2DStampedConstraint::costFunction() const
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePose2DStampedConstraint);

--- a/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
@@ -31,8 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_constraints/normal_delta_pose_3d_cost_functor.h>
 #include <fuse_constraints/relative_pose_3d_stamped_constraint.h>
+
+#include <fuse_constraints/normal_delta_pose_3d_cost_functor.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -75,3 +77,4 @@ ceres::CostFunction* RelativePose3DStampedConstraint::costFunction() const
 }  // namespace fuse_constraints
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePose3DStampedConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_constraints::RelativePose3DStampedConstraint, fuse_core::Constraint);

--- a/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/normal_delta_pose_3d_cost_functor.h>
 #include <fuse_constraints/relative_pose_3d_stamped_constraint.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 
 
@@ -57,10 +58,10 @@ void RelativePose3DStampedConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  position1 variable: " << variables_.at(0) << "\n"
-         << "  orientation1 variable: " << variables_.at(1) << "\n"
-         << "  position2 variable: " << variables_.at(2) << "\n"
-         << "  orientation2 variable: " << variables_.at(3) << "\n"
+         << "  position1 variable: " << variables().at(0) << "\n"
+         << "  orientation1 variable: " << variables().at(1) << "\n"
+         << "  position2 variable: " << variables().at(2) << "\n"
+         << "  orientation2 variable: " << variables().at(3) << "\n"
          << "  delta: " << delta().transpose() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
@@ -72,3 +73,5 @@ ceres::CostFunction* RelativePose3DStampedConstraint::costFunction() const
 }
 
 }  // namespace fuse_constraints
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_constraints::RelativePose3DStampedConstraint);

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -33,6 +33,8 @@
  */
 #include <fuse_constraints/absolute_constraint.h>
 #include <fuse_core/eigen.h>
+#include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -374,6 +376,37 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   covariance.GetCovarianceBlock(variable->data(), variable->data(), covariance_vector.data());
   fuse_core::Matrix1d covariance_matrix(covariance_vector.data());
   EXPECT_TRUE(cov.isApprox(covariance_matrix, 1.0e-9));
+}
+
+TEST(AbsoluteConstraint, Serialization)
+{
+  // Construct a constraint
+  fuse_variables::AccelerationAngular2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("robby"));
+  fuse_core::Vector1d mean;
+  mean << 3.0;
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint expected(variable, mean, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  fuse_constraints::AbsoluteAccelerationAngular2DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_orientation_3d_stamped_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <geometry_msgs/Quaternion.h>
@@ -158,6 +159,37 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
     0.1, 2.0, 0.3,
     0.2, 0.3, 3.0;
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation3DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  fuse_core::Vector4d mean;
+  mean << 1.0, 0.0, 0.0, 0.0;
+  fuse_core::Matrix3d cov;
+  cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
+  AbsoluteOrientation3DStampedConstraint expected(orientation_variable, mean, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  AbsoluteOrientation3DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -33,6 +33,7 @@
  */
 #include <fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h>
 #include <fuse_core/eigen.h>
+#include <fuse_core/eigen_gtest.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <geometry_msgs/Quaternion.h>
@@ -209,6 +210,39 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationPartial)
   EXPECT_NEAR(expected.z(), orientation_variable->z(), 5.0e-3);
 
   // TODO(swilliams) Determine what I expect the covariance matrix to be and test it here
+}
+
+TEST(AbsoluteOrientation3DStampedEulerConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  fuse_core::Vector3d mean;
+  mean << 1.0, 2.0, 3.0;
+  fuse_core::Matrix3d cov;
+  cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
+  std::vector<Orientation3DStamped::Euler> axes =
+    {Orientation3DStamped::Euler::YAW, Orientation3DStamped::Euler::ROLL, Orientation3DStamped::Euler::PITCH};
+  AbsoluteOrientation3DStampedEulerConstraint expected(orientation_variable, mean, cov, axes);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  AbsoluteOrientation3DStampedEulerConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
@@ -264,6 +265,38 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   expected_covariance(1, 1) = cov2(0, 0);
 
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-9);
+}
+
+TEST(AbsolutePose2DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  Position2DStamped position_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  fuse_core::Vector3d mean;
+  mean << 1.0, 2.0, 3.0;
+  fuse_core::Matrix3d cov;
+  cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
+  AbsolutePose2DStampedConstraint expected(position_variable, orientation_variable, mean, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  AbsolutePose2DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
@@ -34,6 +34,7 @@
 #include <fuse_constraints/absolute_pose_3d_stamped_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_3d_stamped.h>
@@ -60,7 +61,7 @@ TEST(AbsolutePose3DStampedConstraint, Constructor)
   fuse_core::Vector7d mean;
   mean << 1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0;
 
-  // Generated PD matrix using Octiave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
+  // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
   cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
          1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
@@ -209,6 +210,47 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
     0.5, 0.3, 0.2, 0.4, 0.5, 6.0;
 
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-5);
+}
+
+TEST(AbsolutePose3DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Position3DStamped position_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  Orientation3DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+
+  fuse_core::Vector7d mean;
+  mean << 1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0;
+
+  // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
+  fuse_core::Matrix6d cov;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
+         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
+         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+
+  AbsolutePose3DStampedConstraint expected(position_variable, orientation_variable, mean, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  AbsolutePose3DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -34,12 +34,14 @@
 #include <fuse_constraints/marginal_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <ros/time.h>
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 
@@ -157,7 +159,7 @@ TEST(MarginalConstraint, TwoVariables)
 
 TEST(MarginalConstraint, LocalParameterization)
 {
-  // Create a marginal constraint with one variable, no local parameterizations
+  // Create a marginal constraint with one variable with a local parameterizations
   std::vector<fuse_variables::Orientation3DStamped> variables;
   fuse_variables::Orientation3DStamped x1(ros::Time(1, 0));
   x1.w() = 0.842614977;
@@ -209,6 +211,61 @@ TEST(MarginalConstraint, LocalParameterization)
   EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);
 
   delete cost_function;
+}
+
+TEST(MarginalConstraint, Serialization)
+{
+  // Construct a constraint
+  std::vector<fuse_variables::Orientation3DStamped> variables;
+  fuse_variables::Orientation3DStamped x1(ros::Time(1, 0));
+  x1.w() = 0.842614977;
+  x1.x() = 0.2;
+  x1.y() = 0.3;
+  x1.z() = 0.4;
+  variables.push_back(x1);
+
+  std::vector<fuse_core::MatrixXd> A;
+  fuse_core::MatrixXd A1(1, 3);
+  A1 << 5.0, 6.0, 7.0;
+  A.push_back(A1);
+
+  fuse_core::Vector1d b;
+  b << 8.0;
+
+  auto expected = fuse_constraints::MarginalConstraint(variables.begin(),
+                                                         variables.end(),
+                                                         A.begin(),
+                                                         A.end(),
+                                                         b);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  fuse_constraints::MarginalConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_EQ(expected.A(), actual.A());
+  EXPECT_EQ(expected.b(), actual.b());
+  EXPECT_EQ(expected.x_bar(), actual.x_bar());
+  // The shared ptrs will not be the same instances, but they should point to the same types
+  using ExpectedLocalParam = fuse_variables::Orientation3DLocalParameterization;
+  ASSERT_EQ(expected.localParameterizations().size(), actual.localParameterizations().size());
+  for (auto i = 0u; i < actual.localParameterizations().size(); ++i)
+  {
+    auto actual_derived = std::dynamic_pointer_cast<ExpectedLocalParam>(actual.localParameterizations()[i]);
+    EXPECT_TRUE(static_cast<bool>(actual_derived));
+  }
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -118,6 +118,22 @@ public:
   void print(std::ostream& /*stream = std::cout*/) const override {}
 
   ceres::CostFunction* costFunction() const override { return nullptr; }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+  }
 };
 
 

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -39,11 +39,15 @@
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_graphs/hash_graph.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <ceres/cost_function.h>
 #include <gtest/gtest.h>
 
@@ -74,7 +78,26 @@ public:
 
 protected:
   double data_;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & data_;
+  }
 };
+
+BOOST_CLASS_EXPORT(GenericVariable);
 
 /**
  * @brief Create a simple Constraint implementation for testing

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -34,6 +34,8 @@
 #include <fuse_constraints/absolute_constraint.h>
 #include <fuse_constraints/relative_constraint.h>
 #include <fuse_core/eigen.h>
+#include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
@@ -434,6 +436,38 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   fuse_core::Matrix1d x2_expected_covariance;
   x2_expected_covariance << 3.0;
   EXPECT_TRUE(x2_expected_covariance.isApprox(x2_actual_covariance, 1.0e-9));
+}
+
+TEST(RelativeConstraint, Serialization)
+{
+  // Construct a constraint
+  fuse_variables::AccelerationAngular2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("robby"));
+  fuse_variables::AccelerationAngular2DStamped x2(ros::Time(1235, 5678), fuse_core::uuid::generate("robby"));
+  fuse_core::Vector1d delta;
+  delta << 3.0;
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  fuse_constraints::RelativeAccelerationAngular2DStampedConstraint expected(x1, x2, delta, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  fuse_constraints::RelativeAccelerationAngular2DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.delta(), actual.delta());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
@@ -35,6 +35,7 @@
 #include <fuse_constraints/relative_pose_2d_stamped_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
@@ -419,6 +420,40 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
     expected_covariance << 2.0, 0.0, 0.0, 0.0, 3.0, 1.0, 0.0, 1.0, 2.0;
     EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-9);
   }
+}
+
+TEST(RelativePose2DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation2DStamped orientation1(ros::Time(1234, 5678), fuse_core::uuid::generate("r5d4"));
+  Position2DStamped position1(ros::Time(1234, 5678), fuse_core::uuid::generate("r5d4"));
+  Orientation2DStamped orientation2(ros::Time(1235, 5678), fuse_core::uuid::generate("r5d4"));
+  Position2DStamped position2(ros::Time(1235, 5678), fuse_core::uuid::generate("r5d4"));
+  fuse_core::Vector3d delta;
+  delta << 1.0, 2.0, 3.0;
+  fuse_core::Matrix3d cov;
+  cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
+  RelativePose2DStampedConstraint expected(position1, orientation1, position2, orientation2, delta, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  RelativePose2DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.delta(), actual.delta());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
@@ -35,6 +35,7 @@
 #include <fuse_constraints/relative_pose_3d_stamped_constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 #include <fuse_variables/position_3d_stamped.h>
@@ -64,7 +65,7 @@ TEST(RelativePose3DStampedConstraint, Constructor)
   fuse_core::Vector7d delta;
   delta << 1.0, 2.0, 3.0, 0.988, 0.094, 0.079, 0.094;
 
-  // Generated PD matrix using Octiave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
+  // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
   cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
          1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
@@ -298,6 +299,49 @@ TEST(RelativePose3DStampedConstraint, Optimization)
 
     EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-9);
   }
+}
+
+TEST(RelativePose3DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation3DStamped orientation1(ros::Time(1234, 5678), fuse_core::uuid::generate("r5d4"));
+  Position3DStamped position1(ros::Time(1234, 5678), fuse_core::uuid::generate("r5d4"));
+  Orientation3DStamped orientation2(ros::Time(1235, 5678), fuse_core::uuid::generate("r5d4"));
+  Position3DStamped position2(ros::Time(1235, 5678), fuse_core::uuid::generate("r5d4"));
+
+  fuse_core::Vector7d delta;
+  delta << 1.0, 2.0, 3.0, 0.988, 0.094, 0.079, 0.094;
+
+  // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
+  fuse_core::Matrix6d cov;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
+         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
+         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+
+  RelativePose3DStampedConstraint expected(position1, orientation1, position2, orientation2, delta, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  RelativePose3DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.delta(), actual.delta());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
 int main(int argc, char **argv)

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(fuse_core)
 
 set(build_depends
+  fuse_msgs
+  pluginlib
   roscpp
 )
 
@@ -38,8 +40,11 @@ add_library(${PROJECT_NAME}
   src/async_sensor_model.cpp
   src/constraint.cpp
   src/graph.cpp
+  src/graph_deserializer.cpp
+  src/serialization.cpp
   src/timestamp_manager.cpp
   src/transaction.cpp
+  src/transaction_deserializer.cpp
   src/variable.cpp
 )
 add_dependencies(${PROJECT_NAME}
@@ -59,6 +64,23 @@ target_link_libraries(${PROJECT_NAME}
   ${CERES_LIBRARIES}
 )
 
+# fuse_echo executable
+add_executable(fuse_echo
+  src/fuse_echo.cpp
+)
+add_dependencies(fuse_echo
+  ${catkin_EXPORTED_TARGETS}
+)
+target_include_directories(fuse_echo
+  PUBLIC
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(fuse_echo
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
 #############
 ## Install ##
 #############
@@ -68,6 +90,11 @@ install(
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(
+  TARGETS fuse_echo
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 install(

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -8,22 +8,21 @@ set(build_depends
 find_package(catkin REQUIRED COMPONENTS
   ${build_depends}
 )
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS serialization)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS
     include
-    ${CERES_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
-    ${CERES_LIBRARIES}
   CATKIN_DEPENDS
     ${build_depends}
   DEPENDS
     Boost
+    CERES
+    EIGEN3
 )
 
 ###########
@@ -55,6 +54,7 @@ target_include_directories(${PROJECT_NAME}
     ${EIGEN3_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME}
+  ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
   ${CERES_LIBRARIES}
 )

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -35,9 +35,11 @@
 #define FUSE_CORE_CONSTRAINT_H
 
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
-#include <boost/core/demangle.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/vector.hpp>
 #include <boost/type_index/stl_type_index.hpp>
 #include <ceres/cost_function.h>
 #include <ceres/loss_function.h>
@@ -65,6 +67,37 @@
   fuse_core::Constraint::UniquePtr clone() const override \
   { \
     return __VA_ARGS__::make_unique(*this); \
+  }
+
+/**
+ * @brief Implementation of the serialize() and deserialize() member functions for derived classes
+ *
+ * Usage:
+ * @code{.cpp}
+ * class Derived : public Constraint
+ * {
+ * public:
+ *   FUSE_CONSTRAINT_SERIALIZE_DEFINITION(Derived);
+ *   // The rest of the derived constraint implementation
+ * }
+ * @endcode
+ */
+#define FUSE_CONSTRAINT_SERIALIZE_DEFINITION(...) \
+  void serialize(fuse_core::BinaryOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void serialize(fuse_core::TextOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::BinaryInputArchive& archive) override \
+  { \
+    archive >> *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::TextInputArchive& archive) override \
+  { \
+    archive >> *this; \
   }
 
 /**
@@ -111,11 +144,12 @@
 #define FUSE_CONSTRAINT_DEFINITIONS(...) \
   SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_CONSTRAINT_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__)
+  FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__) \
+  FUSE_CONSTRAINT_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 /**
  * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
- *        for derived Variable classes that have fixed-sized Eigen member objects.
+ *        for derived Constraint classes that have fixed-sized Eigen member objects.
  *
  * Usage:
  * @code{.cpp}
@@ -130,7 +164,8 @@
 #define FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(...) \
   SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
   FUSE_CONSTRAINT_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__)
+  FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__) \
+  FUSE_CONSTRAINT_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 
 namespace fuse_core
@@ -156,6 +191,11 @@ class Constraint
 {
 public:
   SMART_PTR_ALIASES_ONLY(Constraint);
+
+  /**
+   * @brief Default constructor
+   */
+  Constraint() = default;
 
   /**
    * @brief Constructor
@@ -188,7 +228,7 @@ public:
    * The constraint type string must be unique for each class. As such, the fully-qualified class name is an excellent
    * choice for the type string.
    */
-  virtual std::string type() const { return boost::core::demangle(typeid(*this).name()); }
+  virtual std::string type() const = 0;
 
   /**
    * @brief Returns the UUID for this constraint.
@@ -259,9 +299,77 @@ public:
    */
   const std::vector<UUID>& variables() const { return variables_; }
 
-protected:
+  /**
+   * @brief Serialize this Constraint into the provided binary archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this constraint into
+   */
+  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Serialize this Constraint into the provided text archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this constraint into
+   */
+  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Deserialize data from the provided binary archive into this Constraint
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized Constraint data
+   */
+  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
+
+  /**
+   * @brief Deserialize data from the provided text archive into this Constraint
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized Constraint data
+   */
+  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
+
+private:
   UUID uuid_;  //!< The unique ID associated with this constraint
   std::vector<UUID> variables_;  //!< The ordered set of variables involved with this constraint
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * This method, or a combination of save() and load() methods, must be implemented by all derived classes. See
+   * documentation on Boost Serialization for information on how to implement the serialize() method.
+   * https://www.boost.org/doc/libs/1_70_0/libs/serialization/doc/
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & uuid_;
+    archive & variables_;
+  }
 };
 
 /**

--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -36,17 +36,100 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 
+#include <boost/core/demangle.hpp>
 #include <boost/range/any_range.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/type_index/stl_type_index.hpp>
 #include <ceres/covariance.h>
 #include <ceres/solver.h>
 
 #include <ostream>
+#include <string>
 #include <utility>
 #include <vector>
+
+
+/**
+ * @brief Implementation of the serialize() and deserialize() member functions for derived classes
+ *
+ * Usage:
+ * @code{.cpp}
+ * class Derived : public Graph
+ * {
+ * public:
+ *   FUSE_GRAPH_SERIALIZE_DEFINITION(Derived);
+ *   // The rest of the derived graph implementation
+ * }
+ * @endcode
+ */
+#define FUSE_GRAPH_SERIALIZE_DEFINITION(...) \
+  void serialize(fuse_core::BinaryOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void serialize(fuse_core::TextOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::BinaryInputArchive& archive) override \
+  { \
+    archive >> *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::TextInputArchive& archive) override \
+  { \
+    archive >> *this; \
+  }
+
+/**
+ * @brief Implements the type() member function using the suggested implementation
+ *
+ * Also creates a static detail::type() function that may be used without an object instance
+ *
+ * Usage:
+ * @code{.cpp}
+ * class Derived : public Graph
+ * {
+ * public:
+ *   FUSE_GRAPH_TYPE_DEFINITION(Derived);
+ *   // The rest of the derived graph implementation
+ * }
+ * @endcode
+ */
+#define FUSE_GRAPH_TYPE_DEFINITION(...) \
+  struct detail \
+  { \
+    static std::string type() \
+    { \
+      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>().pretty_name(); \
+    }  /* NOLINT */ \
+  };  /* NOLINT */ \
+  std::string type() const override \
+  { \
+    return detail::type(); \
+  }
+
+/**
+* @brief Convenience function that creates the required pointer aliases, and type() method
+*
+* Usage:
+* @code{.cpp}
+* class Derived : public Graph
+* {
+* public:
+*   FUSE_GRAPH_DEFINITIONS(Derived);
+*   // The rest of the derived graph implementation
+* }
+* @endcode
+*/
+#define FUSE_GRAPH_DEFINITIONS(...) \
+  SMART_PTR_DEFINITIONS(__VA_ARGS__) \
+  FUSE_GRAPH_TYPE_DEFINITION(__VA_ARGS__) \
+  FUSE_GRAPH_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 
 namespace fuse_core
@@ -93,6 +176,14 @@ public:
    * @brief Destructor
    */
   virtual ~Graph() = default;
+
+  /**
+   * @brief Returns a unique name for this graph type.
+   *
+   * The constraint type string must be unique for each class. As such, the fully-qualified class name is an excellent
+   * choice for the type string.
+   */
+  virtual std::string type() const = 0;
 
   /**
    * @brief Clear all variables and constraints from the graph object.
@@ -270,6 +361,73 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   virtual void print(std::ostream& stream = std::cout) const = 0;
+
+  /**
+   * @brief Serialize this graph into the provided binary archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this graph into
+   */
+  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Serialize this graph into the provided text archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this graph into
+   */
+  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Deserialize data from the provided binary archive into this graph
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized graph data
+   */
+  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
+
+  /**
+   * @brief Deserialize data from the provided text archive into this graph
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized graph data
+   */
+  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * This method, or a combination of save() and load() methods, must be implemented by all derived classes. See
+   * documentation on Boost Serialization for information on how to implement the serialize() method.
+   * https://www.boost.org/doc/libs/1_70_0/libs/serialization/doc/
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& /* archive */, const unsigned int /* version */)
+  {
+  }
 };
 
 /**

--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -1,0 +1,97 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_GRAPH_DESERIALIZER_H
+#define FUSE_CORE_GRAPH_DESERIALIZER_H
+
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_core/constraint.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/variable.h>
+#include <pluginlib/class_loader.h>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief Serialize a graph into a message
+ */
+void serializeGraph(const fuse_core::Graph& graph, fuse_msgs::SerializedGraph& msg);
+
+/**
+ * @brief Deserialize a graph
+ *
+ * The deserializer object loads all of the known Variable and Constraint libraries, allowing derived types contained
+ * within the graph to be properly deserialized. The libraries will be unloaded on destruction. As a consequence, the
+ * deserializer object must outlive any created graph instances.
+ */
+class GraphDeserializer
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  GraphDeserializer();
+
+  /**
+   * @brief Deserialize a SerializedGraph message into a fuse Graph object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[in]  msg  The SerializedGraph message to be deserialized
+   * @return          A unique_ptr to a derived Graph object
+   */
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg);
+
+  /**
+   * @brief Deserialize a SerializedGraph message into a fuse Graph object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[in]  msg  The SerializedGraph message to be deserialized
+   * @return          A unique_ptr to a derived Graph object
+   */
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg);
+
+private:
+  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
+  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
+  pluginlib::ClassLoader<fuse_core::Graph> graph_loader_;  //!< Pluginlib class loader for Graph types
+};
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_GRAPH_DESERIALIZER_H

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -35,7 +35,9 @@
 #define FUSE_CORE_LOCAL_PARAMETERIZATION_H
 
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 
+#include <boost/serialization/access.hpp>
 #include <ceres/local_parameterization.h>
 
 
@@ -86,6 +88,21 @@ public:
   virtual bool ComputeMinusJacobian(
     const double* x,
     double* jacobian) const = 0;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& /* archive */, const unsigned int /* version */)
+  {
+  }
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/serialization.h
+++ b/fuse_core/include/fuse_core/serialization.h
@@ -1,0 +1,143 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_SERIALIZATION_H
+#define FUSE_CORE_SERIALIZATION_H
+
+#include <fuse_core/uuid.h>
+
+#include <ros/time.h>
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/uuid/uuid_serialize.hpp>
+#include <Eigen/Core>
+
+
+namespace fuse_core
+{
+  using BinaryInputArchive = boost::archive::binary_iarchive;
+  using BinaryOutputArchive = boost::archive::binary_oarchive;
+  using TextInputArchive = boost::archive::text_iarchive;
+  using TextOutputArchive = boost::archive::text_oarchive;
+}
+
+namespace boost
+{
+namespace serialization
+{
+
+/**
+ * @brief Serialize a ros::Time variable using Boost Serialization
+ */
+template<class Archive>
+void serialize(Archive& archive, ros::Time& stamp, const unsigned int /* version */)
+{
+  archive & stamp.sec;
+  archive & stamp.nsec;
+}
+
+/**
+ * @brief Serialize an Eigen Matrix using Boost Serialization
+ */
+template<class Archive,
+         class S,
+         int Rows_,
+         int Cols_,
+         int Ops_,
+         int MaxRows_,
+         int MaxCols_>
+inline void save(
+  Archive& archive,
+  const Eigen::Matrix<S, Rows_, Cols_, Ops_, MaxRows_, MaxCols_>& matrix,
+  const unsigned int /* version */)
+{
+  int rows = matrix.rows();
+  int cols = matrix.cols();
+
+  archive & rows;
+  archive & cols;
+  archive & boost::serialization::make_array(matrix.data(), rows * cols);
+}
+
+/**
+ * @brief Deserialize an Eigen Matrix using Boost Serialization
+ */
+template<class Archive,
+         class S,
+         int Rows_,
+         int Cols_,
+         int Ops_,
+         int MaxRows_,
+         int MaxCols_>
+inline void load(
+  Archive& archive,
+  Eigen::Matrix<S, Rows_, Cols_, Ops_, MaxRows_, MaxCols_>& matrix,
+  const unsigned int /* version */)
+{
+  int rows, cols;
+  archive & rows;
+  archive & cols;
+  matrix.resize(rows, cols);
+  archive & boost::serialization::make_array(matrix.data(), rows * cols);
+}
+
+/**
+ * @brief Indicate the Eigen Matrix serialization uses separate save() and load() methods
+ */
+template<class Archive,
+         class S,
+         int Rows_,
+         int Cols_,
+         int Ops_,
+         int MaxRows_,
+         int MaxCols_>
+inline void serialize(
+  Archive& archive,
+  Eigen::Matrix<S, Rows_, Cols_, Ops_, MaxRows_, MaxCols_>& matrix,
+  const unsigned int version)
+{
+  split_free(archive, matrix, version);
+}
+
+}  // namespace serialization
+}  // namespace boost
+
+#endif  // FUSE_CORE_SERIALIZATION_H

--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -36,11 +36,16 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <ros/time.h>
 
 #include <boost/range/any_range.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/set.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include <ostream>
 #include <set>
@@ -224,13 +229,61 @@ public:
    */
   Transaction::UniquePtr clone() const;
 
-protected:
+  /**
+   * @brief Serialize this Constraint into the provided binary archive
+   *
+   * @param[out] archive - The archive to serialize this constraint into
+   */
+  void serialize(fuse_core::BinaryOutputArchive& /* archive */) const;
+
+  /**
+   * @brief Serialize this Constraint into the provided text archive
+   *
+   * @param[out] archive - The archive to serialize this constraint into
+   */
+  void serialize(fuse_core::TextOutputArchive& /* archive */) const;
+
+  /**
+   * @brief Deserialize data from the provided binary archive into this Constraint
+   *
+   * @param[in] archive - The archive holding serialized Constraint data
+   */
+  void deserialize(fuse_core::BinaryInputArchive& /* archive */);
+
+  /**
+   * @brief Deserialize data from the provided text archive into this Constraint
+   *
+   * @param[in] archive - The archive holding serialized Constraint data
+   */
+  void deserialize(fuse_core::TextInputArchive& /* archive */);
+
+private:
   ros::Time stamp_;  //!< The transaction message timestamp
   std::vector<Constraint::SharedPtr> added_constraints_;  //!< The constraints to be added
   std::vector<Variable::SharedPtr> added_variables_;  //!< The variables to be added
   std::set<ros::Time> involved_stamps_;  //!< The set of timestamps involved in this transaction
   std::vector<UUID> removed_constraints_;  //!< The constraint UUIDs to be removed
   std::vector<UUID> removed_variables_;  //!< The variable UUIDs to be removed
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & stamp_;
+    archive & added_constraints_;
+    archive & added_variables_;
+    archive & involved_stamps_;
+    archive & removed_constraints_;
+    archive & removed_variables_;
+  }
 };
 
 /**

--- a/fuse_core/include/fuse_core/transaction_deserializer.h
+++ b/fuse_core/include/fuse_core/transaction_deserializer.h
@@ -1,0 +1,96 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_TRANSACTION_DESERIALIZER_H
+#define FUSE_CORE_TRANSACTION_DESERIALIZER_H
+
+#include <fuse_msgs/SerializedTransaction.h>
+#include <fuse_core/constraint.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/variable.h>
+#include <pluginlib/class_loader.h>
+
+
+namespace fuse_core
+{
+
+/**
+ * @brief Serialize a transaction into a message
+ */
+void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::SerializedTransaction& msg);
+
+/**
+ * @brief Deserialize a Transaction
+ *
+ * The deserializer object loads all of the known Variable and Constraint libraries, allowing derived types contained
+ * within the transaction to be properly deserialized. The libraries will be unloaded on destruction. As a consequence,
+ * the deserializer object must outlive any created transaction instances.
+ */
+class TransactionDeserializer
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  TransactionDeserializer();
+
+  /**
+   * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedTransaction message to be deserialized
+   * @return          A fuse Transaction object
+   */
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg);
+
+  /**
+   * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
+   *
+   * If no plugin is available for a contained Variable or Constraint, or an error occurs during deserialization,
+   * an exception is thrown.
+   *
+   * @param[IN]  msg  The SerializedTransaction message to be deserialized
+   * @return          A fuse Transaction object
+   */
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction& msg);
+
+private:
+  pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;  //!< Pluginlib class loader for Variable types
+  pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
+};
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_TRANSACTION_DESERIALIZER_H

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -36,8 +36,10 @@
 
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
+#include <boost/serialization/access.hpp>
 #include <boost/type_index/stl_type_index.hpp>
 
 #include <ostream>
@@ -61,6 +63,37 @@
   fuse_core::Variable::UniquePtr clone() const override \
   { \
     return __VA_ARGS__::make_unique(*this); \
+  }
+
+/**
+ * @brief Implementation of the serialize() and deserialize() member functions for derived classes
+ *
+ * Usage:
+ * @code{.cpp}
+ * class Derived : public Variable
+ * {
+ * public:
+ *   FUSE_VARIABLE_SERIALIZE_DEFINITION(Derived);
+ *   // The rest of the derived variable implementation
+ * }
+ * @endcode
+ */
+#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...) \
+  void serialize(fuse_core::BinaryOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void serialize(fuse_core::TextOutputArchive& archive) const override \
+  { \
+    archive << *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::BinaryInputArchive& archive) override \
+  { \
+    archive >> *this; \
+  }  /* NOLINT */ \
+  void deserialize(fuse_core::TextInputArchive& archive) override \
+  { \
+    archive >> *this; \
   }
 
 /**
@@ -107,7 +140,8 @@
 #define FUSE_VARIABLE_DEFINITIONS(...) \
   SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+  FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 /**
  * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
@@ -126,7 +160,8 @@
 #define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...) \
   SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
   FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+  FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 
 namespace fuse_core
@@ -153,6 +188,11 @@ class Variable
 {
 public:
   SMART_PTR_ALIASES_ONLY(Variable);
+
+  /**
+   * @brief Default constructor
+   */
+  Variable() = default;
 
   /**
    * @brief Constructor
@@ -276,8 +316,75 @@ public:
     return nullptr;
   }
 
+  /**
+   * @brief Serialize this Variable into the provided binary archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this variable into
+   */
+  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Serialize this Variable into the provided text archive
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive << *this;
+   * @endcode
+   *
+   * @param[out] archive - The archive to serialize this variable into
+   */
+  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
+
+  /**
+   * @brief Deserialize data from the provided binary archive into this Variable
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized Variable data
+   */
+  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
+
+  /**
+   * @brief Deserialize data from the provided text archive into this Variable
+   *
+   * This can/should be implemented as follows in all derived classes:
+   * @code{.cpp}
+   * archive >> *this;
+   * @endcode
+   *
+   * @param[in] archive - The archive holding serialized Variable data
+   */
+  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
+
 private:
   fuse_core::UUID uuid_;  //!< The unique ID number for this variable
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * This method, or a combination of save() and load() methods, must be implemented by all derived classes. See
+   * documentation on Boost Serialization for information on how to implement the serialize() method.
+   * https://www.boost.org/doc/libs/1_70_0/libs/serialization/doc/
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & uuid_;
+  }
 };
 
 /**

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -14,6 +14,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>
+  <depend>fuse_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>

--- a/fuse_core/src/fuse_echo.cpp
+++ b/fuse_core/src/fuse_echo.cpp
@@ -1,0 +1,94 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_msgs/SerializedTransaction.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/transaction_deserializer.h>
+#include <ros/ros.h>
+
+
+/**
+ * Class that subscribes to the 'graph' and 'transaction' topics and prints the objects to stdout
+ */
+class FuseEcho
+{
+public:
+  explicit FuseEcho(const ros::NodeHandle& node_handle = ros::NodeHandle()) :
+    node_handle_(node_handle)
+  {
+    // Subscribe to the constraint topic
+    graph_subscriber_ = node_handle_.subscribe("graph", 100, &FuseEcho::graphCallback, this);
+    transaction_subscriber_ = node_handle_.subscribe("transaction", 100, &FuseEcho::transactionCallback, this);
+  }
+
+private:
+  fuse_core::GraphDeserializer graph_deserializer_;
+  fuse_core::TransactionDeserializer transaction_deserializer_;
+  ros::NodeHandle node_handle_;
+  ros::Subscriber graph_subscriber_;
+  ros::Subscriber transaction_subscriber_;
+
+  void graphCallback(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+  {
+    std::cout << "-------------------------" << std::endl;
+    std::cout << "GRAPH:" << std::endl;
+    std::cout << "received at: " << ros::Time::now() << std::endl;
+    auto graph = graph_deserializer_.deserialize(msg);
+    graph->print();
+  }
+
+  void transactionCallback(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+  {
+    std::cout << "-------------------------" << std::endl;
+    std::cout << "TRANSACTION:" << std::endl;
+    std::cout << "received at: " << ros::Time::now() << std::endl;
+    auto transaction = transaction_deserializer_.deserialize(msg);
+    transaction.print();
+  }
+};
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "fuse_echo", ros::init_options::AnonymousName);
+
+  // Object that subscribes to the 'graph' and 'transaction' topics and prints the objects to stdout
+  FuseEcho echoer;
+
+  // Wait for an exit signal
+  ros::spin();
+
+  return 0;
+}

--- a/fuse_core/src/graph_deserializer.cpp
+++ b/fuse_core/src/graph_deserializer.cpp
@@ -1,0 +1,98 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/graph_deserializer.h>
+
+#include <fuse_core/serialization.h>
+#include <fuse_msgs/SerializedGraph.h>
+
+#include <boost/iostreams/stream.hpp>
+
+
+namespace fuse_core
+{
+
+void serializeGraph(const fuse_core::Graph& graph, fuse_msgs::SerializedGraph& msg)
+{
+  // Serialize the graph into the msg.data field
+  boost::iostreams::stream<fuse_core::MessageBufferStreamSink> stream(msg.data);
+  // Scope the archive object. The archive is not guaranteed to write to the stream until the archive goes out of scope.
+  {
+    BinaryOutputArchive archive(stream);
+    graph.serialize(archive);
+  }
+  // Set the plugin name using the graph's type() member function (blindly assuming these are the same thing)
+  msg.plugin_name = graph.type();
+}
+
+GraphDeserializer::GraphDeserializer() :
+  variable_loader_("fuse_core", "fuse_core::Variable"),
+  constraint_loader_("fuse_core", "fuse_core::Constraint"),
+  graph_loader_("fuse_core", "fuse_core::Graph")
+{
+  // Load all known plugin libraries
+  // I believe the library containing a given Variable or Constraint type must be loaded in order to deserialize
+  // an object of that type. But I haven't actually tested that theory.
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.loadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.loadLibraryForClass(class_name);
+  }
+}
+
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+{
+  return deserialize(*msg);
+}
+
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph& msg)
+{
+  // Create a Graph object using pluginlib. This will throw if the plugin name is not found.
+  // The unique ptr returned by pluginlib has a custom deleter. This makes it annoying to return
+  // back to the user as the output is not equivalent to fuse_core::Graph::UniquePtr. Instead, wrap an
+  // unmanaged raw pointer in a unique_ptr, and handle the library unloading in the destructor.
+  auto graph = fuse_core::Graph::UniquePtr(graph_loader_.createUnmanagedInstance(msg.plugin_name));
+  // Deserialize the msg.data field into the graph.
+  // This will throw if something goes wrong in the deserialization.
+  boost::iostreams::stream<fuse_core::MessageBufferStreamSource> stream(msg.data);
+  {
+    BinaryInputArchive archive(stream);
+    graph->deserialize(archive);
+  }
+  return graph;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/serialization.cpp
+++ b/fuse_core/src/serialization.cpp
@@ -1,0 +1,75 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/serialization.h>
+
+#include <algorithm>
+#include <vector>
+
+
+namespace fuse_core
+{
+
+MessageBufferStreamSource::MessageBufferStreamSource(const std::vector<unsigned char>& data) :
+  data_(data),
+  index_(0)
+{
+}
+
+std::streamsize MessageBufferStreamSource::read(char_type* s, std::streamsize n)
+{
+  std::streamsize result = std::min(n, static_cast<std::streamsize>(data_.size() - index_));
+  if (result != 0)
+  {
+    std::copy(data_.begin() + index_, data_.begin() + index_ + result, s);
+    index_ += result;
+    return result;
+  }
+  else
+  {
+    return -1;  // EOF
+  }
+}
+
+MessageBufferStreamSink::MessageBufferStreamSink(std::vector<unsigned char>& data) :
+  data_(data)
+{
+}
+
+std::streamsize MessageBufferStreamSink::write(const char_type* s, std::streamsize n)
+{
+  data_.insert(data_.end(), s, s + n);
+  return n;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -236,6 +236,26 @@ Transaction::UniquePtr Transaction::clone() const
   return Transaction::make_unique(*this);
 }
 
+void Transaction::serialize(fuse_core::BinaryOutputArchive& archive) const
+{
+  archive << *this;
+}
+
+void Transaction::serialize(fuse_core::TextOutputArchive& archive) const
+{
+  archive << *this;
+}
+
+void Transaction::deserialize(fuse_core::BinaryInputArchive& archive)
+{
+  archive >> *this;
+}
+
+void Transaction::deserialize(fuse_core::TextInputArchive& archive)
+{
+  archive >> *this;
+}
+
 std::ostream& operator <<(std::ostream& stream, const Transaction& transaction)
 {
   transaction.print(stream);

--- a/fuse_core/src/transaction_deserializer.cpp
+++ b/fuse_core/src/transaction_deserializer.cpp
@@ -1,0 +1,92 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/transaction_deserializer.h>
+
+#include <fuse_core/serialization.h>
+#include <fuse_msgs/SerializedTransaction.h>
+
+#include <boost/iostreams/stream.hpp>
+
+
+namespace fuse_core
+{
+
+void serializeTransaction(const fuse_core::Transaction& transaction, fuse_msgs::SerializedTransaction& msg)
+{
+  // Serialize the transaction into the msg.data field
+  boost::iostreams::stream<fuse_core::MessageBufferStreamSink> stream(msg.data);
+  // Scope the archive object. The archive is not guaranteed to write to the stream until the archive goes out of scope.
+  {
+    BinaryOutputArchive archive(stream);
+    transaction.serialize(archive);
+  }
+}
+
+TransactionDeserializer::TransactionDeserializer() :
+  variable_loader_("fuse_core", "fuse_core::Variable"),
+  constraint_loader_("fuse_core", "fuse_core::Constraint")
+{
+  // Load all known plugin libraries
+  // I believe the library containing a given Variable or Constraint must be loaded in order to deserialize
+  // an object of that type. But I haven't actually tested that theory.
+  for (const auto& class_name : variable_loader_.getDeclaredClasses())
+  {
+    variable_loader_.loadLibraryForClass(class_name);
+  }
+  for (const auto& class_name : constraint_loader_.getDeclaredClasses())
+  {
+    constraint_loader_.loadLibraryForClass(class_name);
+  }
+}
+
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+{
+  return deserialize(*msg);
+}
+
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction& msg)
+{
+  // The Transaction object is not a plugin and has no derived types. That makes it much easier to use.
+  auto transaction = fuse_core::Transaction();
+  // Deserialize the msg.data field into the transaction.
+  // This will throw if something goes wrong in the deserialization.
+  boost::iostreams::stream<fuse_core::MessageBufferStreamSource> stream(msg.data);
+  {
+    BinaryInputArchive archive(stream);
+    transaction.deserialize(archive);
+  }
+  return transaction;
+}
+
+}  // namespace fuse_core

--- a/fuse_core/test/example_constraint.h
+++ b/fuse_core/test/example_constraint.h
@@ -36,7 +36,12 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <initializer_list>
 
@@ -48,6 +53,8 @@ class ExampleConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+
+  ExampleConstraint() = default;
 
   ExampleConstraint(std::initializer_list<fuse_core::UUID> variable_uuid_list) :
     fuse_core::Constraint(variable_uuid_list),
@@ -66,6 +73,25 @@ public:
   ceres::CostFunction* costFunction() const override { return nullptr; }
 
   double data;  // Public member variable just for testing
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & data;
+  }
 };
+
+BOOST_CLASS_EXPORT(ExampleConstraint);
 
 #endif  // FUSE_CORE_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}

--- a/fuse_core/test/example_variable.h
+++ b/fuse_core/test/example_variable.h
@@ -35,8 +35,13 @@
 #define FUSE_CORE_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 
 /**
@@ -60,6 +65,24 @@ public:
 
 private:
   double data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & data_;
+  }
 };
+
+BOOST_CLASS_EXPORT(ExampleVariable);
 
 #endif  // FUSE_CORE_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}

--- a/fuse_core/test/test_transaction.cpp
+++ b/fuse_core/test/test_transaction.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_core/transaction.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <test/example_constraint.h>
 #include <test/example_variable.h>
@@ -51,16 +52,17 @@ using fuse_core::UUID;
  *
  * Order of the stamps is not important. Extra stamps in the Transaction will return False.
  *
- * @param expected_stamps  The set of expected stamps
- * @param transaction      The transaction to test
- * @return                 True if the expected stamps, and only the expected stamps, exist in the
- *                         transaction, False otherwise.
+ * @tparam TimeRange   A range or container with objects compatible with a "const ros::Time&" signature
+ * @param expected     The set of expected stamps
+ * @param transaction  The transaction to test
+ * @return             True if the expected stamps, and only the expected stamps, exist in the
+ *                     transaction, False otherwise.
  */
-bool testInvolvedStamps(
-  const std::vector<ros::Time>& expected_stamps, const Transaction& transaction)
+template <typename TimeRange>
+bool testInvolvedStamps(const TimeRange& expected, const Transaction& transaction)
 {
   auto range = transaction.involvedStamps();
-  if (static_cast<int>(expected_stamps.size()) != std::distance(range.begin(), range.end()))
+  if (std::distance(expected.begin(), expected.end()) != std::distance(range.begin(), range.end()))
   {
     return false;
   }
@@ -70,7 +72,7 @@ bool testInvolvedStamps(
     const auto& actual_stamp = *iter;
 
     bool found = false;
-    for (const auto& expected_stamp : expected_stamps)
+    for (const auto& expected_stamp : expected)
     {
       if (actual_stamp == expected_stamp)
       {
@@ -94,16 +96,17 @@ bool testInvolvedStamps(
  *
  * Order of the constraints is not important. Extra constraints in the Transaction will return False.
  *
- * @param expected_constraints  The set of expected added constraints
- * @param transaction           The transaction to test
- * @return                      True if the expected constraints, and only the expected constraints, exist in the
- *                              transaction, False otherwise.
+ * @tparam ConstraintRange  A range or container with objects compatible with a "const ExampleConstraint&" signature
+ * @param expected          The set of expected added constraints
+ * @param transaction       The transaction to test
+ * @return                  True if the expected constraints, and only the expected constraints, exist in the
+ *                          transaction, False otherwise.
  */
-bool testAddedConstraints(
-  const std::vector<ExampleConstraint::SharedPtr>& expected_constraints, const Transaction& transaction)
+template <typename ConstraintRange>
+bool testAddedConstraints(const ConstraintRange& expected, const Transaction& transaction)
 {
   auto range = transaction.addedConstraints();
-  if (static_cast<int>(expected_constraints.size()) != std::distance(range.begin(), range.end()))
+  if (std::distance(expected.begin(), expected.end()) != std::distance(range.begin(), range.end()))
   {
     return false;
   }
@@ -113,19 +116,20 @@ bool testAddedConstraints(
     const auto& actual_constraint = dynamic_cast<const ExampleConstraint&>(*iter);
 
     bool found = false;
-    for (const auto& expected_constraint : expected_constraints)
+    for (const auto& expected_constraint : expected)
     {
-      if (actual_constraint.uuid() == expected_constraint->uuid())
+      if (actual_constraint.uuid() == expected_constraint.uuid())
       {
         found = true;
         bool is_equal = true;
-        is_equal = is_equal && (expected_constraint->type() == actual_constraint.type());
-        is_equal = is_equal && (expected_constraint->variables().size() == actual_constraint.variables().size());
-        for (size_t i = 0; i < expected_constraint->variables().size(); ++i)
+        is_equal = is_equal && (expected_constraint.type() == actual_constraint.type());
+        is_equal = is_equal && (expected_constraint.variables().size() == actual_constraint.variables().size());
+        for (size_t i = 0; i < expected_constraint.variables().size(); ++i)
         {
-          is_equal = is_equal && (expected_constraint->variables().at(i) == actual_constraint.variables().at(i));
+          is_equal = is_equal && (expected_constraint.variables().at(i) == actual_constraint.variables().at(i));
         }
-        is_equal = is_equal && (expected_constraint->data == actual_constraint.data);
+        const auto& expected_derived = dynamic_cast<const ExampleConstraint&>(expected_constraint);
+        is_equal = is_equal && (expected_derived.data == actual_constraint.data);
 
         if (!is_equal)
         {
@@ -149,16 +153,17 @@ bool testAddedConstraints(
  *
  * Order of the constraint UUIDs is not important. Extra constraint UUIDs in the Transaction will return False.
  *
- * @param expected_constraints  The set of expected removed constraint UUIDs
- * @param transaction           The transaction to test
- * @return                      True if the expected constraints, and only the expected constraints, exist in the
- *                              transaction, False otherwise.
+ * @tparam UuidRange   A range or container with objects compatible with a "const fuse_core::UUID&" signature
+ * @param expected     The set of expected removed constraint UUIDs
+ * @param transaction  The transaction to test
+ * @return             True if the expected constraints, and only the expected constraints, exist in the
+ *                     transaction, False otherwise.
  */
-bool testRemovedConstraints(
-  const std::vector<UUID>& expected_constraints, const Transaction& transaction)
+template <typename UuidRange>
+bool testRemovedConstraints(const UuidRange& expected, const Transaction& transaction)
 {
   auto range = transaction.removedConstraints();
-  if (static_cast<int>(expected_constraints.size()) != std::distance(range.begin(), range.end()))
+  if (std::distance(expected.begin(), expected.end()) != std::distance(range.begin(), range.end()))
   {
     return false;
   }
@@ -168,7 +173,7 @@ bool testRemovedConstraints(
     const auto& actual_constraint_uuid = *iter;
 
     bool found = false;
-    for (const auto& expected_constraint_uuid : expected_constraints)
+    for (const auto& expected_constraint_uuid : expected)
     {
       if (actual_constraint_uuid == expected_constraint_uuid)
       {
@@ -192,16 +197,17 @@ bool testRemovedConstraints(
  *
  * Order of the variables is not important. Extra variables in the Transaction will return False.
  *
- * @param expected_variables  The set of expected added variables
- * @param transaction         The transaction to test
- * @return                    True if the expected variables, and only the expected variables, exist in the
- *                            transaction, False otherwise.
+ * @tparam VariableRange  A range or container with objects compatible with a "const ExampleVariable&" signature
+ * @param expected        The set of expected added variables
+ * @param transaction     The transaction to test
+ * @return                True if the expected variables, and only the expected variables, exist in the
+ *                        transaction, False otherwise.
  */
-bool testAddedVariables(
-  const std::vector<ExampleVariable::SharedPtr>& expected_variables, const Transaction& transaction)
+template <typename VariableRange>
+bool testAddedVariables(const VariableRange& expected, const Transaction& transaction)
 {
   auto range = transaction.addedVariables();
-  if (static_cast<int>(expected_variables.size()) != std::distance(range.begin(), range.end()))
+  if (std::distance(expected.begin(), expected.end()) != std::distance(range.begin(), range.end()))
   {
     return false;
   }
@@ -211,15 +217,15 @@ bool testAddedVariables(
     const auto& actual_variable = dynamic_cast<const ExampleVariable&>(*iter);
 
     bool found = false;
-    for (const auto& expected_variable : expected_variables)
+    for (const auto& expected_variable : expected)
     {
-      if (actual_variable.uuid() == expected_variable->uuid())
+      if (actual_variable.uuid() == expected_variable.uuid())
       {
         found = true;
         bool is_equal = true;
-        is_equal = is_equal && (expected_variable->type() == actual_variable.type());
-        is_equal = is_equal && (expected_variable->size() == actual_variable.size());
-        is_equal = is_equal && (expected_variable->data()[0] == actual_variable.data()[0]);
+        is_equal = is_equal && (expected_variable.type() == actual_variable.type());
+        is_equal = is_equal && (expected_variable.size() == actual_variable.size());
+        is_equal = is_equal && (expected_variable.data()[0] == actual_variable.data()[0]);
 
         if (!is_equal)
         {
@@ -243,16 +249,17 @@ bool testAddedVariables(
  *
  * Order of the variable UUIDs is not important. Extra variable UUIDs in the Transaction will return False.
  *
- * @param expected_variables  The set of expected removed variable UUIDs
- * @param transaction         The transaction to test
- * @return                    True if the expected variables, and only the expected variables, exist in the
- *                            transaction, False otherwise.
+ * @tparam UuidRange   A range or container with objects compatible with a "const fuse_core::UUID&" signature
+ * @param expected     The set of expected removed variable UUIDs
+ * @param transaction  The transaction to test
+ * @return             True if the expected variables, and only the expected variables, exist in the
+ *                     transaction, False otherwise.
  */
-bool testRemovedVariables(
-  const std::vector<UUID>& expected_variables, const Transaction& transaction)
+template <typename UuidRange>
+bool testRemovedVariables(const UuidRange& expected, const Transaction& transaction)
 {
   auto range = transaction.removedVariables();
-  if (static_cast<int>(expected_variables.size()) != std::distance(range.begin(), range.end()))
+  if (std::distance(expected.begin(), expected.end()) != std::distance(range.begin(), range.end()))
   {
     return false;
   }
@@ -262,7 +269,7 @@ bool testRemovedVariables(
     const auto& actual_variable_uuid = *iter;
 
     bool found = false;
-    for (const auto& expected_variable_uuid : expected_variables)
+    for (const auto& expected_variable_uuid : expected)
     {
       if (actual_variable_uuid == expected_variable_uuid)
       {
@@ -291,8 +298,8 @@ TEST(Transaction, AddConstraint)
     Transaction transaction;
     transaction.addConstraint(constraint);
 
-    std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-    expected_constraints.push_back(constraint);
+    std::vector<ExampleConstraint> expected_constraints;
+    expected_constraints.push_back(*constraint);
     EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
   }
 
@@ -306,8 +313,8 @@ TEST(Transaction, AddConstraint)
     transaction.addConstraint(constraint);
     transaction.addConstraint(constraint);
 
-    std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-    expected_constraints.push_back(constraint);
+    std::vector<ExampleConstraint> expected_constraints;
+    expected_constraints.push_back(*constraint);
     EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
   }
 
@@ -325,10 +332,10 @@ TEST(Transaction, AddConstraint)
     transaction.addConstraint(constraint2);
     transaction.addConstraint(constraint3);
 
-    std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-    expected_constraints.push_back(constraint1);
-    expected_constraints.push_back(constraint2);
-    expected_constraints.push_back(constraint3);
+    std::vector<ExampleConstraint> expected_constraints;
+    expected_constraints.push_back(*constraint1);
+    expected_constraints.push_back(*constraint2);
+    expected_constraints.push_back(*constraint3);
     EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
   }
 
@@ -345,7 +352,7 @@ TEST(Transaction, AddConstraint)
     transaction.removeConstraint(constraint2_uuid);
     transaction.addConstraint(constraint1);
 
-    std::vector<ExampleConstraint::SharedPtr> added_constraints;  // empty
+    std::vector<ExampleConstraint> added_constraints;  // empty
     std::vector<UUID> removed_constraints;
     removed_constraints.push_back(constraint2_uuid);
     EXPECT_TRUE(testAddedConstraints(added_constraints, transaction));
@@ -364,8 +371,8 @@ TEST(Transaction, AddConstraint)
 
     // Verify it exists
     {
-      std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-      expected_constraints.push_back(constraint1);
+      std::vector<ExampleConstraint> expected_constraints;
+      expected_constraints.push_back(*constraint1);
       EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
     }
 
@@ -378,8 +385,8 @@ TEST(Transaction, AddConstraint)
 
     // Verify the data value is unchanged
     {
-      std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-      expected_constraints.push_back(constraint1);
+      std::vector<ExampleConstraint> expected_constraints;
+      expected_constraints.push_back(*constraint1);
       EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
     }
 
@@ -388,8 +395,8 @@ TEST(Transaction, AddConstraint)
 
     // Verify the data value is updated
     {
-      std::vector<ExampleConstraint::SharedPtr> expected_constraints;
-      expected_constraints.push_back(constraint2);
+      std::vector<ExampleConstraint> expected_constraints;
+      expected_constraints.push_back(*constraint2);
       EXPECT_TRUE(testAddedConstraints(expected_constraints, transaction));
     }
   }
@@ -456,8 +463,8 @@ TEST(Transaction, RemoveConstraint)
     transaction.removeConstraint(constraint1->uuid());
 
     // Test
-    std::vector<ExampleConstraint::SharedPtr> expected_added_constraints;
-    expected_added_constraints.push_back(constraint2);
+    std::vector<ExampleConstraint> expected_added_constraints;
+    expected_added_constraints.push_back(*constraint2);
     EXPECT_TRUE(testAddedConstraints(expected_added_constraints, transaction));
 
     std::vector<UUID> expected_removed_constraints;
@@ -474,8 +481,8 @@ TEST(Transaction, AddVariable)
     Transaction transaction;
     transaction.addVariable(variable);
 
-    std::vector<ExampleVariable::SharedPtr> expected_variables;
-    expected_variables.push_back(variable);
+    std::vector<ExampleVariable> expected_variables;
+    expected_variables.push_back(*variable);
     EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
   }
 
@@ -488,8 +495,8 @@ TEST(Transaction, AddVariable)
     transaction.addVariable(variable);
     transaction.addVariable(variable);
 
-    std::vector<ExampleVariable::SharedPtr> expected_variables;
-    expected_variables.push_back(variable);
+    std::vector<ExampleVariable> expected_variables;
+    expected_variables.push_back(*variable);
     EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
   }
 
@@ -504,10 +511,10 @@ TEST(Transaction, AddVariable)
     transaction.addVariable(variable2);
     transaction.addVariable(variable3);
 
-    std::vector<ExampleVariable::SharedPtr> expected_variables;
-    expected_variables.push_back(variable1);
-    expected_variables.push_back(variable2);
-    expected_variables.push_back(variable3);
+    std::vector<ExampleVariable> expected_variables;
+    expected_variables.push_back(*variable1);
+    expected_variables.push_back(*variable2);
+    expected_variables.push_back(*variable3);
     EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
   }
 
@@ -523,7 +530,7 @@ TEST(Transaction, AddVariable)
     transaction.addVariable(variable1);
 
     // Test
-    std::vector<ExampleVariable::SharedPtr> expected_added_variables;
+    std::vector<ExampleVariable> expected_added_variables;
     EXPECT_TRUE(testAddedVariables(expected_added_variables, transaction));
 
     std::vector<UUID> expected_removed_variables;
@@ -542,8 +549,8 @@ TEST(Transaction, AddVariable)
 
     // Verify the variable exists
     {
-      std::vector<ExampleVariable::SharedPtr> expected_variables;
-      expected_variables.push_back(variable1);
+      std::vector<ExampleVariable> expected_variables;
+      expected_variables.push_back(*variable1);
       EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
     }
 
@@ -556,8 +563,8 @@ TEST(Transaction, AddVariable)
 
     // Verify the variable1 values still exist
     {
-      std::vector<ExampleVariable::SharedPtr> expected_variables;
-      expected_variables.push_back(variable1);
+      std::vector<ExampleVariable> expected_variables;
+      expected_variables.push_back(*variable1);
       EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
     }
 
@@ -566,8 +573,8 @@ TEST(Transaction, AddVariable)
 
     // Verify the variable2 values now exist
     {
-      std::vector<ExampleVariable::SharedPtr> expected_variables;
-      expected_variables.push_back(variable2);
+      std::vector<ExampleVariable> expected_variables;
+      expected_variables.push_back(*variable2);
       EXPECT_TRUE(testAddedVariables(expected_variables, transaction));
     }
   }
@@ -631,8 +638,8 @@ TEST(Transaction, RemoveVariable)
     transaction.removeVariable(variable1->uuid());
 
     // Test
-    std::vector<ExampleVariable::SharedPtr> expected_added_variables;
-    expected_added_variables.push_back(variable2);
+    std::vector<ExampleVariable> expected_added_variables;
+    expected_added_variables.push_back(*variable2);
     EXPECT_TRUE(testAddedVariables(expected_added_variables, transaction));
 
     std::vector<UUID> expected_removed_variables;
@@ -701,10 +708,10 @@ TEST(Transaction, Merge)
   expected_involved_stamps.push_back(involved_stamp3);
   EXPECT_TRUE(testInvolvedStamps(expected_involved_stamps, transaction1));
 
-  std::vector<ExampleConstraint::SharedPtr> expected_added_constraints;
-  expected_added_constraints.push_back(added_constraint1);
-  expected_added_constraints.push_back(added_constraint2);
-  expected_added_constraints.push_back(added_constraint3);
+  std::vector<ExampleConstraint> expected_added_constraints;
+  expected_added_constraints.push_back(*added_constraint1);
+  expected_added_constraints.push_back(*added_constraint2);
+  expected_added_constraints.push_back(*added_constraint3);
   EXPECT_TRUE(testAddedConstraints(expected_added_constraints, transaction1));
 
   std::vector<UUID> expected_removed_constraints;
@@ -713,10 +720,10 @@ TEST(Transaction, Merge)
   expected_removed_constraints.push_back(removed_constraint3);
   EXPECT_TRUE(testRemovedConstraints(expected_removed_constraints, transaction1));
 
-  std::vector<ExampleVariable::SharedPtr> expected_added_variables;
-  expected_added_variables.push_back(added_variable1);
-  expected_added_variables.push_back(added_variable2);
-  expected_added_variables.push_back(added_variable3);
+  std::vector<ExampleVariable> expected_added_variables;
+  expected_added_variables.push_back(*added_variable1);
+  expected_added_variables.push_back(*added_variable2);
+  expected_added_variables.push_back(*added_variable3);
   EXPECT_TRUE(testAddedVariables(expected_added_variables, transaction1));
 
   std::vector<UUID> expected_removed_variables;
@@ -769,9 +776,9 @@ TEST(Transaction, Clone)
   expected_involved_stamps.push_back(involved_stamp2);
   EXPECT_TRUE(testInvolvedStamps(expected_involved_stamps, *transaction2));
 
-  std::vector<ExampleConstraint::SharedPtr> expected_added_constraints;
-  expected_added_constraints.push_back(added_constraint1);
-  expected_added_constraints.push_back(added_constraint2);
+  std::vector<ExampleConstraint> expected_added_constraints;
+  expected_added_constraints.push_back(*added_constraint1);
+  expected_added_constraints.push_back(*added_constraint2);
   EXPECT_TRUE(testAddedConstraints(expected_added_constraints, *transaction2));
 
   std::vector<UUID> expected_removed_constraints;
@@ -779,15 +786,69 @@ TEST(Transaction, Clone)
   expected_removed_constraints.push_back(removed_constraint2);
   EXPECT_TRUE(testRemovedConstraints(expected_removed_constraints, *transaction2));
 
-  std::vector<ExampleVariable::SharedPtr> expected_added_variables;
-  expected_added_variables.push_back(added_variable1);
-  expected_added_variables.push_back(added_variable2);
+  std::vector<ExampleVariable> expected_added_variables;
+  expected_added_variables.push_back(*added_variable1);
+  expected_added_variables.push_back(*added_variable2);
   EXPECT_TRUE(testAddedVariables(expected_added_variables, *transaction2));
 
   std::vector<UUID> expected_removed_variables;
   expected_removed_variables.push_back(removed_variable1);
   expected_removed_variables.push_back(removed_variable2);
   EXPECT_TRUE(testRemovedVariables(expected_removed_variables, *transaction2));
+}
+
+TEST(Transaction, Serialize)
+{
+  // Create a transaction
+  ros::Time involved_stamp1(12345, 6789);
+  ros::Time involved_stamp2(12346, 6789);
+
+  UUID variable1_uuid = fuse_core::uuid::generate();
+  UUID variable2_uuid = fuse_core::uuid::generate();
+  auto added_constraint1 = ExampleConstraint::make_shared(std::initializer_list<UUID>{variable1_uuid});  // NOLINT
+  auto added_constraint2 = ExampleConstraint::make_shared(std::initializer_list<UUID>{variable2_uuid});  // NOLINT
+
+  UUID removed_constraint1 = fuse_core::uuid::generate();
+  UUID removed_constraint2 = fuse_core::uuid::generate();
+
+  auto added_variable1 = ExampleVariable::make_shared();
+  auto added_variable2 = ExampleVariable::make_shared();
+
+  UUID removed_variable1 = fuse_core::uuid::generate();
+  UUID removed_variable2 = fuse_core::uuid::generate();
+
+  Transaction expected;
+  expected.addInvolvedStamp(involved_stamp1);
+  expected.addInvolvedStamp(involved_stamp2);
+  expected.addConstraint(added_constraint1);
+  expected.addConstraint(added_constraint2);
+  expected.removeConstraint(removed_constraint1);
+  expected.removeConstraint(removed_constraint2);
+  expected.addVariable(added_variable1);
+  expected.addVariable(added_variable2);
+  expected.removeVariable(removed_variable1);
+  expected.removeVariable(removed_variable2);
+
+  // Serialize the object into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new object from that same stream
+  Transaction actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_TRUE(testInvolvedStamps(expected.involvedStamps(), actual));
+  EXPECT_TRUE(testAddedConstraints(expected.addedConstraints(), actual));
+  EXPECT_TRUE(testRemovedConstraints(expected.removedConstraints(), actual));
+  EXPECT_TRUE(testAddedVariables(expected.addedVariables(), actual));
+  EXPECT_TRUE(testRemovedVariables(expected.removedVariables(), actual));
 }
 
 int main(int argc, char **argv)

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -3,6 +3,7 @@ project(fuse_graphs)
 
 set(build_depends
   fuse_core
+  pluginlib
   roscpp
 )
 
@@ -15,14 +16,13 @@ find_package(Ceres REQUIRED)
 catkin_package(
   INCLUDE_DIRS
     include
-    ${CERES_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
-    ${CERES_LIBRARIES}
   CATKIN_DEPENDS
     ${build_depends}
   DEPENDS
     Boost
+    CERES
 )
 
 ###########
@@ -64,6 +64,11 @@ install(
 install(
   DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  FILES fuse_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 #############

--- a/fuse_graphs/fuse_plugins.xml
+++ b/fuse_graphs/fuse_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libfuse_graphs">
+  <class type="fuse_graphs::HashGraph" base_class_type="fuse_core::Graph">
+    <description>
+    This is a concrete implementation of the Graph interface using hashmaps to store the constraints and variables.
+    </description>
+  </class>
+</library>

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -37,9 +37,16 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/unordered_set.hpp>
 #include <ceres/covariance.h>
 #include <ceres/problem.h>
 #include <ceres/solver.h>
@@ -67,7 +74,7 @@ namespace fuse_graphs
 class HashGraph : public fuse_core::Graph
 {
 public:
-  SMART_PTR_DEFINITIONS(HashGraph);
+  FUSE_GRAPH_DEFINITIONS(HashGraph);
 
   /**
    * @brief Constructor
@@ -330,8 +337,52 @@ protected:
    * @param[out] problem The ceres::Problem object to modify
    */
   void createProblem(ceres::Problem& problem) const;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Graph>(*this);
+    archive & constraints_;
+    archive & constraints_by_variable_uuid_;
+    archive & problem_options_;
+    archive & variables_;
+    archive & variables_on_hold_;
+  }
 };
 
 }  // namespace fuse_graphs
+
+namespace boost
+{
+namespace serialization
+{
+
+/**
+ * @brief Serialize a ceres::Problem::Options object using Boost Serialization
+ */
+template<class Archive>
+void serialize(Archive& archive, ceres::Problem::Options& options, const unsigned int /* version */)
+{
+  archive & options.cost_function_ownership;
+  archive & options.disable_all_safety_checks;
+  archive & options.enable_fast_removal;
+  archive & options.local_parameterization_ownership;
+  archive & options.loss_function_ownership;
+}
+
+}  // namespace serialization
+}  // namespace boost
+
+BOOST_CLASS_EXPORT_KEY(fuse_graphs::HashGraph);
 
 #endif  // FUSE_GRAPHS_HASH_GRAPH_H

--- a/fuse_graphs/package.xml
+++ b/fuse_graphs/package.xml
@@ -13,7 +13,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+
+  <export>
+    <fuse_core plugin="${prefix}/fuse_plugins.xml" />
+  </export>
 </package>

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -35,6 +35,7 @@
 #include <fuse_core/uuid.h>
 
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -462,3 +463,5 @@ void HashGraph::createProblem(ceres::Problem& problem) const
 }
 
 }  // namespace fuse_graphs
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_graphs::HashGraph);

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -32,7 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_graphs/hash_graph.h>
+
 #include <fuse_core/uuid.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/serialization/export.hpp>
@@ -465,3 +467,4 @@ void HashGraph::createProblem(ceres::Problem& problem) const
 }  // namespace fuse_graphs
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_graphs::HashGraph);
+PLUGINLIB_EXPORT_CLASS(fuse_graphs::HashGraph, fuse_core::Graph);

--- a/fuse_graphs/test/covariance_constraint.h
+++ b/fuse_graphs/test/covariance_constraint.h
@@ -36,8 +36,12 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <ceres/cost_function.h>
 
 #include <algorithm>
@@ -139,6 +143,8 @@ class CovarianceConstraint : public fuse_core::Constraint
 public:
   FUSE_CONSTRAINT_DEFINITIONS(CovarianceConstraint);
 
+  CovarianceConstraint() = default;
+
   CovarianceConstraint(
     const fuse_core::UUID& variable1_uuid,
     const fuse_core::UUID& variable2_uuid,
@@ -149,6 +155,24 @@ public:
 
   void print(std::ostream& /*stream = std::cout*/) const override {}
   ceres::CostFunction* costFunction() const override { return new CovarianceCostFunction(); }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+  }
 };
+
+BOOST_CLASS_EXPORT(CovarianceConstraint);
 
 #endif  // FUSE_GRAPHS_TEST_COVARIANCE_CONSTRAINT_H  // NOLINT{build/header_guard}

--- a/fuse_graphs/test/example_constraint.h
+++ b/fuse_graphs/test/example_constraint.h
@@ -36,8 +36,12 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
 
 
@@ -71,6 +75,8 @@ class ExampleConstraint : public fuse_core::Constraint
 public:
   FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
 
+  ExampleConstraint() = default;
+
   explicit ExampleConstraint(const fuse_core::UUID& variable_uuid) :
     fuse_core::Constraint{variable_uuid},
     data(0.0)
@@ -84,6 +90,25 @@ public:
   }
 
   double data;  // Public member variable just for testing
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & data;
+  }
 };
+
+BOOST_CLASS_EXPORT(ExampleConstraint);
 
 #endif  // FUSE_GRAPHS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}

--- a/fuse_graphs/test/example_variable.h
+++ b/fuse_graphs/test/example_variable.h
@@ -34,8 +34,14 @@
 #ifndef FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 #define FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include <vector>
 
@@ -61,6 +67,24 @@ public:
 
 private:
   std::vector<double> data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & data_;
+  }
 };
+
+BOOST_CLASS_EXPORT(ExampleVariable);
 
 #endif  // FUSE_GRAPHS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}

--- a/fuse_models/fuse_plugins.xml
+++ b/fuse_models/fuse_plugins.xml
@@ -1,4 +1,10 @@
 <library path="lib/libfuse_models">
+  <class type="fuse_models::Unicycle2DStateKinematicConstraint" base_class_type="fuse_core::Constraint">
+    <description>
+    A class that represents a kinematic constraint between 2D states at two different times.
+    </description>
+  </class>
+
   <class type="fuse_models::Unicycle2D" base_class_type="fuse_core::MotionModel">
     <description>
     A fuse_models 2D kinematic model that generates kinematic constraints between provided time stamps, and adds

--- a/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
@@ -37,12 +37,17 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 #include <vector>
@@ -61,6 +66,11 @@ class Unicycle2DStateKinematicConstraint : public fuse_core::Constraint
 {
 public:
   FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(Unicycle2DStateKinematicConstraint);
+
+  /**
+   * @brief Default constructor
+   */
+  Unicycle2DStateKinematicConstraint() = default;
 
   /**
    * @brief Create a constraint using a time delta and a kinematic model cost functor
@@ -139,8 +149,28 @@ public:
 protected:
   double dt_;  //!< The time delta for the constraint
   fuse_core::Matrix8d sqrt_information_;  //!< The square root information matrix
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive & dt_;
+    archive & sqrt_information_;
+  }
 };
 
 }  // namespace fuse_models
+
+BOOST_CLASS_EXPORT_KEY(fuse_models::Unicycle2DStateKinematicConstraint);
 
 #endif  // FUSE_MODELS_UNICYCLE_2D_STATE_KINEMATIC_CONSTRAINT_H

--- a/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
+++ b/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
@@ -39,6 +39,7 @@
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
+#include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>
@@ -105,3 +106,4 @@ ceres::CostFunction* Unicycle2DStateKinematicConstraint::costFunction() const
 }  // namespace fuse_models
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_models::Unicycle2DStateKinematicConstraint);
+PLUGINLIB_EXPORT_CLASS(fuse_models::Unicycle2DStateKinematicConstraint, fuse_core::Constraint);

--- a/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
+++ b/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
@@ -34,13 +34,15 @@
 #include <fuse_models/unicycle_2d_state_kinematic_constraint.h>
 #include <fuse_models/unicycle_2d_state_cost_functor.h>
 
-#include <ceres/autodiff_cost_function.h>
-#include <Eigen/Dense>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
+
+#include <boost/serialization/export.hpp>
+#include <ceres/autodiff_cost_function.h>
+#include <Eigen/Dense>
 
 #include <ostream>
 
@@ -80,17 +82,17 @@ void Unicycle2DStateKinematicConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
          << "  uuid: " << uuid() << "\n"
-         << "  position variable 1: " << variables_.at(0) << "\n"
-         << "  yaw variable 1: " << variables_.at(1) << "\n"
-         << "  linear velocity variable 1: " << variables_.at(2) << "\n"
-         << "  yaw velocity variable 1: " << variables_.at(3) << "\n"
-         << "  linear acceleration variable 1: " << variables_.at(4) << "\n"
-         << "  position variable 2: " << variables_.at(5) << "\n"
-         << "  yaw variable 2: " << variables_.at(6) << "\n"
-         << "  linear velocity variable 2: " << variables_.at(7) << "\n"
-         << "  yaw velocity variable 2: " << variables_.at(8) << "\n"
-         << "  linear acceleration variable 2: " << variables_.at(9) << "\n"
-         << "  dt: " << dt_ << "\n"
+         << "  position variable 1: " << variables().at(0) << "\n"
+         << "  yaw variable 1: " << variables().at(1) << "\n"
+         << "  linear velocity variable 1: " << variables().at(2) << "\n"
+         << "  yaw velocity variable 1: " << variables().at(3) << "\n"
+         << "  linear acceleration variable 1: " << variables().at(4) << "\n"
+         << "  position variable 2: " << variables().at(5) << "\n"
+         << "  yaw variable 2: " << variables().at(6) << "\n"
+         << "  linear velocity variable 2: " << variables().at(7) << "\n"
+         << "  yaw velocity variable 2: " << variables().at(8) << "\n"
+         << "  linear acceleration variable 2: " << variables().at(9) << "\n"
+         << "  dt: " << dt() << "\n"
          << "  sqrt_info: " << sqrtInformation() << "\n";
 }
 
@@ -101,3 +103,5 @@ ceres::CostFunction* Unicycle2DStateKinematicConstraint::costFunction() const
 }
 
 }  // namespace fuse_models
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_models::Unicycle2DStateKinematicConstraint);

--- a/fuse_msgs/CMakeLists.txt
+++ b/fuse_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  std_msgs
+)
+
+add_message_files(
+  DIRECTORY
+    msg
+  FILES
+    SerializedGraph.msg
+    SerializedTransaction.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+)

--- a/fuse_msgs/msg/SerializedGraph.msg
+++ b/fuse_msgs/msg/SerializedGraph.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header  # A timestamp associated with the graph
+string plugin_name      # The fully-qualified name of the plugin used to serialize/deserialize this graph
+uint8[] data            # The serialized graph as a raw data buffer

--- a/fuse_msgs/msg/SerializedTransaction.msg
+++ b/fuse_msgs/msg/SerializedTransaction.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header  # A timestamp associated with this transaction
+uint8[] data            # The serialized transaction as a raw data buffer

--- a/fuse_msgs/package.xml
+++ b/fuse_msgs/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse_msgs</name>
+  <version>0.4.0</version>
+  <description>
+    The fuse_msgs package contains messages capable of holding serialized fuse objects
+  </description>
+
+  <maintainer email="swilliams@locusrobotics.com">Stephen Williams</maintainer>
+  <author email="swilliams@locusrobotics.com">Stephen Williams</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>std_msgs</depend>
+
+  <build_depend>message_generation</build_depend>
+
+  <build_export_depend>message_runtime</build_export_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+</package>

--- a/fuse_optimizers/test/test_variable_stamp_index.cpp
+++ b/fuse_optimizers/test/test_variable_stamp_index.cpp
@@ -171,6 +171,8 @@ class GenericConstraint : public fuse_core::Constraint
 public:
   FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint);
 
+  GenericConstraint() = default;
+
   GenericConstraint(std::initializer_list<fuse_core::UUID> variable_uuids) :
     Constraint(variable_uuids)
   {
@@ -204,7 +206,26 @@ public:
   {
     return nullptr;
   }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Constraint>(*this);
+  }
 };
+
+BOOST_CLASS_EXPORT(GenericConstraint);
+
 
 TEST(VariableStampIndex, Size)
 {

--- a/fuse_optimizers/test/test_variable_stamp_index.cpp
+++ b/fuse_optimizers/test/test_variable_stamp_index.cpp
@@ -33,12 +33,16 @@
  */
 #include <fuse_core/constraint.h>
 #include <fuse_core/transaction.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_optimizers/variable_stamp_index.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -81,9 +85,28 @@ public:
   {
   }
 
-protected:
+private:
   double data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & boost::serialization::base_object<fuse_variables::Stamped>(*this);
+    archive & data_;
+  }
 };
+
+BOOST_CLASS_EXPORT(StampedVariable);
 
 /**
  * @brief Create a simple unstamped Variable for testing
@@ -118,9 +141,27 @@ public:
   {
   }
 
-protected:
+private:
   double data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & data_;
+  }
 };
+
+BOOST_CLASS_EXPORT(UnstampedVariable);
 
 /**
  * @brief Create a simple Constraint for testing

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -36,6 +36,7 @@ add_compile_options(-std=c++14 -Wall -Werror)
 add_library(${PROJECT_NAME}
   src/path_2d_publisher.cpp
   src/pose_2d_publisher.cpp
+  src/serialized_publisher.cpp
 )
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}

--- a/fuse_publishers/fuse_plugins.xml
+++ b/fuse_publishers/fuse_plugins.xml
@@ -11,4 +11,9 @@
       including tf.
     </description>
   </class>
+  <class type="fuse_publishers::SerializedPublisher" base_class_type="fuse_core::Publisher">
+    <description>
+      Publisher plugin that publishes the transaction and graph as serialized messages.
+    </description>
+  </class>
 </library>

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -1,0 +1,88 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H
+#define FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H
+
+#include <fuse_core/async_publisher.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/transaction.h>
+#include <ros/ros.h>
+
+
+namespace fuse_publishers
+{
+
+/**
+ * @brief Publisher plugin that publishes the transaction and graph as serialized messages
+ */
+class SerializedPublisher : public fuse_core::AsyncPublisher
+{
+public:
+  SMART_PTR_DEFINITIONS(SerializedPublisher);
+
+  /**
+   * @brief Constructor
+   */
+  SerializedPublisher();
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~SerializedPublisher() = default;
+
+  /**
+   * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the
+   * parameter server.
+   */
+  void onInit() override;
+
+  /**
+   * @brief Notify the publisher about variables that have been added or removed
+   *
+   * @param[in] transaction A Transaction object, describing the set of variables that have been added and/or removed
+   * @param[in] graph       A read-only pointer to the graph object, allowing queries to be performed whenever needed
+   */
+  void notifyCallback(
+    fuse_core::Transaction::ConstSharedPtr transaction,
+    fuse_core::Graph::ConstSharedPtr graph) override;
+
+protected:
+  ros::Publisher graph_publisher_;
+  ros::Publisher transaction_publisher_;
+};
+
+}  // namespace fuse_publishers
+
+#endif  // FUSE_PUBLISHERS_SERIALIZED_PUBLISHER_H

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -40,6 +40,8 @@
 #include <fuse_core/transaction.h>
 #include <ros/ros.h>
 
+#include <string>
+
 
 namespace fuse_publishers
 {
@@ -79,6 +81,7 @@ public:
     fuse_core::Graph::ConstSharedPtr graph) override;
 
 protected:
+  std::string frame_id_;  //!< The name of the frame for this path
   ros::Publisher graph_publisher_;
   ros::Publisher transaction_publisher_;
 };

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -1,0 +1,87 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_publishers/serialized_publisher.h>
+
+#include <fuse_core/async_publisher.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/transaction_deserializer.h>
+#include <fuse_msgs/SerializedGraph.h>
+#include <fuse_msgs/SerializedTransaction.h>
+#include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+
+
+// Register this publisher with ROS as a plugin.
+PLUGINLIB_EXPORT_CLASS(fuse_publishers::SerializedPublisher, fuse_core::Publisher);
+
+namespace fuse_publishers
+{
+
+SerializedPublisher::SerializedPublisher() :
+  fuse_core::AsyncPublisher(1)
+{
+}
+
+void SerializedPublisher::onInit()
+{
+  // Advertise the topics
+  graph_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
+  transaction_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
+}
+
+void SerializedPublisher::notifyCallback(
+  fuse_core::Transaction::ConstSharedPtr transaction,
+  fuse_core::Graph::ConstSharedPtr graph)
+{
+  auto stamp = ros::Time::now();
+  if (graph_publisher_.getNumSubscribers() > 0)
+  {
+    fuse_msgs::SerializedGraph msg;
+    msg.header.stamp = stamp;
+    fuse_core::serializeGraph(*graph, msg);
+    graph_publisher_.publish(msg);
+  }
+
+  if (transaction_publisher_.getNumSubscribers() > 0)
+  {
+    fuse_msgs::SerializedTransaction msg;
+    msg.header.stamp = stamp;
+    fuse_core::serializeTransaction(*transaction, msg);
+    transaction_publisher_.publish(msg);
+  }
+}
+
+}  // namespace fuse_publishers

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -51,12 +51,16 @@ namespace fuse_publishers
 {
 
 SerializedPublisher::SerializedPublisher() :
-  fuse_core::AsyncPublisher(1)
+  fuse_core::AsyncPublisher(1),
+  frame_id_("map")
 {
 }
 
 void SerializedPublisher::onInit()
 {
+  // Configure the publisher
+  private_node_handle_.getParam("frame_id", frame_id_);
+
   // Advertise the topics
   graph_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
   transaction_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
@@ -71,6 +75,7 @@ void SerializedPublisher::notifyCallback(
   {
     fuse_msgs::SerializedGraph msg;
     msg.header.stamp = stamp;
+    msg.header.frame_id = frame_id_;
     fuse_core::serializeGraph(*graph, msg);
     graph_publisher_.publish(msg);
   }
@@ -79,6 +84,7 @@ void SerializedPublisher::notifyCallback(
   {
     fuse_msgs::SerializedTransaction msg;
     msg.header.stamp = stamp;
+    msg.header.frame_id = frame_id_;
     fuse_core::serializeTransaction(*transaction, msg);
     transaction_publisher_.publish(msg);
   }

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -3,6 +3,7 @@ project(fuse_variables)
 
 set(build_depends
   fuse_core
+  pluginlib
   roscpp
 )
 
@@ -14,12 +15,12 @@ find_package(Ceres REQUIRED)
 catkin_package(
   INCLUDE_DIRS
     include
-    ${CERES_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
-    ${CERES_LIBRARIES}
   CATKIN_DEPENDS
     ${build_depends}
+  DEPENDS
+    CERES
 )
 
 ###########
@@ -71,6 +72,11 @@ install(
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  FILES fuse_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 #############

--- a/fuse_variables/fuse_plugins.xml
+++ b/fuse_variables/fuse_plugins.xml
@@ -1,0 +1,65 @@
+<library path="lib/libfuse_variables">
+  <class type="fuse_variables::AccelerationAngular2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D angular acceleration at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::AccelerationAngular3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D angular acceleration (aroll, apitch, ayaw) at a specific time, with a specific
+    piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::AccelerationLinear2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D linear acceleration (ax, ay) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::AccelerationLinear3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D linear acceleration (ax, ay, az) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::Orientation2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D orientation (theta) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::Orientation3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D orientation as a quaternion at a specific time and for a specific piece of
+    hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::Position2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D position (x, y) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::Position3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D position (x, y, z) at a specific time and for a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::VelocityAngular2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D angular velocity (vtheta) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::VelocityAngular3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D angular velocity (vroll, vpitch, vyaw) at a specific time, with a specific piece
+    of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::VelocityLinear2DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 2D linear velocity (vx, vy) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+  <class type="fuse_variables::VelocityLinear3DStamped" base_class_type="fuse_core::Variable">
+    <description>
+    Variable representing a 3D linear velocity (vx, vy, vz) at a specific time, with a specific piece of hardware.
+    </description>
+  </class>
+</library>

--- a/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_ACCELERATION_ANGULAR_2D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -66,6 +71,11 @@ public:
   };
 
   /**
+   * @brief Default constructor
+   */
+  AccelerationAngular2DStamped() = default;
+
+  /**
    * @brief Construct a 2D acceleration at a specific point in time.
    *
    * @param[in] stamp     The timestamp attached to this velocity.
@@ -91,8 +101,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::AccelerationAngular2DStamped);
 
 #endif  // FUSE_VARIABLES_ACCELERATION_ANGULAR_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_ACCELERATION_ANGULAR_3D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -67,6 +72,11 @@ public:
     PITCH = 1,
     YAW = 2
   };
+
+  /**
+   * @brief Default constructor
+   */
+  AccelerationAngular3DStamped() = default;
 
   /**
    * @brief Construct a 3D angular acceleration at a specific point in time.
@@ -114,8 +124,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::AccelerationAngular3DStamped);
 
 #endif  // FUSE_VARIABLES_ACCELERATION_ANGULAR_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_ACCELERATION_LINEAR_2D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -65,6 +70,11 @@ public:
     X = 0,
     Y = 1
   };
+
+  /**
+   * @brief Default constructor
+   */
+  AccelerationLinear2DStamped() = default;
 
   /**
    * @brief Construct a 2D acceleration at a specific point in time.
@@ -102,8 +112,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::AccelerationLinear2DStamped);
 
 #endif  // FUSE_VARIABLES_ACCELERATION_LINEAR_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
@@ -52,7 +52,8 @@ namespace fuse_variables
 {
 
 /**
- * @brief Variable representing a 3D linear acceleration (ax, ay, az) at a specific time, with a specific piece of hardware.
+ * @brief Variable representing a 3D linear acceleration (ax, ay, az) at a specific time, with a specific piece
+ * of hardware.
  *
  * This is commonly used to represent a robot's acceleration. The UUID of this class is static after construction.
  * As such, the timestamp and device id cannot be modified. The value of the acceleration can be modified.

--- a/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_ACCELERATION_LINEAR_3D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -66,6 +71,11 @@ public:
     Y = 1,
     Z = 2
   };
+
+  /**
+   * @brief Default constructor
+   */
+  AccelerationLinear3DStamped() = default;
 
   /**
    * @brief Construct a 3D acceleration at a specific point in time.
@@ -113,8 +123,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::AccelerationLinear3DStamped);
 
 #endif  // FUSE_VARIABLES_ACCELERATION_LINEAR_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/fixed_size_variable.h
+++ b/fuse_variables/include/fuse_variables/fixed_size_variable.h
@@ -35,7 +35,12 @@
 #define FUSE_VARIABLES_FIXED_SIZE_VARIABLE_H
 
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/array.hpp>
 
 #include <array>
 
@@ -63,6 +68,11 @@ public:
    * @brief A static version of the variable size
    */
   constexpr static size_t SIZE = N;
+
+  /**
+   * @brief Default constructor
+   */
+  FixedSizeVariable() = default;
 
   /**
    * @brief Constructor
@@ -106,6 +116,22 @@ public:
 
 protected:
   std::array<double, N> data_;  //!< Fixed-sized, contiguous memory for holding the variable data members
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive & data_;
+  }
 };
 
 // Define the constant that was declared above

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -35,11 +35,16 @@
 #define FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H
 
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -65,6 +70,11 @@ public:
   {
     YAW = 0
   };
+
+  /**
+   * @brief Default constructor
+   */
+  Orientation2DStamped() = default;
 
   /**
    * @brief Construct a 2D orientation at a specific point in time.
@@ -108,8 +118,27 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   fuse_core::LocalParameterization* localParameterization() const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -46,12 +46,117 @@
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
+#include <ceres/rotation.h>
 
 #include <ostream>
 
 
 namespace fuse_variables
 {
+
+/**
+ * @brief A LocalParameterization class for 3D Orientations.
+ *
+ * 3D orientations add and subtract nonlinearly. Additionally, the typcial 3D orientation representation is a
+ * quaternion, which has 4 degrees of freedom to parameterize a 3D space. This local parameterization uses the
+ * Rodrigues/angle-axis formulas to combine 3D rotations, along with the appropriate "analytic" derivatives.
+ */
+class Orientation3DLocalParameterization : public fuse_core::LocalParameterization
+{
+public:
+  /**
+   * @brief Create the inverse quaternion
+   *
+   * ceres/rotation.h is missing this function for some reason.
+   */
+  template<typename T> inline
+  static void QuaternionInverse(const T in[4], T out[4])
+  {
+    out[0] = in[0];
+    out[1] = -in[1];
+    out[2] = -in[2];
+    out[3] = -in[3];
+  }
+
+  int GlobalSize() const override
+  {
+    return 4;
+  }
+
+  int LocalSize() const override
+  {
+    return 3;
+  }
+
+  bool Plus(
+    const double* x,
+    const double* delta,
+    double* x_plus_delta) const override
+  {
+    double q_delta[4];
+    ceres::AngleAxisToQuaternion(delta, q_delta);
+    ceres::QuaternionProduct(x, q_delta, x_plus_delta);
+    return true;
+}
+
+  bool ComputeJacobian(
+    const double* x,
+    double* jacobian) const override
+  {
+    double x0 = x[0] / 2;
+    double x1 = x[1] / 2;
+    double x2 = x[2] / 2;
+    double x3 = x[3] / 2;
+    jacobian[0] = -x1; jacobian[1]  = -x2; jacobian[2]  = -x3;  // NOLINT
+    jacobian[3] =  x0; jacobian[4]  = -x3; jacobian[5]  =  x2;  // NOLINT
+    jacobian[6] =  x3; jacobian[7]  =  x0; jacobian[8]  = -x1;  // NOLINT
+    jacobian[9] = -x2; jacobian[10] =  x1; jacobian[11] =  x0;  // NOLINT
+    return true;
+  }
+
+  bool Minus(
+    const double* x1,
+    const double* x2,
+    double* delta) const override
+  {
+    double x1_inverse[4];
+    QuaternionInverse(x1, x1_inverse);
+    double q_delta[4];
+    ceres::QuaternionProduct(x1_inverse, x2, q_delta);
+    ceres::QuaternionToAngleAxis(q_delta, delta);
+    return true;
+  }
+
+  bool ComputeMinusJacobian(
+    const double* x,
+    double* jacobian) const override
+  {
+    double x0 = x[0] * 2;
+    double x1 = x[1] * 2;
+    double x2 = x[2] * 2;
+    double x3 = x[3] * 2;
+    jacobian[0] = -x1; jacobian[1]  =  x0; jacobian[2]  =  x3;  jacobian[3]  = -x2;  // NOLINT
+    jacobian[4] = -x2; jacobian[5]  = -x3; jacobian[6]  =  x0;  jacobian[7]  =  x1;  // NOLINT
+    jacobian[8] = -x3; jacobian[9]  =  x2; jacobian[10] = -x1;  jacobian[11] =  x0;  // NOLINT
+    return true;
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::LocalParameterization>(*this);
+  }
+};
 
 /**
  * @brief Variable representing a 3D orientation as a quaternion at a specific time and for a specific piece of
@@ -200,6 +305,7 @@ private:
 
 }  // namespace fuse_variables
 
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DLocalParameterization);
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -35,12 +35,17 @@
 #define FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H
 
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/util.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -84,6 +89,11 @@ public:
     PITCH = 5,
     YAW = 6
   };
+
+  /**
+   * @brief Default constructor
+   */
+  Orientation3DStamped() = default;
 
   /**
    * @brief Construct a 3D orientation at a specific point in time.
@@ -169,8 +179,27 @@ public:
    * @return A pointer to a local parameterization object that indicates how to "add" increments to the quaternion
    */
   fuse_core::LocalParameterization* localParameterization() const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/position_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_2d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_POSITION_2D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -65,6 +70,11 @@ public:
     X = 0,
     Y = 1
   };
+
+  /**
+   * @brief Default constructor
+   */
+  Position2DStamped() = default;
 
   /**
    * @brief Construct a 2D position at a specific point in time.
@@ -101,8 +111,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Position2DStamped);
 
 #endif  // FUSE_VARIABLES_POSITION_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/position_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_3d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_POSITION_3D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -68,6 +73,11 @@ public:
     Y = 1,
     Z = 2
   };
+
+  /**
+   * @brief Default constructor
+   */
+  Position3DStamped() = default;
 
   /**
    * @brief Construct a 3D position at a specific point in time.
@@ -113,8 +123,27 @@ public:
    * @param  stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Position3DStamped);
 
 #endif  // FUSE_VARIABLES_POSITION_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/stamped.h
+++ b/fuse_variables/include/fuse_variables/stamped.h
@@ -35,9 +35,12 @@
 #define FUSE_VARIABLES_STAMPED_H
 
 #include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <ros/node_handle.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
 
 
 namespace fuse_variables
@@ -55,6 +58,11 @@ class Stamped
 {
 public:
   SMART_PTR_ALIASES_ONLY(Stamped);
+
+  /**
+   * @brief Default constructor
+   */
+  Stamped() = default;
 
   /**
    * @brief Constructor
@@ -82,6 +90,22 @@ public:
 private:
   fuse_core::UUID device_id_;  //!< The UUID associated with this specific device or hardware
   ros::Time stamp_;  //!< The timestamp associated with this variable instance
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & device_id_;
+    archive & stamp_;
+  }
 };
 
 /**

--- a/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_VELOCITY_ANGULAR_2D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -66,6 +71,11 @@ public:
   };
 
   /**
+   * @brief Default constructor
+   */
+  VelocityAngular2DStamped() = default;
+
+  /**
    * @brief Construct a 2D velocity at a specific point in time.
    *
    * @param[in] stamp     The timestamp attached to this velocity.
@@ -89,8 +99,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::VelocityAngular2DStamped);
 
 #endif  // FUSE_VARIABLES_VELOCITY_ANGULAR_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_VELOCITY_ANGULAR_3D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -53,7 +58,7 @@ namespace fuse_variables
  * This is commonly used to represent a robot's velocity. The UUID of this class is static after construction.
  * As such, the timestamp and device ID cannot be modified. The value of the velocity can be modified.
  */
-class VelocityAngular3DStamped final : public FixedSizeVariable<3>, public Stamped
+class VelocityAngular3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
   FUSE_VARIABLE_DEFINITIONS(VelocityAngular3DStamped);
@@ -67,6 +72,11 @@ public:
     PITCH = 1,
     YAW = 2
   };
+
+  /**
+   * @brief Default constructor
+   */
+  VelocityAngular3DStamped() = default;
 
   /**
    * @brief Construct a 3D angular velocity at a specific point in time.
@@ -112,8 +122,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::VelocityAngular3DStamped);
 
 #endif  // FUSE_VARIABLES_VELOCITY_ANGULAR_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_VELOCITY_LINEAR_2D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -65,6 +70,11 @@ public:
     X = 0,
     Y = 1
   };
+
+  /**
+   * @brief Default constructor
+   */
+  VelocityLinear2DStamped() = default;
 
   /**
    * @brief Construct a 2D velocity at a specific point in time.
@@ -101,8 +111,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::VelocityLinear2DStamped);
 
 #endif  // FUSE_VARIABLES_VELOCITY_LINEAR_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
@@ -35,10 +35,15 @@
 #define FUSE_VARIABLES_VELOCITY_LINEAR_3D_STAMPED_H
 
 #include <fuse_core/uuid.h>
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
@@ -67,6 +72,11 @@ public:
     Y = 1,
     Z = 2
   };
+
+  /**
+   * @brief Default constructor
+   */
+  VelocityLinear3DStamped() = default;
 
   /**
    * @brief Construct a 3D velocity at a specific point in time.
@@ -113,8 +123,27 @@ public:
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
   void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & boost::serialization::base_object<Stamped>(*this);
+  }
 };
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::VelocityLinear3DStamped);
 
 #endif  // FUSE_VARIABLES_VELOCITY_LINEAR_3D_STAMPED_H

--- a/fuse_variables/package.xml
+++ b/fuse_variables/package.xml
@@ -15,7 +15,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+
+  <export>
+    <fuse_core plugin="${prefix}/fuse_plugins.xml" />
+  </export>
 </package>

--- a/fuse_variables/src/acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_2d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -62,3 +64,5 @@ void AccelerationAngular2DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationAngular2DStamped);

--- a/fuse_variables/src/acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -66,3 +67,4 @@ void AccelerationAngular2DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationAngular2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::AccelerationAngular2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_3d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -70,3 +71,4 @@ void AccelerationAngular3DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationAngular3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::AccelerationAngular3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_3d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -66,3 +68,5 @@ void AccelerationAngular3DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationAngular3DStamped);

--- a/fuse_variables/src/acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_2d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -63,3 +65,5 @@ void AccelerationLinear2DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationLinear2DStamped);

--- a/fuse_variables/src/acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -67,3 +68,4 @@ void AccelerationLinear2DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationLinear2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::AccelerationLinear2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_3d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -68,3 +69,4 @@ void AccelerationLinear3DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationLinear3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::AccelerationLinear3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_3d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -64,3 +66,5 @@ void AccelerationLinear3DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::AccelerationLinear3DStamped);

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -40,6 +40,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -126,3 +128,5 @@ fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() 
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DStamped);

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -37,6 +37,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -73,3 +74,4 @@ fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() 
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DLocalParameterization);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -34,7 +34,6 @@
 #include <fuse_variables/orientation_2d_stamped.h>
 
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/util.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
@@ -47,63 +46,6 @@
 
 namespace fuse_variables
 {
-
-/**
- * @brief A LocalParameterization class for 2D Orientations.
- *
- * 2D orientations add and subtract in the "usual" way, except for the 2*pi rollover issue. This local parameterization
- * handles the rollover. Because the Jacobians for this parameterization are always identity, we implement this
- * parameterization with "analytic" derivatives, instead of using the Ceres's autodiff system.
- */
-class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
-{
-public:
-  int GlobalSize() const override
-  {
-    return 1;
-  }
-
-  int LocalSize() const override
-  {
-    return 1;
-  }
-
-  bool Plus(
-    const double* x,
-    const double* delta,
-    double* x_plus_delta) const override
-  {
-    // Compute the angle increment as a linear update, and handle the 2*Pi rollover
-    x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
-    return true;
-  }
-
-  bool ComputeJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
-  {
-    jacobian[0] = 1.0;
-    return true;
-  }
-
-  bool Minus(
-    const double* x1,
-    const double* x2,
-    double* delta) const override
-  {
-    // Compute the difference from x2 to x1, and handle the 2*Pi rollover
-    delta[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
-    return true;
-  }
-
-  bool ComputeMinusJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
-  {
-    jacobian[0] = 1.0;
-    return true;
-  }
-};
 
 Orientation2DStamped::Orientation2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
   FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
@@ -129,4 +71,5 @@ fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() 
 
 }  // namespace fuse_variables
 
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DLocalParameterization);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DStamped);

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -37,6 +37,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -77,3 +78,4 @@ fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() 
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -40,6 +40,7 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
 #include <ceres/rotation.h>
 
 #include <ostream>
@@ -159,3 +160,5 @@ fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() 
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);

--- a/fuse_variables/src/position_2d_stamped.cpp
+++ b/fuse_variables/src/position_2d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -63,3 +65,5 @@ void Position2DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Position2DStamped);

--- a/fuse_variables/src/position_2d_stamped.cpp
+++ b/fuse_variables/src/position_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -67,3 +68,4 @@ void Position2DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Position2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::Position2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/position_3d_stamped.cpp
+++ b/fuse_variables/src/position_3d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -68,3 +69,4 @@ void Position3DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Position3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::Position3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/position_3d_stamped.cpp
+++ b/fuse_variables/src/position_3d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -64,3 +66,5 @@ void Position3DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Position3DStamped);

--- a/fuse_variables/src/velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_2d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -62,3 +64,5 @@ void VelocityAngular2DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityAngular2DStamped);

--- a/fuse_variables/src/velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -66,3 +67,4 @@ void VelocityAngular2DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityAngular2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::VelocityAngular2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_3d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -68,3 +69,4 @@ void VelocityAngular3DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityAngular3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::VelocityAngular3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_3d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -64,3 +66,5 @@ void VelocityAngular3DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityAngular3DStamped);

--- a/fuse_variables/src/velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_2d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -63,3 +65,5 @@ void VelocityLinear2DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityLinear2DStamped);

--- a/fuse_variables/src/velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_2d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -67,3 +68,4 @@ void VelocityLinear2DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityLinear2DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::VelocityLinear2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/velocity_linear_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_3d_stamped.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>
@@ -68,3 +69,4 @@ void VelocityLinear3DStamped::print(std::ostream& stream) const
 }  // namespace fuse_variables
 
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityLinear3DStamped);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::VelocityLinear3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/velocity_linear_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_3d_stamped.cpp
@@ -38,6 +38,8 @@
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
 
+#include <boost/serialization/export.hpp>
+
 #include <ostream>
 
 
@@ -64,3 +66,5 @@ void VelocityLinear3DStamped::print(std::ostream& stream) const
 }
 
 }  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::VelocityLinear3DStamped);

--- a/fuse_variables/test/test_acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_angular_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::AccelerationAngular2DStamped;
@@ -137,6 +139,32 @@ TEST(AccelerationAngular2DStamped, Optimization)
 
   // Check
   EXPECT_NEAR(2.7, acceleration.yaw(), 1.0e-5);
+}
+
+TEST(AccelerationAngular2DStamped, Serialization)
+{
+  // Create a AccelerationAngular2DStamped
+  AccelerationAngular2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.yaw() = 1.5;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  AccelerationAngular2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.yaw(), actual.yaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_angular_3d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/acceleration_angular_3d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::AccelerationAngular3DStamped;
@@ -143,6 +145,36 @@ TEST(AccelerationAngular3DStamped, Optimization)
   EXPECT_NEAR(3.0, acceleration.roll(), 1.0e-5);
   EXPECT_NEAR(-8.0, acceleration.pitch(), 1.0e-5);
   EXPECT_NEAR(17.0, acceleration.yaw(), 1.0e-5);
+}
+
+TEST(AccelerationAngular3DStamped, Serialization)
+{
+  // Create a AccelerationAngular3DStamped
+  AccelerationAngular3DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.roll() = 1.5;
+  expected.pitch() = -3.0;
+  expected.yaw() = 14.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  AccelerationAngular3DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.roll(), actual.roll());
+  EXPECT_EQ(expected.pitch(), actual.pitch());
+  EXPECT_EQ(expected.yaw(), actual.yaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_linear_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::AccelerationLinear2DStamped;
@@ -140,6 +142,34 @@ TEST(AccelerationLinear2DStamped, Optimization)
   // Check
   EXPECT_NEAR(3.0, acceleration.x(), 1.0e-5);
   EXPECT_NEAR(-8.0, acceleration.y(), 1.0e-5);
+}
+
+TEST(AccelerationLinear2DStamped, Serialization)
+{
+  // Create a AccelerationLinear2DStamped
+  AccelerationLinear2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  AccelerationLinear2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_linear_3d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/acceleration_linear_3d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::AccelerationLinear3DStamped;
@@ -116,7 +118,7 @@ TEST(AccelerationLinear3DStamped, Optimization)
   AccelerationLinear3DStamped acceleration(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
   acceleration.x() = 1.5;
   acceleration.y() = -3.0;
-  acceleration.y() = 14.0;
+  acceleration.z() = 14.0;
 
   // Create a simple a constraint
   ceres::CostFunction* cost_function = new ceres::AutoDiffCostFunction<CostFunctor, 3, 3>(new CostFunctor());
@@ -143,6 +145,36 @@ TEST(AccelerationLinear3DStamped, Optimization)
   EXPECT_NEAR(3.0, acceleration.x(), 1.0e-5);
   EXPECT_NEAR(-8.0, acceleration.y(), 1.0e-5);
   EXPECT_NEAR(17.0, acceleration.z(), 1.0e-5);
+}
+
+TEST(AccelerationLinear3DStamped, Serialization)
+{
+  // Create a AccelerationLinear3DStamped
+  AccelerationLinear3DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+  expected.z() = 14.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  AccelerationLinear3DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
+  EXPECT_EQ(expected.z(), actual.z());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_fixed_size_variable.cpp
+++ b/fuse_variables/test/test_fixed_size_variable.cpp
@@ -31,9 +31,12 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
 
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
 #include <gtest/gtest.h>
 
 
@@ -48,6 +51,22 @@ public:
   virtual ~TestVariable() = default;
 
   void print(std::ostream& /*stream = std::cout*/) const override {}
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_variables::FixedSizeVariable<2>>(*this);
+  }
 };
 
 

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_core/autodiff_local_parameterization.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -43,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <sstream>
 #include <vector>
 
 
@@ -263,6 +265,32 @@ TEST(Orientation2DStamped, Optimization)
 
   // Check
   EXPECT_NEAR(3.0, orientation.yaw(), 1.0e-5);
+}
+
+TEST(Orientation2DStamped, Serialization)
+{
+  // Create a Orientation2DStamped
+  Orientation2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.yaw() = 1.5;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  Orientation2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.yaw(), actual.yaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_orientation_3d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_3d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_core/autodiff_local_parameterization.h>
 #include <fuse_core/eigen.h>
 #include <fuse_variables/orientation_3d_stamped.h>
@@ -45,6 +46,7 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 
@@ -378,6 +380,38 @@ TEST(Orientation3DStamped, Euler)
   orientation_y.z() = 0.258819;
 
   EXPECT_NEAR(30.0, RAD_TO_DEG * orientation_y.yaw(), 1e-5);
+}
+
+TEST(Orientation3DStamped, Serialization)
+{
+  // Create an Orientation3DStamped
+  Orientation3DStamped expected(ros::Time(12345678, 910111213));
+  expected.w() = 0.952;
+  expected.x() = 0.038;
+  expected.y() = -0.189;
+  expected.z() = 0.239;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  Orientation3DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.w(), actual.w());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
+  EXPECT_EQ(expected.z(), actual.z());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_position_2d_stamped.cpp
+++ b/fuse_variables/test/test_position_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::Position2DStamped;
@@ -140,6 +142,34 @@ TEST(Position2DStamped, Optimization)
   // Check
   EXPECT_NEAR(3.0, position.x(), 1.0e-5);
   EXPECT_NEAR(-8.0, position.y(), 1.0e-5);
+}
+
+TEST(Position2DStamped, Serialization)
+{
+  // Create a Position2DStamped
+  Position2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  Position2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_position_3d_stamped.cpp
+++ b/fuse_variables/test/test_position_3d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/position_3d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::Position3DStamped;
@@ -160,6 +162,36 @@ TEST(Position3DStamped, Optimization)
   EXPECT_NEAR(3.0, position.x(), 1.0e-5);
   EXPECT_NEAR(-8.0, position.y(), 1.0e-5);
   EXPECT_NEAR(3.1, position.z(), 1.0e-5);
+}
+
+TEST(Position3DStamped, Serialization)
+{
+  // Create a Position3DStamped
+  Position3DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+  expected.z() = 0.8;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  Position3DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
+  EXPECT_EQ(expected.z(), actual.z());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_angular_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::VelocityAngular2DStamped;
@@ -137,6 +139,32 @@ TEST(VelocityAngular2DStamped, Optimization)
 
   // Check
   EXPECT_NEAR(2.7, velocity.yaw(), 1.0e-5);
+}
+
+TEST(VelocityAngular2DStamped, Serialization)
+{
+  // Create a VelocityAngular2DStamped
+  VelocityAngular2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.yaw() = 1.5;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  VelocityAngular2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.yaw(), actual.yaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_angular_3d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/velocity_angular_3d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::VelocityAngular3DStamped;
@@ -143,6 +145,36 @@ TEST(VelocityAngular3DStamped, Optimization)
   EXPECT_NEAR(3.0, velocity.roll(), 1.0e-5);
   EXPECT_NEAR(-8.0, velocity.pitch(), 1.0e-5);
   EXPECT_NEAR(17.0, velocity.yaw(), 1.0e-5);
+}
+
+TEST(VelocityAngular3DStamped, Serialization)
+{
+  // Create a VelocityAngular3DStamped
+  VelocityAngular3DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.roll() = 1.5;
+  expected.pitch() = -3.0;
+  expected.yaw() = 14.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  VelocityAngular3DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.roll(), actual.roll());
+  EXPECT_EQ(expected.pitch(), actual.pitch());
+  EXPECT_EQ(expected.yaw(), actual.yaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_variables/test/test_velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_linear_2d_stamped.cpp
@@ -31,6 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/serialization.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 #include <fuse_variables/stamped.h>
 #include <ros/time.h>
@@ -40,6 +41,7 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <vector>
 
 using fuse_variables::VelocityLinear2DStamped;
@@ -140,6 +142,34 @@ TEST(VelocityLinear2DStamped, Optimization)
   // Check
   EXPECT_NEAR(3.0, velocity.x(), 1.0e-5);
   EXPECT_NEAR(-8.0, velocity.y(), 1.0e-5);
+}
+
+TEST(VelocityLinear2DStamped, Serialization)
+{
+  // Create a VelocityLinear2DStamped
+  VelocityLinear2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  VelocityLinear2DStamped actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.deviceId(), actual.deviceId());
+  EXPECT_EQ(expected.stamp(), actual.stamp());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR adds serialization to the API of the Variable, Constraint, Graph, and Transaction classes. Support for additional class types can be added as needed.

Additionally, a ROS msgs have been added to transport serialized Graph and Transaction objects using standard ROS comms mechanisms. To demonstrate this ability, a fuse Publisher was created to serialize and publish the updated graph, and a stand alone utility, fuse_echo, was created to subscribe, deserialize, and print the graph.

All commits in this PR have been reviewed independently.