### PR TITLE
[RST-2437] Ensure that all variables are updated

### DIFF
--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -123,9 +123,9 @@ void TimestampManager::query(
             if (std::any_of(
                   transaction_variables.begin(),
                   transaction_variables.end(),
-                  [&variable](const fuse_core::Variable& input_variable)
+                  [variable_uuid = variable->uuid()](const auto& input_variable)
                   {
-                    return input_variable.uuid() == variable->uuid();
+                    return input_variable.uuid() == variable_uuid;
                   }))  // NOLINT
             {
               motion_model_transaction.addVariable(variable, update_variables);

--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -81,7 +81,7 @@ void TimestampManager::query(
   Transaction motion_model_transaction;
   std::set<ros::Time> augmented_stamps(stamps.begin(), stamps.end());
   auto first_stamp = *augmented_stamps.begin();
-  ros::Time last_stamp = *augmented_stamps.rbegin();
+  auto last_stamp = *augmented_stamps.rbegin();
   {
     auto begin = motion_model_history_.upper_bound(first_stamp);
     if (begin != motion_model_history_.begin())

--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -41,6 +41,7 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 
+#include <algorithm>
 #include <iterator>
 #include <set>
 #include <stdexcept>
@@ -78,18 +79,9 @@ void TimestampManager::query(
   // Create a list of all the required timestamps involved in motion model segments that must be created
   // Add all of the existing timestamps between the first and last input stamp
   Transaction motion_model_transaction;
-  auto first_stamp = stamps.front();
-  // stamps is a forward-only range. Getting the last element takes a bit of work.
-  ros::Time last_stamp;
-  {
-    auto iter = stamps.begin();
-    while (std::next(iter) != stamps.end())
-    {
-      ++iter;
-    }
-    last_stamp = *iter;
-  }
   std::set<ros::Time> augmented_stamps(stamps.begin(), stamps.end());
+  auto first_stamp = *augmented_stamps.begin();
+  ros::Time last_stamp = *augmented_stamps.rbegin();
   {
     auto begin = motion_model_history_.upper_bound(first_stamp);
     if (begin != motion_model_history_.begin())
@@ -121,6 +113,25 @@ void TimestampManager::query(
           (history_iter->second.beginning_stamp == previous_stamp) &&
           (history_iter->second.ending_stamp == current_stamp))
       {
+        if (update_variables)
+        {
+          // Add the motion model version of the variables involved in this motion model segment
+          // This ensures that the variables in the final transaction will be overwritten with the motion model version
+          auto transaction_variables = transaction.addedVariables();
+          for (const auto& variable : history_iter->second.variables)
+          {
+            if (std::any_of(
+                  transaction_variables.begin(),
+                  transaction_variables.end(),
+                  [&variable](const fuse_core::Variable& input_variable)
+                  {
+                    return input_variable.uuid() == variable->uuid();
+                  }))  // NOLINT
+            {
+              motion_model_transaction.addVariable(variable, update_variables);
+            }
+          }
+        }
         continue;
       }
       // Check if this stamp is in the middle of an existing entry. If so, delete it.


### PR DESCRIPTION
Ensure that all variables are updated when the update_variables flag is set. Previously, only variables involved in motion model segments that needed to be generated were being updated. Variables involved in previously generated segments were left untouched. This could result in incorrect initial state guesses being used for those variables.

As an example, imagine a sensor transaction that connects two adjacent states at T1 and T2, and a second transaction that connects T1 to T3. If both of these transactions are added to the graph at the same time:
* Transaction1 is processed. A motion model segment is generated from T1 to T2. Since states T1 and T2 are involved in the newly generated motion model segment, their states are updated. No other states are involved in this transaction, so all states have been updated.
* Transaction2 is processed. A motion model is generated from T2 to T3. Since a motion model was previously generated from T1 to T2, the motion model does not need to regenerate that segment. Since states T2 and T3 are involved in the newly generated motion model segment, their states are updated. However, the transaction also involves the state at T1. It was not involved in the generated motion model segment, so its state has not been updated. The original state from Transaction2 overwrites the updated state from Transaction1. This can lead to a poor initial guess being sent to the optimizer.

With this PR, if the `update_variables` flag is set, any variable from a previously generated motion model segment that is also involved in the current transaction is updated from the value stored in the motion model history.