### PR TITLE
Fix build with ceres 2.0 with CMake < 3.8

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(${PROJECT_NAME}
   src/uuid_ordering.cpp
   src/variable_constraints.cpp
 )
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_generic_lambdas)
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
 )
@@ -216,6 +217,7 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(test_marginal_constraint
     ${catkin_EXPORTED_TARGETS}
   )
+  target_compile_features(test_marginal_constraint PRIVATE cxx_generic_lambdas)
   target_include_directories(test_marginal_constraint
     PRIVATE
       include
@@ -233,6 +235,7 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(test_marginalize_variables
     ${catkin_EXPORTED_TARGETS}
   )
+  target_compile_features(test_marginalize_variables PRIVATE cxx_generic_lambdas)
   target_include_directories(test_marginalize_variables
     PRIVATE
       include

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(SuiteSparse REQUIRED COMPONENTS CCOLAMD)

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(${PROJECT_NAME}
   src/uuid.cpp
   src/variable.cpp
 )
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_generic_lambdas)
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
 )

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -10,6 +10,7 @@ set(build_depends
 find_package(catkin REQUIRED COMPONENTS
   ${build_depends}
 )
+set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Boost REQUIRED COMPONENTS serialization)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)


### PR DESCRIPTION
With CMake < 3.8 ceres-solver sets/exports `-std=gnu++11`, which comes after the `-std=c++14` set in `add_compile_options`, so we get these flags:

`-std=c++14 -Wall -Werror -std=gnu++11`

With this change and `CMAKE_CXX_EXTENSIONS=OFF` we get this instead:

`-std=c++14 -Wall -Werror -std=c++14`
    
See: https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/CMakeLists.txt#L237-L247
    
Even if we build ceres-solver with (same w/o `-DBUILD_SHARED_LIBS=ON`):

`cmake .. -DCMAKE_CXX_STANDARD=14 -DCMAKE_CXX_EXTENSIONS=OFF -DBUILD_SHARED_LIBS=ON`

we still get:

`-std=c++14 -Wall -Werror -std=gnu++11`

if with have CMake < 3.8.

This can be reproduced with the latest ceres-solver source code from the `master` branch: https://github.com/ceres-solver/ceres-solver/commit/667062dcc8144057aa122aa198eb86656c433df2
    
Without this, the code builds with C++11, and we get the following compilation error:
``` bash    
    Building CXX object CMakeFiles/fuse_core.dir/src/timestamp_manager.cpp.o
    /usr/lib/ccache/c++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"fuse_core\" -Dfuse_core_EXPORTS -I/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/include -I/opt/clearpath/2.16/include -I/opt/clearpath/2.16/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -isystem /usr/include/eigen3 -isystem /usr/local/include  -g -O2 -fPIC -frecord-gcc-switches -march=core-avx-i -mcx16 -msahf -mno-movbe -maes -mpclmul -mpopcnt -mno-abm -mno-lwp -mno-fma -mno-fma4 -mno-xop -mno-bmi -mno-bmi2 -mno-tbm -mavx -mno-avx2 -msse4.2 -msse4.1 -mno-lzcnt -mno-rtm -mno-hle -mrdrnd -mf16c -mfsgsbase -mno-rdseed -mno-prfchw -mno-adx -mfxsr -mxsave -mxsaveopt --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=6144 -mtune=core-avx-i -DCPR_VERSION=2.16.0~20190918023746-0   -std=c++11 -fPIC   -std=c++14 -Wall -Werror -std=c++11 -o CMakeFiles/fuse_core.dir/src/timestamp_manager.cpp.o -c /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp: In member function ‘void fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)’:
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:126:20: error: lambda capture initializers only available with -std=c++14 or -std=gnu++14 [-Werror]
                       [variable_uuid = variable->uuid()](const auto& input_variable)
                        ^
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:126:60: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
                       [variable_uuid = variable->uuid()](const auto& input_variable)
                                                                ^
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp: In lambda function:
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:128:43: error: request for member ‘uuid’ in ‘input_variable’, which is of non-class type ‘const int’
                         return input_variable.uuid() == variable_uuid;
                                               ^
    In file included from /usr/include/c++/5/bits/stl_algobase.h:71:0,
                     from /usr/include/c++/5/memory:62,
                     from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/include/fuse_core/macros.h:58,
                     from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/include/fuse_core/constraint.h:37,
                     from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/include/fuse_core/timestamp_manager.h:37,
                     from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:34:
    /usr/include/c++/5/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>]’:
    /usr/include/c++/5/bits/stl_algo.h:104:42:   required from ‘_InputIterator std::__find_if(_InputIterator, _InputIterator, _Predicate, std::input_iterator_tag) [with _InputIterator = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)> >]’
    /usr/include/c++/5/bits/stl_algo.h:161:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)> >]’
    /usr/include/c++/5/bits/stl_algo.h:3815:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>]’
    /usr/include/c++/5/bits/stl_algo.h:526:36:   required from ‘bool std::none_of(_IIter, _IIter, _Predicate) [with _IIter = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>]’
    /usr/include/c++/5/bits/stl_algo.h:544:27:   required from ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = boost::range_detail::any_iterator<const fuse_core::Variable, boost::iterators::forward_traversal_tag, const fuse_core::Variable&, long int, boost::any_iterator_buffer<64ul> >; _Predicate = fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>]’
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:129:20:   required from here
    /usr/include/c++/5/bits/predefined_ops.h:241:30: error: no match for call to ‘(fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>) (const fuse_core::Variable&)’
      { return bool(_M_pred(*__it)); }
                                  ^
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:126:80: note: candidate: fuse_core::TimestampManager::query(fuse_core::Transaction&, bool)::<lambda(const int&)>
                       [variable_uuid = variable->uuid()](const auto& input_variable)
                                                                                    ^
    /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/src/timestamp_manager.cpp:126:80: note:   no known conversion for argument 1 from ‘const fuse_core::Variable’ to ‘const int&’
    cc1plus: all warnings being treated as errors
    CMakeFiles/fuse_core.dir/build.make:254: recipe for target 'CMakeFiles/fuse_core.dir/src/timestamp_manager.cpp.o' failed
    
    And a similar one in fuse_constraints. Both of them are related with
    generic lambdas, so we request the cxx_generic_lambdas feature. See:
    https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
```

This PR also disables `CMAKE_CXX_EXTENSIONS`. This tells CMake not to use `-std=gnu++11` or `-std=gnu++14`, and use `-std=c++11` or `-std=c++14` instead. Note that CMake defaults to `CMAKE_CXX_EXTENSIONS=ON`. See:
1. https://cmake.org/cmake/help/v3.1/variable/CMAKE_CXX_EXTENSIONS.html
2. https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS