### PR TITLE
Use measurement stamps for transformed variables

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -273,8 +273,8 @@ inline bool processAbsolutePoseWithCovariance(
   tf2::fromMsg(transformed_message.pose.pose, absolute_pose_2d);
 
   // Create the pose variable
-  auto position = fuse_variables::Position2DStamped::make_shared(transformed_message.header.stamp, device_id);
-  auto orientation = fuse_variables::Orientation2DStamped::make_shared(transformed_message.header.stamp, device_id);
+  auto position = fuse_variables::Position2DStamped::make_shared(pose.header.stamp, device_id);
+  auto orientation = fuse_variables::Orientation2DStamped::make_shared(pose.header.stamp, device_id);
   position->x() = absolute_pose_2d.x();
   position->y() = absolute_pose_2d.y();
   orientation->yaw() = absolute_pose_2d.yaw();
@@ -509,7 +509,7 @@ inline bool processTwistWithCovariance(
   if (!linear_indices.empty())
   {
     auto velocity_linear =
-      fuse_variables::VelocityLinear2DStamped::make_shared(transformed_message.header.stamp, device_id);
+      fuse_variables::VelocityLinear2DStamped::make_shared(twist.header.stamp, device_id);
     velocity_linear->x() = transformed_message.twist.twist.linear.x;
     velocity_linear->y() = transformed_message.twist.twist.linear.y;
 
@@ -548,7 +548,7 @@ inline bool processTwistWithCovariance(
   {
     // Create the twist variables
     auto velocity_angular =
-      fuse_variables::VelocityAngular2DStamped::make_shared(transformed_message.header.stamp, device_id);
+      fuse_variables::VelocityAngular2DStamped::make_shared(twist.header.stamp, device_id);
     velocity_angular->yaw() = transformed_message.twist.twist.angular.z;
 
     fuse_core::Vector1d angular_vel_vector;
@@ -614,7 +614,7 @@ inline bool processAccelWithCovariance(
 
   // Create the acceleration variables
   auto acceleration_linear =
-    fuse_variables::AccelerationLinear2DStamped::make_shared(transformed_message.header.stamp, device_id);
+    fuse_variables::AccelerationLinear2DStamped::make_shared(acceleration.header.stamp, device_id);
   acceleration_linear->x() = transformed_message.accel.accel.linear.x;
   acceleration_linear->y() = transformed_message.accel.accel.linear.y;
 


### PR DESCRIPTION
This PR fixes an issue where the graph is incorrectly updated due to sensor measurement transactions with inconsistent timestamps. This is minor, but it came up in a test case and _I don't think_ it's intended behaviour.

Currently there is a discrepancy in how transactions and variables are timestamped for the built-in sensor models where transforms are applied (e.g., pose message received in frame F1 with target frame F2). For transactions, the original measurement stamp is used to add involved stamps, however for variables, the transformed stamp (based on transform time) is used. 
This is problematic in cases where [older](https://github.com/locusrobotics/fuse/blob/9933456ecc24ba9b649a8a2885be3f852306efee/fuse_models/include/fuse_models/common/sensor_proc.h#L217) transforms are used - i.e., subsequent motion models will generate (and stamp) variables based on the transaction's involved stamps, resulting in different uuids than any corresponding measured variables - the end result being that some variables are added to the graph twice, where the measurement 'version' of the variable is not connected.