### PR TITLE
[RST-2149] better publisher log msgs

### DIFF
--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -93,7 +93,8 @@ void Odometry2DPublisher::notifyCallback(
   latest_stamp_ = synchronizer_.findLatestCommonStamp(*transaction, *graph);
   if (latest_stamp_ == Synchronizer::TIME_ZERO)
   {
-    ROS_WARN_STREAM_THROTTLE(10.0, "Failed to find a matching set of position and orientation variables.");
+    ROS_WARN_STREAM_THROTTLE(
+        10.0, "Failed to find a matching set of state variables with device id '" << device_id_ << "'.");
     return;
   }
 

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -204,7 +204,8 @@ void Pose2DPublisher::notifyCallback(
   auto latest_stamp = synchronizer_->findLatestCommonStamp(*transaction, *graph);
   if (latest_stamp == Synchronizer::TIME_ZERO)
   {
-    ROS_WARN_STREAM_THROTTLE(10.0, "Failed to find a matching set of position and orientation variables.");
+    ROS_WARN_STREAM_THROTTLE(
+        10.0, "Failed to find a matching set of stamped pose variables with device id '" << device_id_ << "'.");
     return;
   }
   // Get the pose values associated with the selected timestamp


### PR DESCRIPTION
During a test, the odometry publisher was complaining that it could not find a matched set of variables. However, the actual problem was the device id was configured differently than the sensors and motion models.

This PR adds the configured device_id to the log message. If the device_id is misconfigured, probably by not specifying one at all, it should be more obvious what the problem is.