### PR TITLE
Add fuse_viz pkg with rviz SerializedGraph display

### DIFF
--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>fuse_optimizers</exec_depend>
   <exec_depend>fuse_publishers</exec_depend>
   <exec_depend>fuse_variables</exec_depend>
+  <exec_depend>fuse_viz</exec_depend>
 
   <export>
     <metapackage />

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse_viz)
+
+set(build_depends
+  fuse_msgs
+  fuse_variables
+  rviz
+)
+
+find_package(catkin REQUIRED COMPONENTS
+  ${build_depends}
+)
+
+find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+set(QT_LIBRARIES Qt5::Widgets)
+
+add_definitions(-DQT_NO_KEYWORDS)
+
+###########
+## Build ##
+###########
+
+add_compile_options(-std=c++14 -Wall -Werror)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    ${build_depends}
+  DEPENDS
+    QT
+)
+
+qt5_wrap_cpp(moc_files
+  include/fuse_viz/serialized_graph_display.h
+)
+
+set(source_files
+  src/serialized_graph_display.cpp
+  ${moc_files}
+)
+
+add_library(${PROJECT_NAME}
+  ${source_files}
+)
+add_dependencies(${PROJECT_NAME}
+  ${catkin_EXPORTED_TARGETS}
+)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${QT_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  FILES rviz_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslint REQUIRED)
+
+  # Lint tests
+  set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
+  roslint_cpp()
+  roslint_add_test()
+endif()

--- a/fuse_viz/include/fuse_viz/serialized_graph_display.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_display.h
@@ -1,0 +1,104 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H
+#define FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H
+
+#ifndef Q_MOC_RUN
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_msgs/SerializedGraph.h>
+
+#include <rviz/message_filter_display.h>
+#endif  // Q_MOC_RUN
+
+#include <vector>
+
+namespace Ogre
+{
+class SceneNode;
+}
+
+namespace rviz
+{
+
+class Object;
+
+class BoolProperty;
+class FloatProperty;
+
+/**
+ * @brief An rviz dispaly for fuse_msgs::SerializedGraph messages.
+ */
+class SerializedGraphDisplay : public MessageFilterDisplay<fuse_msgs::SerializedGraph>
+{
+  Q_OBJECT
+public:
+  SerializedGraphDisplay();
+
+  ~SerializedGraphDisplay() override;
+
+  void reset() override;
+
+protected:
+  void onInitialize() override;
+
+  void onEnable() override;
+
+  void onDisable() override;
+
+private Q_SLOTS:
+  void updateDrawVariablesAxesProperty();
+
+  void updateScaleProperty();
+
+private:
+  void clear();
+
+  void processMessage(const fuse_msgs::SerializedGraph::ConstPtr& msg) override;
+
+  Ogre::SceneNode* root_node_;
+  Ogre::SceneNode* variables_axes_node_;
+  Ogre::SceneNode* variables_spheres_node_;
+
+  std::vector<Object*> graph_shapes_;
+
+  BoolProperty* draw_variables_axes_property_;
+  FloatProperty* scale_property_;
+
+  fuse_core::GraphDeserializer graph_deserializer_;
+};
+
+}  // namespace rviz
+
+#endif  // FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H

--- a/fuse_viz/package.xml
+++ b/fuse_viz/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse_viz</name>
+  <version>0.4.0</version>
+  <description>
+    The fuse_viz package provides visualization tools for fuse.
+  </description>
+
+  <maintainer email="efernandez@clearpath.ai">Enrique Fernandez</maintainer>
+  <author email="efernandez@clearpath.ai">Enrique Fernandez</author>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>fuse_msgs</depend>
+  <depend>fuse_variables</depend>
+  <depend>rviz</depend>
+
+  <export>
+    <rviz plugin="${prefix}/rviz_plugins.xml"/>
+  </export>
+</package>

--- a/fuse_viz/rviz_plugins.xml
+++ b/fuse_viz/rviz_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libfuse_viz">
+  <class name="fuse_viz/SerializedGraph" type="rviz::SerializedGraphDisplay" base_class_type="rviz::Display">
+    <description>
+    An rviz display for fuse_msgs::SerializedGraph messages.
+    </description>
+  </class>
+</library>

--- a/fuse_viz/src/serialized_graph_display.cpp
+++ b/fuse_viz/src/serialized_graph_display.cpp
@@ -1,0 +1,193 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef Q_MOC_RUN
+#include <OgreBillboardSet.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+#include <rviz/ogre_helpers/axes.h>
+#include <rviz/ogre_helpers/billboard_line.h>
+#include <rviz/ogre_helpers/object.h>
+#include <rviz/ogre_helpers/shape.h>
+
+#include <rviz/display_context.h>
+#include <rviz/frame_manager.h>
+
+#include <rviz/properties/bool_property.h>
+#include <rviz/properties/float_property.h>
+#endif  // Q_MOC_RUN
+
+#include <fuse_viz/serialized_graph_display.h>
+
+#include <fuse_core/graph.h>
+#include <fuse_variables/orientation_2d_stamped.h>
+#include <fuse_variables/position_2d_stamped.h>
+
+namespace rviz
+{
+
+SerializedGraphDisplay::SerializedGraphDisplay()
+{
+  draw_variables_axes_property_ = new BoolProperty("Draw Variables as Axes", true,
+                                                   "Whether to draw graph variables axes or not (spheres are always "
+                                                   "drawn)",
+                                                   this, SLOT(updateDrawVariablesAxesProperty()));
+
+  scale_property_ = new FloatProperty("Scale", 0.1, "Scale of graph markers drawn", this, SLOT(updateScaleProperty()));
+}
+
+SerializedGraphDisplay::~SerializedGraphDisplay()
+{
+  if (initialized())
+  {
+    clear();
+    root_node_->removeAndDestroyAllChildren();
+    scene_manager_->destroySceneNode(root_node_->getName());
+  }
+}
+
+void SerializedGraphDisplay::reset()
+{
+  MFDClass::reset();
+  clear();
+}
+
+void SerializedGraphDisplay::onInitialize()
+{
+  MFDClass::onInitialize();
+
+  root_node_ = scene_node_->createChildSceneNode();
+
+  variables_axes_node_ = root_node_->createChildSceneNode();
+  variables_spheres_node_ = root_node_->createChildSceneNode();
+}
+
+void SerializedGraphDisplay::onEnable()
+{
+  MFDClass::onEnable();
+
+  root_node_->setVisible(true);
+}
+
+void SerializedGraphDisplay::onDisable()
+{
+  MFDClass::onDisable();
+
+  root_node_->setVisible(false);
+}
+
+void SerializedGraphDisplay::updateDrawVariablesAxesProperty()
+{
+  variables_axes_node_->setVisible(draw_variables_axes_property_->getBool());
+}
+
+void SerializedGraphDisplay::updateScaleProperty()
+{
+  // TODO(efernandez) Redraw all variables so the scale is applied to the current graph. This is useful if no new
+  // message is received
+}
+
+void SerializedGraphDisplay::clear()
+{
+  for (auto& graph_shape : graph_shapes_)
+  {
+    delete graph_shape;
+  }
+  graph_shapes_.clear();
+}
+
+void SerializedGraphDisplay::processMessage(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+{
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  if (!context_->getFrameManager()->getTransform(msg->header, position, orientation))
+  {
+    ROS_DEBUG_STREAM("Error transforming from frame '" << msg->header.frame_id << "' to frame '"
+                                                       << qPrintable(fixed_frame_) << "'");
+  }
+
+  root_node_->setPosition(position);
+  root_node_->setOrientation(orientation);
+
+  clear();
+
+  const auto graph = graph_deserializer_.deserialize(msg);
+
+  const Ogre::Vector3 scale(scale_property_->getFloat());
+
+  for (const auto& variable : graph->getVariables())
+  {
+    const auto orientation = dynamic_cast<const fuse_variables::Orientation2DStamped*>(&variable);
+    if (!orientation)
+    {
+      continue;
+    }
+
+    const auto& stamp = orientation->stamp();
+    const auto position_uuid = fuse_variables::Position2DStamped(stamp, orientation->deviceId()).uuid();
+    if (!graph->variableExists(position_uuid))
+    {
+      continue;
+    }
+
+    const auto position = dynamic_cast<const fuse_variables::Position2DStamped*>(&graph->getVariable(position_uuid));
+
+    const tf2::Quaternion tf_q(tf2::Vector3(0, 0, 1), orientation->yaw());
+
+    const Ogre::Vector3 p(position->x(), position->y(), 0);
+    const Ogre::Quaternion q(tf_q.w(), tf_q.x(), tf_q.y(), tf_q.z());
+
+    // Add sphere:
+    Object* sphere = new rviz::Shape(rviz::Shape::Sphere, scene_manager_, variables_spheres_node_);
+    sphere->setPosition(p);
+    sphere->setScale(scale);
+    sphere->setColor(1.0, 0.0, 0.0, 1.0);
+    graph_shapes_.push_back(sphere);
+
+    // Add axes:
+    Object* axes = new rviz::Axes(scene_manager_, variables_axes_node_, 10.0, 1.0);
+    axes->setPosition(p);
+    axes->setOrientation(q);
+    axes->setScale(scale);
+    graph_shapes_.push_back(axes);
+  }
+
+  updateDrawVariablesAxesProperty();
+}
+
+}  // namespace rviz
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(rviz::SerializedGraphDisplay, rviz::Display)


### PR DESCRIPTION
This adds a `fuse_viz` pkg with and `rviz` `fuse_msgs::SerializedGraph` display. This is a very basic implementation for now, but it sets a baseline for improvements and discussions.

This PR is now targeting `devel` and it's been rebased.