### PR TITLE
Add SerializedGraph to GraphViz DOT writer

### DIFF
--- a/fuse/package.xml
+++ b/fuse/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>fuse_optimizers</exec_depend>
   <exec_depend>fuse_publishers</exec_depend>
   <exec_depend>fuse_variables</exec_depend>
+  <exec_depend>fuse_viz</exec_depend>
 
   <export>
     <metapackage />

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(fuse_viz)
+
+set(build_depends
+  fuse_msgs
+  fuse_variables
+  rviz
+)
+
+find_package(catkin REQUIRED COMPONENTS
+  ${build_depends}
+)
+
+find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+set(QT_LIBRARIES Qt5::Widgets)
+
+add_definitions(-DQT_NO_KEYWORDS)
+
+###########
+## Build ##
+###########
+
+add_compile_options(-std=c++14 -Wall -Werror)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    ${build_depends}
+  DEPENDS
+    QT
+)
+
+qt5_wrap_cpp(moc_files
+  include/fuse_viz/serialized_graph_display.h
+)
+
+set(source_files
+  src/serialized_graph_display.cpp
+  ${moc_files}
+)
+
+add_library(${PROJECT_NAME}
+  ${source_files}
+)
+add_dependencies(${PROJECT_NAME}
+  ${catkin_EXPORTED_TARGETS}
+)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${QT_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  FILES rviz_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslint REQUIRED)
+
+  # Lint tests
+  set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
+  roslint_cpp()
+  roslint_add_test()
+endif()

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
   ${build_depends}
 )
 
+find_package(Boost REQUIRED COMPONENTS graph)
+
 find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
 set(QT_LIBRARIES Qt5::Widgets)
 
@@ -28,6 +30,7 @@ catkin_package(
   CATKIN_DEPENDS
     ${build_depends}
   DEPENDS
+    Boost
     QT
 )
 
@@ -56,11 +59,28 @@ target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
 )
 
+add_executable(serialized_graph_dot_writer_node
+  src/serialized_graph_dot_writer.cpp
+  src/serialized_graph_dot_writer_node.cpp
+)
+add_dependencies(serialized_graph_dot_writer_node
+  ${catkin_EXPORTED_TARGETS}
+)
+target_include_directories(serialized_graph_dot_writer_node
+  PUBLIC
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(serialized_graph_dot_writer_node
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
 #############
 ## Install ##
 #############
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} serialized_graph_dot_writer_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/fuse_viz/include/fuse_viz/serialized_graph_display.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_display.h
@@ -1,0 +1,104 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H
+#define FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H
+
+#ifndef Q_MOC_RUN
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_msgs/SerializedGraph.h>
+
+#include <rviz/message_filter_display.h>
+#endif  // Q_MOC_RUN
+
+#include <vector>
+
+namespace Ogre
+{
+class SceneNode;
+}
+
+namespace rviz
+{
+
+class Object;
+
+class BoolProperty;
+class FloatProperty;
+
+/**
+ * @brief An rviz dispaly for fuse_msgs::SerializedGraph messages.
+ */
+class SerializedGraphDisplay : public MessageFilterDisplay<fuse_msgs::SerializedGraph>
+{
+  Q_OBJECT
+public:
+  SerializedGraphDisplay();
+
+  ~SerializedGraphDisplay() override;
+
+  void reset() override;
+
+protected:
+  void onInitialize() override;
+
+  void onEnable() override;
+
+  void onDisable() override;
+
+private Q_SLOTS:
+  void updateDrawVariablesAxesProperty();
+
+  void updateScaleProperty();
+
+private:
+  void clear();
+
+  void processMessage(const fuse_msgs::SerializedGraph::ConstPtr& msg) override;
+
+  Ogre::SceneNode* root_node_;
+  Ogre::SceneNode* variables_axes_node_;
+  Ogre::SceneNode* variables_spheres_node_;
+
+  std::vector<Object*> graph_shapes_;
+
+  BoolProperty* draw_variables_axes_property_;
+  FloatProperty* scale_property_;
+
+  fuse_core::GraphDeserializer graph_deserializer_;
+};
+
+}  // namespace rviz
+
+#endif  // FUSE_VIZ_SERIALIZED_GRAPH_DISPLAY_H

--- a/fuse_viz/include/fuse_viz/serialized_graph_dot_writer.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_dot_writer.h
@@ -1,0 +1,145 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_VIZ_SERIALIZED_GRAPH_DOT_WRITER_H
+#define FUSE_VIZ_SERIALIZED_GRAPH_DOT_WRITER_H
+
+#include <fuse_core/constraint.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
+#include <fuse_msgs/SerializedGraph.h>
+
+#include <boost/graph/adjacency_list.hpp>
+
+#include <string>
+
+namespace fuse_viz
+{
+
+/**
+ * @brief A fuse_msgs::SerializedGraph to Graphviz DOT format writer.
+ *
+ * This converts a fuse_msgs::SerializedGraph message into a BGL (Boost Graph Library) graph that can be easily
+ * converted/serialized into a Graphviz DOT format. The DOT format is serialized into an std::ostream.
+ */
+class SerializedGraphDOTWriter
+{
+public:
+  /**
+   * @brief A vertex property bundle to store inside the BGL graph.
+   *
+   * This allows to store the fields from the variables and constraints in a fuse_msgs::SerializedGraph message. This
+   * information is stored as part of the BGL graph as a property bundle, so later we can easily access that
+   * information.
+   */
+  class VertexProperty
+  {
+  public:
+    /**
+     * @brief Vertex property type.
+     *
+     * A vertex property can either be a VARIABLE or a CONSTRAINT. The default constructor uses the UNKOWN type though.
+     */
+    enum Type
+    {
+      VARIABLE,    //< Variable type
+      CONSTRAINT,  //< Constraint type
+      UNKNOWN      //< Unknown type
+    };
+
+    /**
+     * @brief Vertex property constructor.
+     */
+    VertexProperty(const std::string& uuid = fuse_core::uuid::to_string(fuse_core::uuid::NIL),
+                   const Type type = UNKNOWN, const std::string& subtype = "NO_SUBTYPE")
+      : uuid(uuid), type(type), subtype(subtype)
+    {
+    }
+
+    /**
+     * @brief Vertex property constructor from a fuse_core::Variable.
+     * The type is set to VARIABLE. The variable type is used to set the subtype.
+     *
+     * @param[in] variable A fuse_core::Variable.
+     */
+    explicit VertexProperty(const fuse_core::Variable& variable)
+      : uuid(fuse_core::uuid::to_string(variable.uuid())), type(VARIABLE), subtype(variable.type())
+    {
+    }
+
+    /**
+     * @brief Vertex property constructor from a fuse_core::Constraint.
+     * The type is set to CONSTRAINT. The constraint type is used to set the subtype.
+     *
+     * @param[in] constraint A fuse_core::Constraint.
+     */
+    explicit VertexProperty(const fuse_core::Constraint& constraint)
+      : uuid(fuse_core::uuid::to_string(constraint.uuid())), type(CONSTRAINT), subtype(constraint.type())
+    {
+    }
+
+    std::string uuid;     //< Variable/Constraint UUID
+    Type type;            //< VARIABLE or CONTRAINT type
+    std::string subtype;  //< Variable/Constraint type
+  };
+
+  // Graph typedef
+  using Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, VertexProperty>;
+
+  // Disable constructor and destructor, since this class only provides static methods
+  SerializedGraphDOTWriter() = delete;
+  ~SerializedGraphDOTWriter() = delete;
+
+  /**
+   * @brief Converts a fuse_msgs::SerializedGraph message into a BGL graph.
+   *
+   * @param[in] msg A fuse_msgs::SerializedGraph message.
+   * @return A BGL graph.
+   */
+  static Graph toBoost(const fuse_msgs::SerializedGraphConstPtr& msg);
+
+  /**
+   * @brief Write a fuse_msgs::SerializedGraph message into an std::ostream.
+   * The message is first converted into a BGL graph and then serialized as a Graphviz DOT format.
+   *
+   * @param[in, out] os  Output stream.
+   * @param[in]      msg A fuse_msgs::SerializedGraph message.
+   * @return Output stream with the fuse_msgs::SerializedGraph serialized into it.
+   */
+  static std::ostream& write(std::ostream& os, const fuse_msgs::SerializedGraphConstPtr& msg);
+};
+
+}  // namespace fuse_viz
+
+#endif  // FUSE_VIZ_SERIALIZED_GRAPH_DOT_WRITER_H

--- a/fuse_viz/package.xml
+++ b/fuse_viz/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fuse_viz</name>
+  <version>0.4.0</version>
+  <description>
+    The fuse_viz package provides visualization tools for fuse.
+  </description>
+
+  <maintainer email="efernandez@clearpath.ai">Enrique Fernandez</maintainer>
+  <author email="efernandez@clearpath.ai">Enrique Fernandez</author>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>fuse_msgs</depend>
+  <depend>fuse_variables</depend>
+  <depend>rviz</depend>
+
+  <export>
+    <rviz plugin="${prefix}/rviz_plugins.xml"/>
+  </export>
+</package>

--- a/fuse_viz/rviz_plugins.xml
+++ b/fuse_viz/rviz_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libfuse_viz">
+  <class name="fuse_viz/SerializedGraph" type="rviz::SerializedGraphDisplay" base_class_type="rviz::Display">
+    <description>
+    An rviz display for fuse_msgs::SerializedGraph messages.
+    </description>
+  </class>
+</library>

--- a/fuse_viz/src/serialized_graph_display.cpp
+++ b/fuse_viz/src/serialized_graph_display.cpp
@@ -1,0 +1,193 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef Q_MOC_RUN
+#include <OgreBillboardSet.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+#include <rviz/ogre_helpers/axes.h>
+#include <rviz/ogre_helpers/billboard_line.h>
+#include <rviz/ogre_helpers/object.h>
+#include <rviz/ogre_helpers/shape.h>
+
+#include <rviz/display_context.h>
+#include <rviz/frame_manager.h>
+
+#include <rviz/properties/bool_property.h>
+#include <rviz/properties/float_property.h>
+#endif  // Q_MOC_RUN
+
+#include <fuse_viz/serialized_graph_display.h>
+
+#include <fuse_core/graph.h>
+#include <fuse_variables/orientation_2d_stamped.h>
+#include <fuse_variables/position_2d_stamped.h>
+
+namespace rviz
+{
+
+SerializedGraphDisplay::SerializedGraphDisplay()
+{
+  draw_variables_axes_property_ = new BoolProperty("Draw Variables as Axes", true,
+                                                   "Whether to draw graph variables axes or not (spheres are always "
+                                                   "drawn)",
+                                                   this, SLOT(updateDrawVariablesAxesProperty()));
+
+  scale_property_ = new FloatProperty("Scale", 0.1, "Scale of graph markers drawn", this, SLOT(updateScaleProperty()));
+}
+
+SerializedGraphDisplay::~SerializedGraphDisplay()
+{
+  if (initialized())
+  {
+    clear();
+    root_node_->removeAndDestroyAllChildren();
+    scene_manager_->destroySceneNode(root_node_->getName());
+  }
+}
+
+void SerializedGraphDisplay::reset()
+{
+  MFDClass::reset();
+  clear();
+}
+
+void SerializedGraphDisplay::onInitialize()
+{
+  MFDClass::onInitialize();
+
+  root_node_ = scene_node_->createChildSceneNode();
+
+  variables_axes_node_ = root_node_->createChildSceneNode();
+  variables_spheres_node_ = root_node_->createChildSceneNode();
+}
+
+void SerializedGraphDisplay::onEnable()
+{
+  MFDClass::onEnable();
+
+  root_node_->setVisible(true);
+}
+
+void SerializedGraphDisplay::onDisable()
+{
+  MFDClass::onDisable();
+
+  root_node_->setVisible(false);
+}
+
+void SerializedGraphDisplay::updateDrawVariablesAxesProperty()
+{
+  variables_axes_node_->setVisible(draw_variables_axes_property_->getBool());
+}
+
+void SerializedGraphDisplay::updateScaleProperty()
+{
+  // TODO(efernandez) Redraw all variables so the scale is applied to the current graph. This is useful if no new
+  // message is received
+}
+
+void SerializedGraphDisplay::clear()
+{
+  for (auto& graph_shape : graph_shapes_)
+  {
+    delete graph_shape;
+  }
+  graph_shapes_.clear();
+}
+
+void SerializedGraphDisplay::processMessage(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+{
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  if (!context_->getFrameManager()->getTransform(msg->header, position, orientation))
+  {
+    ROS_DEBUG_STREAM("Error transforming from frame '" << msg->header.frame_id << "' to frame '"
+                                                       << qPrintable(fixed_frame_) << "'");
+  }
+
+  root_node_->setPosition(position);
+  root_node_->setOrientation(orientation);
+
+  clear();
+
+  const auto graph = graph_deserializer_.deserialize(msg);
+
+  const Ogre::Vector3 scale(scale_property_->getFloat());
+
+  for (const auto& variable : graph->getVariables())
+  {
+    const auto orientation = dynamic_cast<const fuse_variables::Orientation2DStamped*>(&variable);
+    if (!orientation)
+    {
+      continue;
+    }
+
+    const auto& stamp = orientation->stamp();
+    const auto position_uuid = fuse_variables::Position2DStamped(stamp, orientation->deviceId()).uuid();
+    if (!graph->variableExists(position_uuid))
+    {
+      continue;
+    }
+
+    const auto position = dynamic_cast<const fuse_variables::Position2DStamped*>(&graph->getVariable(position_uuid));
+
+    const tf2::Quaternion tf_q(tf2::Vector3(0, 0, 1), orientation->yaw());
+
+    const Ogre::Vector3 p(position->x(), position->y(), 0);
+    const Ogre::Quaternion q(tf_q.w(), tf_q.x(), tf_q.y(), tf_q.z());
+
+    // Add sphere:
+    Object* sphere = new rviz::Shape(rviz::Shape::Sphere, scene_manager_, variables_spheres_node_);
+    sphere->setPosition(p);
+    sphere->setScale(scale);
+    sphere->setColor(1.0, 0.0, 0.0, 1.0);
+    graph_shapes_.push_back(sphere);
+
+    // Add axes:
+    Object* axes = new rviz::Axes(scene_manager_, variables_axes_node_, 10.0, 1.0);
+    axes->setPosition(p);
+    axes->setOrientation(q);
+    axes->setScale(scale);
+    graph_shapes_.push_back(axes);
+  }
+
+  updateDrawVariablesAxesProperty();
+}
+
+}  // namespace rviz
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(rviz::SerializedGraphDisplay, rviz::Display)

--- a/fuse_viz/src/serialized_graph_dot_writer.cpp
+++ b/fuse_viz/src/serialized_graph_dot_writer.cpp
@@ -1,0 +1,164 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_viz/serialized_graph_dot_writer.h>
+
+#include <fuse_core/graph_deserializer.h>
+
+#include <boost/graph/graphviz.hpp>
+
+#include <map>
+#include <string>
+
+namespace fuse_viz
+{
+
+/**
+ * @brief Vertex writer.
+ *
+ * This tells BGL how to write the vertex properites into the Graphviz DOT format.
+ * This class implements a functor operator() that it's called for each vertex in the graph.
+ *
+ * @tparam UUIDMap    Vertex property UUID mapping.
+ * @tparam TypeMap    Vertex property type mapping.
+ * @tparam SubTypeMap Vertex property subtype mapping.
+ */
+template <class UUIDMap, class TypeMap, class SubTypeMap>
+class vertex_writer
+{
+public:
+  /**
+   * @brief Vertex writer constructor.
+   *
+   * @param[in] uuid_map    Vertex property UUID mapping.
+   * @param[in] type_map    Vertex property type mapping.
+   * @param[in] subtype_map Vertex property subtype mapping.
+   */
+  vertex_writer(UUIDMap uuid_map, TypeMap type_map, SubTypeMap subtype_map)
+    : uuid_map_(uuid_map), type_map_(type_map), subtype_map_(subtype_map)
+  {
+  }
+
+  /**
+   * @brief Functor operator() the writes the vertex properties in DOT format.
+   * This writes the vertex properties as field-value pairs for each node/vertex into the DOT format.
+   *
+   * @param[in, out] os Output stream.
+   * @param[in]      v  Vertex.
+   *
+   * @tparam Vertex Vertex descriptor in the BGL graph.
+   */
+  template <class Vertex>
+  void operator()(std::ostream& os, const Vertex& v) const
+  {
+    os << "["
+       << "shape=" << TYPE_SHAPES[type_map_[v]] << ", label=\"" << uuid_map_[v] << "\""
+       << ", taillabel=\"" << subtype_map_[v] << "\""
+       << "]";
+  }
+
+private:
+  UUIDMap uuid_map_;        //< Vertex property UUID mapping.
+  TypeMap type_map_;        //< Vertex property type mapping.
+  SubTypeMap subtype_map_;  //< Vertex property subtype mapping.
+
+  static const char* const TYPE_SHAPES[];  //< Graphviz DOT shape strings for each vertex property type supported.
+};
+
+// The shapes for each type supported:
+// * VARIABLE   -> circle
+// * CONSTRAINT -> diamond
+template <class UUIDMap, class TypeMap, class SubTypeMap>
+const char* const vertex_writer<UUIDMap, TypeMap, SubTypeMap>::TYPE_SHAPES[] = { "circle", "diamond", "none" };
+
+/**
+ * @brief A helper function to make/create a vertex writer.
+ *
+ * @param[in] uuid_map    Vertex property UUID mapping.
+ * @param[in] type_map    Vertex property type mapping.
+ * @param[in] subtype_map Vertex property subtype mapping.
+ *
+ * @tparam UUIDMap    Vertex property UUID mapping.
+ * @tparam TypeMap    Vertex property type mapping.
+ * @tparam SubTypeMap Vertex property subtype mapping.
+ */
+template <class UUIDMap, class TypeMap, class SubTypeMap>
+inline vertex_writer<UUIDMap, TypeMap, SubTypeMap> make_vertex_writer(UUIDMap uuid_map, TypeMap type_map,
+                                                                      SubTypeMap subtype_map)
+{
+  return vertex_writer<UUIDMap, TypeMap, SubTypeMap>(uuid_map, type_map, subtype_map);
+}
+
+SerializedGraphDOTWriter::Graph SerializedGraphDOTWriter::toBoost(const fuse_msgs::SerializedGraphConstPtr& msg)
+{
+  static fuse_core::GraphDeserializer graph_deserializer;
+
+  using VertexMap = std::map<std::string, Graph::vertex_descriptor>;
+
+  const auto graph = graph_deserializer.deserialize(msg);
+
+  Graph boost_graph;
+
+  VertexMap variable_vertex_by_uuid;
+  for (const auto& variable : graph->getVariables())
+  {
+    variable_vertex_by_uuid[fuse_core::uuid::to_string(variable.uuid())] =
+        boost::add_vertex(VertexProperty(variable), boost_graph);
+  }
+
+  for (const auto& constraint : graph->getConstraints())
+  {
+    const auto constraint_vertex = boost::add_vertex(VertexProperty(constraint), boost_graph);
+
+    for (const auto& variable_uuid : constraint.variables())
+    {
+      boost::add_edge(constraint_vertex, variable_vertex_by_uuid[fuse_core::uuid::to_string(variable_uuid)],
+                      boost_graph);
+    }
+  }
+
+  return boost_graph;
+}
+
+std::ostream& SerializedGraphDOTWriter::write(std::ostream& os, const fuse_msgs::SerializedGraphConstPtr& msg)
+{
+  const auto boost_graph = toBoost(msg);
+  boost::write_graphviz(os, boost_graph,
+                        make_vertex_writer(boost::get(&VertexProperty::uuid, boost_graph),
+                                           boost::get(&VertexProperty::type, boost_graph),
+                                           boost::get(&VertexProperty::subtype, boost_graph)));
+  return os;
+}
+
+}  // namespace fuse_viz

--- a/fuse_viz/src/serialized_graph_dot_writer_node.cpp
+++ b/fuse_viz/src/serialized_graph_dot_writer_node.cpp
@@ -1,0 +1,98 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_viz/serialized_graph_dot_writer.h>
+#include <ros/ros.h>
+
+#include <fstream>
+#include <string>
+
+namespace fuse_viz
+{
+
+/**
+ * @brief A fuse_msgs::SerializedGraph to DOT format writer node.
+ *
+ * This subscribes to a fuse_msgs::SerializedGraph topic and saves each message into a file using Graphviz DOT format.
+ */
+class SerializedGraphDOTWriterNode
+{
+public:
+  /**
+   * @brief Constructor.
+   * This reads ROS parameters and subscribes to the fuse_msgs::SerializedGraph topic.
+   */
+  SerializedGraphDOTWriterNode();
+
+  /**
+   * @brief A callback to process fuse_msgs::SerializedGraph messages.
+   *
+   * @param[in] msg A fuse_msgs::SerializedGraph message.
+   */
+  void graphCallback(const fuse_msgs::SerializedGraphConstPtr& msg);
+
+private:
+  ros::NodeHandle nh_;          //< ROS node handle
+  ros::Subscriber subscriber_;  //< ROS subscriber to the fuse_msgs::SerializedGraph topic
+
+  std::string filename_prefix_{ "" };  //< Filename prefix to save the graph in Graphviz DOT format
+  int queue_size_{ 100 };              //< Queue size for the ROS subscriber
+};
+
+SerializedGraphDOTWriterNode::SerializedGraphDOTWriterNode()
+{
+  ros::NodeHandle private_node_handle("~");
+
+  private_node_handle.param("filename_prefix", filename_prefix_, filename_prefix_);
+  private_node_handle.param("queue_size", queue_size_, queue_size_);
+
+  subscriber_ = nh_.subscribe("graph", queue_size_, &SerializedGraphDOTWriterNode::graphCallback, this);
+}
+
+void SerializedGraphDOTWriterNode::graphCallback(const fuse_msgs::SerializedGraphConstPtr& msg)
+{
+  std::ofstream ofs(filename_prefix_ + std::to_string(msg->header.seq) + ".dot");
+  SerializedGraphDOTWriter::write(ofs, msg);
+}
+
+}  // namespace fuse_viz
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "serialized_graph_dot_writer_node");
+  fuse_viz::SerializedGraphDOTWriterNode node;
+  ros::spin();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds code to convert from a `fuse_msgs::SerializedGraph` into the GraphViz DOT format using the Boost Graph Library (BGL) and a node to dump/write the resulting graph into a `.dot` file that can be visualized with `xdot` or `Gephi`.

This PR is on top of https://github.com/locusrobotics/fuse/pull/99, which should be merged before this one can be reviewed. This also separates this contribution from the `rviz` display that remains in the original PR. The intention is to continue the discussion started in the original PR here, especially these comments:
* https://github.com/locusrobotics/fuse/pull/99#pullrequestreview-279817583
* https://github.com/locusrobotics/fuse/pull/99#issuecomment-526028145

Once I have some time, I'll start working on those comments here. This blog post might be useful: http://www.mupuf.org/blog/2010/07/08/how_to_use_graphviz_to_draw_graphs_in_a_qt_graphics_scene/