### PR TITLE
[RST-2438] Make ceres params loaders reusable

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(${PROJECT_NAME}
   src/async_motion_model.cpp
   src/async_publisher.cpp
   src/async_sensor_model.cpp
+  src/ceres_options.cpp
   src/constraint.cpp
   src/graph.cpp
   src/graph_deserializer.cpp

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -37,6 +37,9 @@
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
+#include <ceres/covariance.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
 #include <ceres/types.h>
 
 #include <string>
@@ -98,7 +101,7 @@ static void UpperCase(std::string* input)
   std::transform(input->begin(), input->end(), input->begin(), ::toupper);  // NOLINT(build/include_what_you_use)
 }
 
-const char* LoggingTypeToString(LoggingType type)
+inline const char* LoggingTypeToString(LoggingType type)
 {
   switch (type)
   {
@@ -109,7 +112,7 @@ const char* LoggingTypeToString(LoggingType type)
   }
 }
 
-bool StringToLoggingType(std::string value, LoggingType* type)
+inline bool StringToLoggingType(std::string value, LoggingType* type)
 {
   UpperCase(&value);
   STRENUM(SILENT);
@@ -117,7 +120,7 @@ bool StringToLoggingType(std::string value, LoggingType* type)
   return false;
 }
 
-const char* DumpFormatTypeToString(DumpFormatType type)
+inline const char* DumpFormatTypeToString(DumpFormatType type)
 {
   switch (type)
   {
@@ -128,7 +131,7 @@ const char* DumpFormatTypeToString(DumpFormatType type)
   }
 }
 
-bool StringToDumpFormatType(std::string value, DumpFormatType* type)
+inline bool StringToDumpFormatType(std::string value, DumpFormatType* type)
 {
   UpperCase(&value);
   STRENUM(CONSOLE);
@@ -210,6 +213,30 @@ T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name
 
   return value;
 }
+
+/**
+ * @brief Populate a ceres::Covariance::Options object with information from the parameter server
+ *
+ * @param[in] nh - A node handle in a namespace containing ceres::Covariance::Options settings
+ * @param[out] covariance_options - The ceres::Covariance::Options object to update
+ */
+void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::Options& covariance_options);
+
+/**
+ * @brief Populate a ceres::Problem::Options object with information from the parameter server
+ *
+ * @param[in] nh - A node handle in a namespace containing ceres::Problem::Options settings
+ * @param[out] problem_options - The ceres::Problem::Options object to update
+ */
+void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Options& problem_options);
+
+/**
+ * @brief Populate a ceres::Solver::Options object with information from the parameter server
+ *
+ * @param[in] nh - A node handle in a namespace containing ceres::Solver::Options settings
+ * @param[out] solver_options - The ceres::Solver::Options object to update
+ */
+void loadSolverOptionsFromROS(const ros::NodeHandle& nh, ceres::Solver::Options& solver_options);
 
 }  // namespace fuse_core
 

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -34,10 +34,14 @@
 #ifndef FUSE_CORE_UTIL_H
 #define FUSE_CORE_UTIL_H
 
+#include <ros/console.h>
+#include <ros/node_handle.h>
+
 #include <ceres/jet.h>
 #include <Eigen/Core>
 
 #include <cmath>
+#include <string>
 
 
 namespace fuse_core
@@ -148,6 +152,30 @@ Eigen::Matrix<T, 2, 2, Eigen::RowMajor> rotationMatrix2D(const T angle)
   Eigen::Matrix<T, 2, 2, Eigen::RowMajor> rotation;
   rotation << cos_angle, -sin_angle, sin_angle, cos_angle;
   return rotation;
+}
+
+
+/**
+ * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in] default_value - A default value to use if the provided parameter name does not exist
+ * @return The loaded (or default) value
+ */
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type* = nullptr>
+T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T default_value)
+{
+  T value;
+  node_handle.param(parameter_name, value, default_value);
+  if (value <= 0)
+  {
+    ROS_WARN_STREAM("The requested " << parameter_name << " is <= 0. Using the default value (" <<
+                    default_value << ") instead.");
+    value = default_value;
+  }
+  return value;
 }
 
 }  // namespace fuse_core

--- a/fuse_core/src/ceres_options.cpp
+++ b/fuse_core/src/ceres_options.cpp
@@ -1,0 +1,202 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019 Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/ceres_options.h>
+
+#include <ros/node_handle.h>
+
+#include <ceres/covariance.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
+
+#include <stdexcept>
+#include <string>
+
+
+namespace fuse_core
+{
+
+void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::Options& covariance_options)
+{
+#if CERES_VERSION_AT_LEAST(1, 13, 0)
+  // The sparse_linear_algebra_library_type field was added to ceres::Covariance::Options in version 1.13.0, see
+  // https://github.com/ceres-solver/ceres-solver/commit/14d8297cf968e421c5db4e3fb0543b3b111155d7
+  covariance_options.sparse_linear_algebra_library_type = fuse_core::getParam(
+      nh, "sparse_linear_algebra_library_type", covariance_options.sparse_linear_algebra_library_type);
+#endif
+  covariance_options.algorithm_type = fuse_core::getParam(nh, "algorithm_type", covariance_options.algorithm_type);
+  nh.param("min_reciprocal_condition_number", covariance_options.min_reciprocal_condition_number,
+           covariance_options.min_reciprocal_condition_number);
+  nh.param("null_space_rank", covariance_options.null_space_rank, covariance_options.null_space_rank);
+  nh.param("num_threads", covariance_options.num_threads, covariance_options.num_threads);
+  nh.param("apply_loss_function", covariance_options.apply_loss_function, covariance_options.apply_loss_function);
+}
+
+void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Options& problem_options)
+{
+  nh.param("enable_fast_removal", problem_options.enable_fast_removal, problem_options.enable_fast_removal);
+  nh.param("disable_all_safety_checks", problem_options.disable_all_safety_checks,
+           problem_options.disable_all_safety_checks);
+}
+
+void loadSolverOptionsFromROS(const ros::NodeHandle& nh, ceres::Solver::Options& solver_options)
+{
+  // Minimizer options
+  solver_options.minimizer_type = fuse_core::getParam(nh, "minimizer_type", solver_options.minimizer_type);
+  solver_options.line_search_direction_type =
+      fuse_core::getParam(nh, "line_search_direction_type", solver_options.line_search_direction_type);
+  solver_options.line_search_type = fuse_core::getParam(nh, "line_search_type", solver_options.line_search_type);
+  solver_options.nonlinear_conjugate_gradient_type =
+      fuse_core::getParam(nh, "nonlinear_conjugate_gradient_type", solver_options.nonlinear_conjugate_gradient_type);
+
+  nh.param("max_lbfgs_rank", solver_options.max_lbfgs_rank, solver_options.max_lbfgs_rank);
+  nh.param("use_approximate_eigenvalue_bfgs_scaling", solver_options.use_approximate_eigenvalue_bfgs_scaling,
+           solver_options.use_approximate_eigenvalue_bfgs_scaling);
+
+  solver_options.line_search_interpolation_type =
+      fuse_core::getParam(nh, "line_search_interpolation_type", solver_options.line_search_interpolation_type);
+  nh.param("min_line_search_step_size", solver_options.min_line_search_step_size,
+           solver_options.min_line_search_step_size);
+
+  // Line search parameters
+  nh.param("line_search_sufficient_function_decrease", solver_options.line_search_sufficient_function_decrease,
+           solver_options.line_search_sufficient_function_decrease);
+  nh.param("max_line_search_step_contraction", solver_options.max_line_search_step_contraction,
+           solver_options.max_line_search_step_contraction);
+  nh.param("min_line_search_step_contraction", solver_options.min_line_search_step_contraction,
+           solver_options.min_line_search_step_contraction);
+  nh.param("max_num_line_search_step_size_iterations", solver_options.max_num_line_search_step_size_iterations,
+           solver_options.max_num_line_search_step_size_iterations);
+  nh.param("max_num_line_search_direction_restarts", solver_options.max_num_line_search_direction_restarts,
+           solver_options.max_num_line_search_direction_restarts);
+  nh.param("line_search_sufficient_curvature_decrease", solver_options.line_search_sufficient_curvature_decrease,
+           solver_options.line_search_sufficient_curvature_decrease);
+  nh.param("max_line_search_step_expansion", solver_options.max_line_search_step_expansion,
+           solver_options.max_line_search_step_expansion);
+
+  solver_options.trust_region_strategy_type =
+      fuse_core::getParam(nh, "trust_region_strategy_type", solver_options.trust_region_strategy_type);
+  solver_options.dogleg_type = fuse_core::getParam(nh, "dogleg_type", solver_options.dogleg_type);
+
+  nh.param("use_nonmonotonic_steps", solver_options.use_nonmonotonic_steps, solver_options.use_nonmonotonic_steps);
+  nh.param("max_consecutive_nonmonotonic_steps", solver_options.max_consecutive_nonmonotonic_steps,
+           solver_options.max_consecutive_nonmonotonic_steps);
+
+  nh.param("max_num_iterations", solver_options.max_num_iterations, solver_options.max_num_iterations);
+  nh.param("max_solver_time_in_seconds", solver_options.max_solver_time_in_seconds,
+           solver_options.max_solver_time_in_seconds);
+
+  nh.param("num_threads", solver_options.num_threads, solver_options.num_threads);
+
+  nh.param("initial_trust_region_radius", solver_options.initial_trust_region_radius,
+           solver_options.initial_trust_region_radius);
+  nh.param("max_trust_region_radius", solver_options.max_trust_region_radius, solver_options.max_trust_region_radius);
+  nh.param("min_trust_region_radius", solver_options.min_trust_region_radius, solver_options.min_trust_region_radius);
+
+  nh.param("min_relative_decrease", solver_options.min_relative_decrease, solver_options.min_relative_decrease);
+  nh.param("min_lm_diagonal", solver_options.min_lm_diagonal, solver_options.min_lm_diagonal);
+  nh.param("max_lm_diagonal", solver_options.max_lm_diagonal, solver_options.max_lm_diagonal);
+  nh.param("max_num_consecutive_invalid_steps", solver_options.max_num_consecutive_invalid_steps,
+           solver_options.max_num_consecutive_invalid_steps);
+  nh.param("function_tolerance", solver_options.function_tolerance, solver_options.function_tolerance);
+  nh.param("gradient_tolerance", solver_options.gradient_tolerance, solver_options.gradient_tolerance);
+  nh.param("parameter_tolerance", solver_options.parameter_tolerance, solver_options.parameter_tolerance);
+
+  solver_options.linear_solver_type =
+      fuse_core::getParam(nh, "linear_solver_type", solver_options.linear_solver_type);
+  solver_options.preconditioner_type =
+      fuse_core::getParam(nh, "preconditioner_type", solver_options.preconditioner_type);
+  solver_options.visibility_clustering_type =
+      fuse_core::getParam(nh, "visibility_clustering_type", solver_options.visibility_clustering_type);
+  solver_options.dense_linear_algebra_library_type =
+      fuse_core::getParam(nh, "dense_linear_algebra_library_type", solver_options.dense_linear_algebra_library_type);
+  solver_options.sparse_linear_algebra_library_type = fuse_core::getParam(
+      nh, "sparse_linear_algebra_library_type", solver_options.sparse_linear_algebra_library_type);
+
+  // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> linear_solver_ordering;
+
+  nh.param("use_explicit_schur_complement", solver_options.use_explicit_schur_complement,
+           solver_options.use_explicit_schur_complement);
+  nh.param("use_postordering", solver_options.use_postordering, solver_options.use_postordering);
+  nh.param("dynamic_sparsity", solver_options.dynamic_sparsity, solver_options.dynamic_sparsity);
+
+#if CERES_VERSION_AT_LEAST(2, 0, 0)
+  nh.param("use_mixed_precision_solves", solver_options.use_mixed_precision_solves,
+           solver_options.use_mixed_precision_solves);
+  nh.param("max_num_refinement_iterations", solver_options.max_num_refinement_iterations,
+           solver_options.max_num_refinement_iterations);
+#endif
+
+  nh.param("use_inner_iterations", solver_options.use_inner_iterations, solver_options.use_inner_iterations);
+
+  // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> inner_iteration_ordering;
+
+  nh.param("inner_iteration_tolerance", solver_options.inner_iteration_tolerance,
+           solver_options.inner_iteration_tolerance);
+  nh.param("min_linear_solver_iterations", solver_options.min_linear_solver_iterations,
+           solver_options.min_linear_solver_iterations);
+  nh.param("max_linear_solver_iterations", solver_options.max_linear_solver_iterations,
+           solver_options.max_linear_solver_iterations);
+  nh.param("eta", solver_options.eta, solver_options.eta);
+
+  nh.param("jacobi_scaling", solver_options.jacobi_scaling, solver_options.jacobi_scaling);
+
+  // Logging options
+  solver_options.logging_type = fuse_core::getParam(nh, "logging_type", solver_options.logging_type);
+  nh.param("minimizer_progress_to_stdout", solver_options.minimizer_progress_to_stdout,
+           solver_options.minimizer_progress_to_stdout);
+  nh.param("trust_region_minimizer_iterations_to_dump", solver_options.trust_region_minimizer_iterations_to_dump,
+           solver_options.trust_region_minimizer_iterations_to_dump);
+  nh.param("trust_region_problem_dump_directory", solver_options.trust_region_problem_dump_directory,
+           solver_options.trust_region_problem_dump_directory);
+  solver_options.trust_region_problem_dump_format_type = fuse_core::getParam(
+      nh, "trust_region_problem_dump_format_type", solver_options.trust_region_problem_dump_format_type);
+
+  // Finite differences options
+  nh.param("check_gradients", solver_options.check_gradients, solver_options.check_gradients);
+  nh.param("gradient_check_relative_precision", solver_options.gradient_check_relative_precision,
+           solver_options.gradient_check_relative_precision);
+  nh.param("gradient_check_numeric_derivative_relative_step_size",
+           solver_options.gradient_check_numeric_derivative_relative_step_size,
+           solver_options.gradient_check_numeric_derivative_relative_step_size);
+  nh.param("update_state_every_iteration", solver_options.update_state_every_iteration,
+           solver_options.update_state_every_iteration);
+
+  std::string error;
+  if (!solver_options.IsValid(&error))
+  {
+    throw std::invalid_argument("Invalid solver options in parameter " + nh.getNamespace() + ". Error: " + error);
+  }
+}
+
+}  // namespace fuse_core

--- a/fuse_graphs/include/fuse_graphs/hash_graph_params.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph_params.h
@@ -34,15 +34,11 @@
 #ifndef FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
 #define FUSE_GRAPHS_HASH_GRAPH_PARAMS_H
 
-#include <ros/console.h>
-#include <ros/duration.h>
+#include <fuse_core/ceres_options.h>
 #include <ros/node_handle.h>
 
 #include <ceres/problem.h>
 
-#include <algorithm>
-#include <string>
-#include <vector>
 
 namespace fuse_graphs
 {
@@ -67,20 +63,7 @@ public:
    */
   void loadFromROS(const ros::NodeHandle& nh)
   {
-    loadProblemOptionsFromROS(ros::NodeHandle(nh, "problem_options"));
-  }
-
-private:
-  /**
-   * @brief Method for loading Ceres Problem::Options parameter values from ROS.
-   *
-   * @param[in] nh - The ROS node handle with which to load Ceres Problem::Options parameters
-   */
-  void loadProblemOptionsFromROS(const ros::NodeHandle& nh)
-  {
-    nh.param("enable_fast_removal", problem_options.enable_fast_removal, problem_options.enable_fast_removal);
-    nh.param("disable_all_safety_checks", problem_options.disable_all_safety_checks,
-             problem_options.disable_all_safety_checks);
+    fuse_core::loadProblemOptionsFromROS(ros::NodeHandle(nh, "problem_options"), problem_options);
   }
 };
 

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -37,6 +37,7 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/macros.h>
 #include <fuse_core/transaction.h>
+#include <fuse_optimizers/batch_optimizer_params.h>
 #include <fuse_optimizers/optimizer.h>
 #include <ros/ros.h>
 
@@ -102,6 +103,7 @@ class BatchOptimizer : public Optimizer
 {
 public:
   SMART_PTR_DEFINITIONS(BatchOptimizer);
+  using ParameterType = BatchOptimizerParams;
 
   /**
    * @brief Constructor
@@ -150,9 +152,7 @@ protected:
                                                             //!< from multiple sensors and motions models before being
                                                             //!< applied to the graph.
   std::mutex combined_transaction_mutex_;  //!< Synchronize access to the combined transaction across different threads
-  std::vector<std::string> ignition_sensors_;  //!< The set of sensors whose transactions will trigger the optimizer
-                                               //!< thread to start running. This is designed to keep the system idle
-                                               //!< until the origin constraint has been received.
+  ParameterType params_;  //!< Configuration settings for this optimizer
   std::atomic<bool> optimization_request_;  //!< Flag to trigger a new optimization
   std::condition_variable optimization_requested_;  //!< Condition variable used by the optimization thread to wait
                                                     //!< until a new optimization is requested by the main thread
@@ -165,8 +165,6 @@ protected:
   std::mutex pending_transactions_mutex_;  //!< Synchronize modification of the pending_transactions_ container
   ros::Time start_time_;  //!< The timestamp of the first ignition sensor transaction
   bool started_;  //!< Flag indicating the optimizer is ready/has received a transaction from an ignition sensor
-  ros::Duration transaction_timeout_;  //!< Parameter that controls how long to wait for a transaction to be processed
-                                       //!< successfully before kicking it out of the queue.
 
   /**
    * @brief Generate motion model constraints for pending transactions

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -1,0 +1,121 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_OPTIMIZERS_BATCH_OPTIMIZER_PARAMS_H
+#define FUSE_OPTIMIZERS_BATCH_OPTIMIZER_PARAMS_H
+
+#include <fuse_core/ceres_options.h>
+#include <fuse_core/util.h>
+#include <ros/duration.h>
+#include <ros/node_handle.h>
+
+#include <ceres/solver.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+
+namespace fuse_optimizers
+{
+
+/**
+ * @brief Defines the set of parameters required by the fuse_optimizers::FixedLagSmoother class
+ */
+struct BatchOptimizerParams
+{
+public:
+  /**
+   * @brief The set of sensors whose transactions will trigger the optimizer thread to start running
+   *
+   * This is designed to keep the system idle until the origin constraint has been received.
+   */
+  std::vector<std::string> ignition_sensors;
+
+  /**
+   * @brief The target duration for optimization cycles
+   *
+   * If an optimization takes longer than expected, an optimization cycle may be skipped. The optimization period
+   * may be specified in either the "optimization_period" parameter in seconds, or in the "optimization_frequency"
+   * parameter in Hz.
+   */
+  ros::Duration optimization_period { 0.1 };
+
+  /**
+   * @brief The maximum time to wait for motion models to be generated for a received transaction.
+   *
+   * Transactions are processed sequentially, so no new transactions will be added to the graph while waiting for
+   * motion models to be generated. Once the timeout expires, that transaction will be deleted from the queue.
+   */
+  ros::Duration transaction_timeout { 0.1 };
+
+  /**
+   * @brief Ceres Solver::Options object that controls various aspects of the optimizer.
+   */
+  ceres::Solver::Options solver_options;
+
+  /**
+   * @brief Method for loading parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load parameters
+   */
+  void loadFromROS(const ros::NodeHandle& nh)
+  {
+    // Read settings from the parameter server
+    nh.getParam("ignition_sensors", ignition_sensors);
+    std::sort(ignition_sensors.begin(), ignition_sensors.end());
+
+    if (nh.hasParam("optimization_frequency"))
+    {
+      auto optimization_frequency =
+        fuse_core::getPositiveParam(nh, "optimization_frequency", 1.0 / optimization_period.toSec());
+      optimization_period.fromSec(1.0 / optimization_frequency);
+    }
+    else
+    {
+      auto optimization_period_sec =
+        fuse_core::getPositiveParam(nh, "optimization_period", optimization_period.toSec());
+      optimization_period.fromSec(optimization_period_sec);
+    }
+
+    auto transaction_timeout_sec =
+      fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
+    transaction_timeout.fromSec(transaction_timeout_sec);
+
+    fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);
+  }
+};
+
+}  // namespace fuse_optimizers
+
+#endif  // FUSE_OPTIMIZERS_BATCH_OPTIMIZER_PARAMS_H

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -1,20 +1,50 @@
-/***************************************************************************
- * Copyright (C) 2019 Locus Robotics. All rights reserved.
- * Unauthorized copying of this file, via any medium, is strictly prohibited
- * Proprietary and confidential
- ***************************************************************************/
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef FUSE_OPTIMIZERS_FIXED_LAG_SMOOTHER_PARAMS_H
 #define FUSE_OPTIMIZERS_FIXED_LAG_SMOOTHER_PARAMS_H
 
-#include <ros/console.h>
+#include <fuse_core/ceres_options.h>
+#include <fuse_core/util.h>
 #include <ros/duration.h>
 #include <ros/node_handle.h>
 
-#include <fuse_core/ceres_options.h>
+#include <ceres/solver.h>
 
 #include <algorithm>
 #include <string>
 #include <vector>
+
 
 namespace fuse_optimizers
 {
@@ -65,29 +95,6 @@ public:
   ceres::Solver::Options solver_options;
 
   /**
-   * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
-   *
-   * @param[in] node_handle - The node handle used to load the parameter
-   * @param[in] parameter_name - The parameter name to load
-   * @param[in] default_value - A default value to use if the provided parameter name does not exist
-   * @return The loaded (or default) value
-   */
-  template <typename T,
-            typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type* = nullptr>
-  T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T default_value)
-  {
-    T value;
-    node_handle.param(parameter_name, value, default_value);
-    if (value <= 0)
-    {
-      ROS_WARN_STREAM("The requested " << parameter_name << " is <= 0. Using the default value (" <<
-                      default_value << ") instead.");
-      value = default_value;
-    }
-    return value;
-  }
-
-  /**
    * @brief Method for loading parameter values from ROS.
    *
    * @param[in] nh - The ROS node handle with which to load parameters
@@ -98,162 +105,29 @@ public:
     nh.getParam("ignition_sensors", ignition_sensors);
     std::sort(ignition_sensors.begin(), ignition_sensors.end());
 
-    auto lag_duration_sec = getPositiveParam(nh, "lag_duration", lag_duration.toSec());
+    auto lag_duration_sec = fuse_core::getPositiveParam(nh, "lag_duration", lag_duration.toSec());
     lag_duration.fromSec(lag_duration_sec);
 
     if (nh.hasParam("optimization_frequency"))
     {
-      auto optimization_frequency = getPositiveParam(nh, "optimization_frequency", 1.0 / optimization_period.toSec());
+      auto optimization_frequency =
+        fuse_core::getPositiveParam(nh, "optimization_frequency", 1.0 / optimization_period.toSec());
       optimization_period.fromSec(1.0 / optimization_frequency);
     }
     else
     {
-      auto optimization_period_sec = getPositiveParam(nh, "optimization_period", optimization_period.toSec());
+      auto optimization_period_sec =
+        fuse_core::getPositiveParam(nh, "optimization_period", optimization_period.toSec());
       optimization_period.fromSec(optimization_period_sec);
     }
 
     nh.getParam("reset_service", reset_service);
 
-    auto transaction_timeout_sec = getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
+    auto transaction_timeout_sec =
+      fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
     transaction_timeout.fromSec(transaction_timeout_sec);
 
-    loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"));
-  }
-
-private:
-  /**
-   * @brief Method for loading Ceres Solver::Options parameter values from ROS.
-   *
-   * @param[in] nh - The ROS node handle with which to load Ceres Solver::Options parameters
-   */
-  void loadSolverOptionsFromROS(const ros::NodeHandle& nh)
-  {
-    // Minimizer options
-    solver_options.minimizer_type = fuse_core::getParam(nh, "minimizer_type", solver_options.minimizer_type);
-    solver_options.line_search_direction_type =
-        fuse_core::getParam(nh, "line_search_direction_type", solver_options.line_search_direction_type);
-    solver_options.line_search_type = fuse_core::getParam(nh, "line_search_type", solver_options.line_search_type);
-    solver_options.nonlinear_conjugate_gradient_type =
-        fuse_core::getParam(nh, "nonlinear_conjugate_gradient_type", solver_options.nonlinear_conjugate_gradient_type);
-
-    nh.param("max_lbfgs_rank", solver_options.max_lbfgs_rank, solver_options.max_lbfgs_rank);
-    nh.param("use_approximate_eigenvalue_bfgs_scaling", solver_options.use_approximate_eigenvalue_bfgs_scaling,
-             solver_options.use_approximate_eigenvalue_bfgs_scaling);
-
-    solver_options.line_search_interpolation_type =
-        fuse_core::getParam(nh, "line_search_interpolation_type", solver_options.line_search_interpolation_type);
-    nh.param("min_line_search_step_size", solver_options.min_line_search_step_size,
-             solver_options.min_line_search_step_size);
-
-    // Line search parameters
-    nh.param("line_search_sufficient_function_decrease", solver_options.line_search_sufficient_function_decrease,
-             solver_options.line_search_sufficient_function_decrease);
-    nh.param("max_line_search_step_contraction", solver_options.max_line_search_step_contraction,
-             solver_options.max_line_search_step_contraction);
-    nh.param("min_line_search_step_contraction", solver_options.min_line_search_step_contraction,
-             solver_options.min_line_search_step_contraction);
-    nh.param("max_num_line_search_step_size_iterations", solver_options.max_num_line_search_step_size_iterations,
-             solver_options.max_num_line_search_step_size_iterations);
-    nh.param("max_num_line_search_direction_restarts", solver_options.max_num_line_search_direction_restarts,
-             solver_options.max_num_line_search_direction_restarts);
-    nh.param("line_search_sufficient_curvature_decrease", solver_options.line_search_sufficient_curvature_decrease,
-             solver_options.line_search_sufficient_curvature_decrease);
-    nh.param("max_line_search_step_expansion", solver_options.max_line_search_step_expansion,
-             solver_options.max_line_search_step_expansion);
-
-    solver_options.trust_region_strategy_type =
-        fuse_core::getParam(nh, "trust_region_strategy_type", solver_options.trust_region_strategy_type);
-    solver_options.dogleg_type = fuse_core::getParam(nh, "dogleg_type", solver_options.dogleg_type);
-
-    nh.param("use_nonmonotonic_steps", solver_options.use_nonmonotonic_steps, solver_options.use_nonmonotonic_steps);
-    nh.param("max_consecutive_nonmonotonic_steps", solver_options.max_consecutive_nonmonotonic_steps,
-             solver_options.max_consecutive_nonmonotonic_steps);
-
-    nh.param("max_num_iterations", solver_options.max_num_iterations, solver_options.max_num_iterations);
-    nh.param("max_solver_time_in_seconds", solver_options.max_solver_time_in_seconds,
-             solver_options.max_solver_time_in_seconds);
-
-    nh.param("num_threads", solver_options.num_threads, solver_options.num_threads);
-
-    nh.param("initial_trust_region_radius", solver_options.initial_trust_region_radius,
-             solver_options.initial_trust_region_radius);
-    nh.param("max_trust_region_radius", solver_options.max_trust_region_radius, solver_options.max_trust_region_radius);
-    nh.param("min_trust_region_radius", solver_options.min_trust_region_radius, solver_options.min_trust_region_radius);
-
-    nh.param("min_relative_decrease", solver_options.min_relative_decrease, solver_options.min_relative_decrease);
-    nh.param("min_lm_diagonal", solver_options.min_lm_diagonal, solver_options.min_lm_diagonal);
-    nh.param("max_lm_diagonal", solver_options.max_lm_diagonal, solver_options.max_lm_diagonal);
-    nh.param("max_num_consecutive_invalid_steps", solver_options.max_num_consecutive_invalid_steps,
-             solver_options.max_num_consecutive_invalid_steps);
-    nh.param("function_tolerance", solver_options.function_tolerance, solver_options.function_tolerance);
-    nh.param("gradient_tolerance", solver_options.gradient_tolerance, solver_options.gradient_tolerance);
-    nh.param("parameter_tolerance", solver_options.parameter_tolerance, solver_options.parameter_tolerance);
-
-    solver_options.linear_solver_type =
-        fuse_core::getParam(nh, "linear_solver_type", solver_options.linear_solver_type);
-    solver_options.preconditioner_type =
-        fuse_core::getParam(nh, "preconditioner_type", solver_options.preconditioner_type);
-    solver_options.visibility_clustering_type =
-        fuse_core::getParam(nh, "visibility_clustering_type", solver_options.visibility_clustering_type);
-    solver_options.dense_linear_algebra_library_type =
-        fuse_core::getParam(nh, "dense_linear_algebra_library_type", solver_options.dense_linear_algebra_library_type);
-    solver_options.sparse_linear_algebra_library_type = fuse_core::getParam(
-        nh, "sparse_linear_algebra_library_type", solver_options.sparse_linear_algebra_library_type);
-
-    // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> linear_solver_ordering;
-
-    nh.param("use_explicit_schur_complement", solver_options.use_explicit_schur_complement,
-             solver_options.use_explicit_schur_complement);
-    nh.param("use_postordering", solver_options.use_postordering, solver_options.use_postordering);
-    nh.param("dynamic_sparsity", solver_options.dynamic_sparsity, solver_options.dynamic_sparsity);
-
-#if CERES_VERSION_AT_LEAST(2, 0, 0)
-    nh.param("use_mixed_precision_solves", solver_options.use_mixed_precision_solves,
-             solver_options.use_mixed_precision_solves);
-    nh.param("max_num_refinement_iterations", solver_options.max_num_refinement_iterations,
-             solver_options.max_num_refinement_iterations);
-#endif
-
-    nh.param("use_inner_iterations", solver_options.use_inner_iterations, solver_options.use_inner_iterations);
-
-    // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> inner_iteration_ordering;
-
-    nh.param("inner_iteration_tolerance", solver_options.inner_iteration_tolerance,
-             solver_options.inner_iteration_tolerance);
-    nh.param("min_linear_solver_iterations", solver_options.min_linear_solver_iterations,
-             solver_options.min_linear_solver_iterations);
-    nh.param("max_linear_solver_iterations", solver_options.max_linear_solver_iterations,
-             solver_options.max_linear_solver_iterations);
-    nh.param("eta", solver_options.eta, solver_options.eta);
-
-    nh.param("jacobi_scaling", solver_options.jacobi_scaling, solver_options.jacobi_scaling);
-
-    // Logging options
-    solver_options.logging_type = fuse_core::getParam(nh, "logging_type", solver_options.logging_type);
-    nh.param("minimizer_progress_to_stdout", solver_options.minimizer_progress_to_stdout,
-             solver_options.minimizer_progress_to_stdout);
-    nh.param("trust_region_minimizer_iterations_to_dump", solver_options.trust_region_minimizer_iterations_to_dump,
-             solver_options.trust_region_minimizer_iterations_to_dump);
-    nh.param("trust_region_problem_dump_directory", solver_options.trust_region_problem_dump_directory,
-             solver_options.trust_region_problem_dump_directory);
-    solver_options.trust_region_problem_dump_format_type = fuse_core::getParam(
-        nh, "trust_region_problem_dump_format_type", solver_options.trust_region_problem_dump_format_type);
-
-    // Finite differences options
-    nh.param("check_gradients", solver_options.check_gradients, solver_options.check_gradients);
-    nh.param("gradient_check_relative_precision", solver_options.gradient_check_relative_precision,
-             solver_options.gradient_check_relative_precision);
-    nh.param("gradient_check_numeric_derivative_relative_step_size",
-             solver_options.gradient_check_numeric_derivative_relative_step_size,
-             solver_options.gradient_check_numeric_derivative_relative_step_size);
-    nh.param("update_state_every_iteration", solver_options.update_state_every_iteration,
-             solver_options.update_state_every_iteration);
-
-    std::string error;
-    if (!solver_options.IsValid(&error))
-    {
-      throw std::invalid_argument("Invalid solver options in parameter " + nh.getNamespace() + ". Error: " + error);
-    }
+    fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);
   }
 };
 


### PR DESCRIPTION
Moved the functions that load Ceres parameter objects into a common file in fuse_core. This allows them to be reused where needed. As an example, both the batch optimizer and fixed-lag smoother use a common function to load all of the Ceres solver parameters.

95% of the changes is just moving existing code around.