### PR TITLE
Support empty linear terms in marginalizeNext

### DIFF
--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -81,9 +81,9 @@ UuidOrdering computeEliminationOrder(
     for (const auto& constraint : constraints)
     {
       unsigned int constraint_index = constraint_order[constraint.uuid()];
-      for (const auto& variable_uuid : constraint.variables())
+      for (const auto& constraint_variable_uuid : constraint.variables())
       {
-        variable_constraints.insert(constraint_index, variable_order[variable_uuid]);
+        variable_constraints.insert(constraint_index, variable_order[constraint_variable_uuid]);
       }
     }
   }

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -74,7 +74,7 @@ UuidOrdering computeEliminationOrder(
   for (const auto& variable_uuid : marginalized_variables)
   {
     // Get all connected constraints to this variable
-    auto constraints = graph.getConnectedConstraints(variable_uuid);
+    const auto constraints = graph.getConnectedConstraints(variable_uuid);
 
     // Add each constraint to the VariableConstraints object
     // New constraint and variable indices are automatically generated
@@ -191,7 +191,7 @@ fuse_core::Transaction marginalizeVariables(
   std::vector<std::vector<detail::LinearTerm>> linear_terms(variable_order.size());
   for (size_t i = 0ul; i < marginalized_variables.size(); ++i)
   {
-    auto constraints = graph.getConnectedConstraints(variable_order[i]);
+    const auto constraints = graph.getConnectedConstraints(variable_order[i]);
     for (const auto& constraint : constraints)
     {
       if (used_constraints.find(constraint.uuid()) == used_constraints.end())

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -363,6 +363,11 @@ LinearTerm linearize(
 
 LinearTerm marginalizeNext(const std::vector<LinearTerm>& linear_terms)
 {
+  if (linear_terms.empty())
+  {
+    return {};
+  }
+
   // We need to create a dense matrix from all of the provided linear terms, and that matrix must order the variables
   // in the proper elimination order. The LinearTerms have the elimination order baked into the variable indices, but
   // since not all variables are necessarily present, we need to remove any gaps from the variable indices.


### PR DESCRIPTION
With the current configuration I'm using for the `fixed_lag_smoother` I've got a crash because there are `linear_terms` that are `empty()` when `marginalizeNext` is called in https://github.com/locusrobotics/fuse/blob/devel/fuse_constraints/src/marginalize_variables.cpp#L221

I've managed to retrieved the `graph` and `marginalized_variables` arguments (https://github.com/locusrobotics/fuse/blob/devel/fuse_constraints/src/marginalize_variables.cpp#L166-L167) at the time of the crash and there's 1 out of 25 variables that has no constraints. I suspect that's the root cause of the crash, but that's all I know so far.

This PR is a band-aid patch in that sense, but I believe the correct action in `marginalizeNext` when the linear terms are empty is exactly the proposed change here, i.e. return an empty `LinearTerm`.

I also tried to implement an unit test with an orphan variable (a variable not used in any constraint) and 3 other variables connected by constraints. Certainly a much simpler test case than the graph I had in the core dump. The problem with this unit test is that it fails before it gets to call `marginalizeNext`. It fails in https://github.com/locusrobotics/fuse/blob/devel/fuse_constraints/src/marginalize_variables.cpp#L137 while computing the elimination order with CCOLAMD.

I can copy-paste the unit test I wrote here if you want to see it, but it doesn't exercise the code that failed for me, and that I'm patching here.

I can also send you the core dump, or the post-processed print output of the `graph` and `marginalized_variables` variables. I even created a Python script with the graph attributes, that it's what I used to find out there was an orphan variable in the graph. Unfortunately, I only have the UUIDs of the graph variables and constraints, that I got using GDB Boost pretty printers. So I don't know what's the type of the orphan variable. And even if I knew, that's probably not enough information to understand how that happened.

There's also two other commits:
* One that renames a variable that shadows another from an outer loop
* And another that enforces `constness` on some local variables