### PR TITLE
Publish odometry with timer and allow to predict it

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -92,7 +92,7 @@ namespace fuse_models
 class Odometry2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS(Odometry2DPublisher);
+  SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher);
   using ParameterType = parameters::Odometry2DPublisherParams;
 
   /**
@@ -155,10 +155,10 @@ protected:
     nav_msgs::Odometry& state);
 
   /**
-   * @brief Timer callback method for the tf publication
+   * @brief Timer callback method for the filtered state publication and tf broadcasting
    * @param[in] event The timer event parameters that are associated with the given invocation
    */
-  void tfPublishTimerCallback(const ros::TimerEvent& event);
+  void publishTimerCallback(const ros::TimerEvent& event);
 
   /**
    * @brief Object that searches for the most recent common timestamp for a set of variables
@@ -174,6 +174,8 @@ protected:
 
   ros::Time latest_stamp_;
 
+  ros::Time latest_covariance_stamp_;
+
   nav_msgs::Odometry odom_output_;
 
   Synchronizer synchronizer_;  //!< Object that tracks the latest common timestamp of multiple variables
@@ -186,7 +188,7 @@ protected:
 
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
-  ros::Timer tf_publish_timer_;
+  ros::Timer publish_timer_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -68,7 +68,8 @@ namespace fuse_models
  *                                                   specifies whether we should predict, using the 2D unicycle model,
  *                                                   the state at the time of the tf publication, rather than the last
  *                                                   posterior (optimized) state.
- *  - tf_publish_frequency (double, default: 10.0)  How often, in Hz, we publish the transform
+ *  - publish_frequency (double, default: 10.0)  How often, in Hz, we publish the filtered state data and broadcast the
+ *                                               transform
  *  - tf_cache_time (double, default: 10.0)  The length of our tf cache (only used if the world_frame_id and the
  *                                           map_frame_id are the same)
  *  - tf_timeout (double, default: 0.1)  Our tf lookup timeout period (only used if the world_frame_id and the

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -73,8 +73,7 @@ public:
   {
     nh.getParam("publish_tf", publish_tf);
     nh.getParam("predict_to_current_time", predict_to_current_time);
-    nh.getParam("predict_odom", predict_odom);
-    nh.getParam("tf_publish_frequency", tf_publish_frequency);
+    nh.getParam("publish_frequency", publish_frequency);
 
     std::vector<double> process_noise_diagonal(8, 0.0);
     nh.param("process_noise_diagonal", process_noise_diagonal, process_noise_diagonal);
@@ -133,8 +132,7 @@ public:
 
   bool publish_tf { true };
   bool predict_to_current_time { false };
-  bool predict_odom { false };
-  double tf_publish_frequency { 10.0 };
+  double publish_frequency { 10.0 };
   fuse_core::Matrix8d process_noise_covariance;   //!< Process noise covariance matrix
   ros::Duration tf_cache_time { 10.0 };
   ros::Duration tf_timeout { 0.1 };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -44,6 +44,7 @@
 
 #include <ceres/covariance.h>
 
+#include <algorithm>
 #include <cassert>
 #include <string>
 #include <vector>
@@ -81,6 +82,12 @@ public:
     if (process_noise_diagonal.size() != 8)
     {
       throw std::runtime_error("Process noise diagonal must be of length 8!");
+    }
+
+    if (std::any_of(process_noise_diagonal.begin(), process_noise_diagonal.end(),
+                    [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
+    {
+      throw std::runtime_error("All process noise diagonal entries must be positive!");
     }
 
     process_noise_covariance = fuse_core::Vector8d(process_noise_diagonal.data()).asDiagonal();

--- a/fuse_models/include/fuse_models/unicycle_2d_predict.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_predict.h
@@ -36,6 +36,7 @@
 
 #include <ceres/jet.h>
 #include <fuse_core/util.h>
+#include <fuse_core/eigen.h>
 #include <tf2_2d/tf2_2d.h>
 
 
@@ -100,6 +101,105 @@ inline void predict(
   fuse_core::wrapAngle2D(yaw2);
 }
 
+enum StateIndex : uint8_t
+{
+  X,
+  Y,
+  YAW,
+  V_X,
+  V_Y,
+  V_YAW,
+  A_X,
+  A_Y
+};
+
+/**
+ * @brief Given a state and time delta, predicts a new state
+ * @param[in] position1_x - First X position
+ * @param[in] position1_y - First Y position
+ * @param[in] yaw1 - First orientation
+ * @param[in] vel_linear1_x - First X velocity
+ * @param[in] vel_linear1_y - First Y velocity
+ * @param[in] vel_yaw1 - First yaw velocity
+ * @param[in] acc_linear1_x - First X acceleration
+ * @param[in] acc_linear1_y - First Y acceleration
+ * @param[in] dt - The time delta across which to predict the state
+ * @param[in] position2_x - Second X position
+ * @param[in] position2_y - Second Y position
+ * @param[in] yaw2 - Second orientation
+ * @param[in] vel_linear2_x - Second X velocity
+ * @param[in] vel_linear2_y - Second Y velocity
+ * @param[in] vel_yaw2 - Second yaw velocity
+ * @param[in] acc_linear2_x - Second X acceleration
+ * @param[in] acc_linear2_y - Second Y acceleration
+ * @param[in] jacobians - Jacobians wrt the state
+ */
+// TODO(efernandez) fuse this with the templated predict function so we can use the analytic Jacobian in the cost
+// function. See http://ceres-solver.org/analytical_derivatives.html
+inline void predict(
+  const double position1_x,
+  const double position1_y,
+  const double yaw1,
+  const double vel_linear1_x,
+  const double vel_linear1_y,
+  const double vel_yaw1,
+  const double acc_linear1_x,
+  const double acc_linear1_y,
+  const double dt,
+  double& position2_x,
+  double& position2_y,
+  double& yaw2,
+  double& vel_linear2_x,
+  double& vel_linear2_y,
+  double& vel_yaw2,
+  double& acc_linear2_x,
+  double& acc_linear2_y,
+  // TODO(efernandez) double** jacobians didn't play well with Eigen::Map<>, at least directly
+  double* jacobians)
+{
+  const double sy = ceres::sin(yaw1);
+  const double cy = ceres::cos(yaw1);
+
+  const double half_dt2 = 0.5 * dt * dt;
+  const double delta_x = vel_linear1_x * dt + acc_linear1_x * half_dt2;
+  const double delta_y = vel_linear1_y * dt + acc_linear1_y * half_dt2;
+
+  const double delta_x_rot = cy * delta_x - sy * delta_y;
+  const double delta_y_rot = sy * delta_x + cy * delta_y;
+
+  position2_x = position1_x + delta_x_rot;
+  position2_y = position1_y + delta_y_rot;
+  yaw2 = yaw1 + vel_yaw1 * dt;
+  vel_linear2_x = vel_linear1_x + acc_linear1_x * dt;
+  vel_linear2_y = vel_linear1_y + acc_linear1_y * dt;
+  vel_yaw2 = vel_yaw1;
+  acc_linear2_x = acc_linear1_x;
+  acc_linear2_y = acc_linear1_y;
+
+  fuse_core::wrapAngle2D(yaw2);
+
+  if (!jacobians)
+  {
+    return;
+  }
+
+  Eigen::Map<fuse_core::Matrix8d> J(jacobians);
+  J.setIdentity();
+  J(X, YAW) = -delta_y_rot;
+  J(X, V_X) = cy * dt;
+  J(Y, V_X) = sy * dt;
+  J(X, V_Y) = -J(Y, V_X);
+  J(X, A_X) = 0.5 * J(X, V_X) * dt;
+  J(X, A_Y) = 0.5 * J(X, V_Y) * dt;
+  J(Y, YAW) = delta_x_rot;
+  J(Y, V_Y) = J(X, V_X);
+  J(Y, A_X) = -J(X, A_Y);
+  J(Y, A_Y) = J(X, A_X);
+  J(YAW, V_YAW) = dt;
+  J(V_X, A_X) = dt;
+  J(V_Y, A_Y) = dt;
+}
+
 /**
  * @brief Given a state and time delta, predicts a new state
  * @param[in] position1 - First position (array with x at index 0, y at index 1)
@@ -146,6 +246,68 @@ inline void predict(
     *vel_yaw2,
     acc_linear2[0],
     acc_linear2[1]);
+}
+
+/**
+ * @brief Given a state and time delta, predicts a new state
+ * @param[in] pose1 - The first 2D pose
+ * @param[in] vel_linear_1 - The first linear velocity
+ * @param[in] vel_yaw1 - The first yaw velocity
+ * @param[in] acc_linear1 - The first linear acceleration
+ * @param[in] dt - The time delta across which to predict the state
+ * @param[in] pose2 - The second 2D pose
+ * @param[in] vel_linear_2 - The second linear velocity
+ * @param[in] vel_yaw2 - The second yaw velocity
+ * @param[in] acc_linear2 - The second linear acceleration
+ * @param[in] jacobian - The jacobian wrt the state
+ */
+inline void predict(
+  const tf2_2d::Transform& pose1,
+  const tf2_2d::Vector2& vel_linear1,
+  const double vel_yaw1,
+  const tf2_2d::Vector2& acc_linear1,
+  const double dt,
+  tf2_2d::Transform& pose2,
+  tf2_2d::Vector2& vel_linear2,
+  double& vel_yaw2,
+  tf2_2d::Vector2& acc_linear2,
+  fuse_core::Matrix8d& jacobian)
+{
+  double x_pred {};
+  double y_pred {};
+  double yaw_pred {};
+  double vel_linear_x_pred {};
+  double vel_linear_y_pred {};
+  double acc_linear_x_pred {};
+  double acc_linear_y_pred {};
+
+  predict(
+    pose1.x(),
+    pose1.y(),
+    pose1.yaw(),
+    vel_linear1.x(),
+    vel_linear1.y(),
+    vel_yaw1,
+    acc_linear1.x(),
+    acc_linear1.y(),
+    dt,
+    x_pred,
+    y_pred,
+    yaw_pred,
+    vel_linear_x_pred,
+    vel_linear_y_pred,
+    vel_yaw2,
+    acc_linear_x_pred,
+    acc_linear_y_pred,
+    jacobian.data());
+
+  pose2.setX(x_pred);
+  pose2.setY(y_pred);
+  pose2.setYaw(yaw_pred);
+  vel_linear2.setX(vel_linear_x_pred);
+  vel_linear2.setY(vel_linear_y_pred);
+  acc_linear2.setX(acc_linear_x_pred);
+  acc_linear2.setY(acc_linear_y_pred);
 }
 
 /**

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
@@ -52,6 +52,7 @@ namespace fuse_models
  *   y position
  *   yaw (rotation about the z axis)
  *   x velocity
+ *   y velocity
  *   yaw velocity
  *   x acceleration
  *   y acceleration

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -80,7 +80,7 @@ void Odometry2DPublisher::onInit()
   odom_pub_ = node_handle_.advertise<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size);
 
   publish_timer_ = node_handle_.createTimer(
-    ros::Duration(1.0 / params_.tf_publish_frequency),
+    ros::Duration(1.0 / params_.publish_frequency),
     &Odometry2DPublisher::publishTimerCallback,
     this,
     false,

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -360,7 +360,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
         auto base_to_odom = tf_buffer_->lookupTransform(
           params_.base_link_frame_id,
           params_.odom_frame_id,
-          latest_stamp_,
+          trans.header.stamp,
           params_.tf_timeout);
 
         geometry_msgs::TransformStamped map_to_odom;


### PR DESCRIPTION
* Add `predict_odom` parameter that:
  1. Disables publishing the odometry in the `notifyCallback`
  2. Enables publishing the odometry in the `tfPublishTimerCallback`, predicting it into the current time.
     The Jacobian of the motion model used in the predict function is computed so the odometry covariance can be propagated.
     The odometry cached in the class is updated with the predicted pose, covariance and time stamp.
* Add `process_noise_diagonal` parameter that defines the diagonal of the process noise covariance that is added to the propagated covariance computing after predicting the odometry into the current time.
  The process noise covariance has 8x8 size, so it can represent all the state, although the acceleration is ignored at the moment.
* Add new `predict` free functions to compute the Jacobian of the motion model wrt the state. Two versions are provided:
  1. One that takes each single component and a plain array of double to
     the Jacobian.
  2. Another that takes aggregate objects like `tf2_2d::Transform` and an `fuse_core::Matrix8d` for the Jacobian.
* Cache the stamp of the latest covariance successfully computed in the `notifyCallback`, so it's possible to know if the covariance is valid and up to date in the `tfPublishTimerCallback`.
  If the covariance is invalid or not up to date, no time is wasted propagating it.