### PR TITLE
Predict jacobians per parameter block

### DIFF
--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -63,6 +63,9 @@ using Matrix7d = Eigen::Matrix<double, 7, 7, Eigen::RowMajor>;
 using Matrix8d = Eigen::Matrix<double, 8, 8, Eigen::RowMajor>;
 using Matrix9d = Eigen::Matrix<double, 9, 9, Eigen::RowMajor>;
 
+template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
+using Matrix = Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Eigen::RowMajor>;
+
 }  // namespace fuse_core
 
 #endif  // FUSE_CORE_EIGEN_H

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -179,6 +179,20 @@ if(CATKIN_ENABLE_TESTING)
     )
   endif()
 
+  # Cost function tests
+  catkin_add_gtest(
+    test_unicycle_2d_state_cost_function
+    test/test_unicycle_2d_state_cost_function.cpp
+  )
+  if(TARGET test_unicycle_2d_state_cost_function)
+    target_link_libraries(
+      test_unicycle_2d_state_cost_function
+      ${PROJECT_NAME}
+      ${catkin_LIBRARIES}
+      ${CERES_LIBRARIES}
+    )
+  endif()
+
   # Ignition tests
   add_rostest_gtest(
     test_unicycle_2d_ignition

--- a/fuse_models/include/fuse_models/unicycle_2d_predict.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_predict.h
@@ -171,7 +171,7 @@ inline void predict(
     // Jacobian wrt position1
     if (jacobians[0])
     {
-      Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[0]);
+      Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[0]);
       jacobian << 1, 0,
                   0, 1,
                   0, 0,
@@ -195,7 +195,7 @@ inline void predict(
       const double cy_dt = cy * dt;
       const double sy_dt = sy * dt;
 
-      Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[2]);
+      Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[2]);
       jacobian << cy_dt, -sy_dt,
                   sy_dt,  cy_dt,
                       0, 0,
@@ -219,7 +219,7 @@ inline void predict(
       const double cy_half_dt2 = cy * half_dt2;
       const double sy_half_dt2 = sy * half_dt2;
 
-      Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[4]);
+      Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[4]);
       jacobian << cy_half_dt2, -sy_half_dt2,
                   sy_half_dt2,  cy_half_dt2,
                             0, 0,
@@ -316,7 +316,7 @@ inline void predict(
   // fuse_core::Matrix8d is Eigen::RowMajor, so we cannot use pointers to the columns where each parameter block starts.
   // Instead, we need to create a vector of Eigen::RowMajor matrices per parameter block and later reconstruct the
   // fuse_core::Matrix8d with the full jacobian.
-  // The parameter blocks have the following sizes: {2, 1, 2, 1, 2}
+  // The parameter blocks have the following sizes: {position1: 2, yaw1: 1, vel_linear1: 2, vel_yaw1: 1, acc_linear1: 2}
   static constexpr size_t num_residuals{ 8 };
   static constexpr size_t num_parameter_blocks{ 5 };
   static const std::array<size_t, num_parameter_blocks> block_sizes = {2, 1, 2, 1, 2};

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
@@ -181,7 +181,7 @@ public:
       // Update jacobian wrt position1
       if (jacobians[0])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[0]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[0]);
         jacobian.applyOnTheLeft(-A_);
       }
 
@@ -195,7 +195,7 @@ public:
       // Update jacobian wrt pvel_linear1
       if (jacobians[2])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[2]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[2]);
         jacobian.applyOnTheLeft(-A_);
       }
 
@@ -209,7 +209,7 @@ public:
       // Update jacobian wrt pacc_linear1
       if (jacobians[4])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[4]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[4]);
         jacobian.applyOnTheLeft(-A_);
       }
 
@@ -233,7 +233,7 @@ public:
       // Jacobian wrt position2
       if (jacobians[5])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[5]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[5]);
         jacobian = A_.block<8, 2>(0, 0);
       }
 
@@ -247,7 +247,7 @@ public:
       // Jacobian wrt vel_linear2
       if (jacobians[7])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[7]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[7]);
         jacobian = A_.block<8, 2>(0, 3);
       }
 
@@ -261,7 +261,7 @@ public:
       // Jacobian wrt acc_linear2
       if (jacobians[9])
       {
-        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[9]);
+        Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[9]);
         jacobian = A_.block<8, 2>(0, 6);
       }
     }

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
@@ -1,0 +1,285 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_MODELS_UNICYCLE_2D_STATE_COST_FUNCTION_H
+#define FUSE_MODELS_UNICYCLE_2D_STATE_COST_FUNCTION_H
+
+#include <fuse_models/unicycle_2d_predict.h>
+
+#include <fuse_core/eigen.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/util.h>
+
+#include <ceres/sized_cost_function.h>
+
+
+namespace fuse_models
+{
+
+/**
+ * @brief Create a cost function for a 2D state vector
+ * 
+ * The state vector includes the following quantities, given in this order:
+ *   x position
+ *   y position
+ *   yaw (rotation about the z axis)
+ *   x velocity
+ *   y velocity
+ *   yaw velocity
+ *   x acceleration
+ *   y acceleration
+ *
+ * The Ceres::NormalPrior cost function only supports a single variable. This is a convenience cost function that
+ * applies a prior constraint on both the entire state vector.
+ *
+ * The cost function is of the form:
+ *
+ *             ||    [        x_t2 - proj(x_t1)       ] ||^2
+ *   cost(x) = ||    [        y_t2 - proj(y_t1)       ] ||
+ *             ||    [      yaw_t2 - proj(yaw_t1)     ] ||
+ *             ||A * [    x_vel_t2 - proj(x_vel_t1)   ] ||
+ *             ||    [    y_vel_t2 - proj(y_vel_t1)   ] ||
+ *             ||    [  yaw_vel_t2 - proj(yaw_vel_t1) ] ||
+ *             ||    [    x_acc_t2 - proj(x_acc_t1)   ] ||
+ *             ||    [    y_acc_t2 - proj(y_acc_t1)   ] ||
+ * 
+ * where, the matrix A is fixed, the state variables are provided at two discrete time steps, and proj is a function
+ * that projects the state variables from time t1 to time t2. In case the user is interested in implementing a cost
+ * function of the form
+ *
+ *   cost(X) = (X - mu)^T S^{-1} (X - mu)
+ *
+ * where, mu is a vector and S is a covariance matrix, then, A = S^{-1/2}, i.e the matrix A is the square root
+ * information matrix (the inverse of the covariance).
+ */
+class Unicycle2DStateCostFunction : public ceres::SizedCostFunction<8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>
+{
+public:
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+
+  /**
+   * @brief Construct a cost function instance
+   *
+   * @param[in] dt The time delta across which to generate the kinematic model cost
+   * @param[in] A The residual weighting matrix, most likely the square root information matrix in order
+   *              (x, y, yaw, x_vel, y_vel, yaw_vel, x_acc, y_acc)
+   */
+  Unicycle2DStateCostFunction(const double dt, const fuse_core::Matrix8d& A);
+
+  /**
+   * @brief Evaluate the cost function. Used by the Ceres optimization engine.
+   *
+   * @param[in] parameters - Parameter blocks:
+   *                         0 : position1 - First position (array with x at index 0, y at index 1)
+   *                         1 : yaw1 - First yaw
+   *                         2 : vel_linear1 - First linear velocity (array with x at index 0, y at index 1)
+   *                         3 : vel_yaw1 - First yaw velocity
+   *                         4 : acc_linear1 - First linear acceleration (array with x at index 0, y at index 1)
+   *                         5 : position2 - Second position (array with x at index 0, y at index 1)
+   *                         6 : yaw2 - Second yaw
+   *                         7 : vel_linear2 - Second linear velocity (array with x at index 0, y at index 1)
+   *                         8 : vel_yaw2 - Second yaw velocity
+   *                         9 : acc_linear2 - Second linear acceleration (array with x at index 0, y at index 1)
+   * @param[out] residual - The computed residual (error)
+   * @param[out] jacobians - Jacobians of the residuals wrt the parameters. Only computed if not NULL, and only
+   *                         computed for the parameters where jacobians[i] is not NULL.
+   * @return The return value indicates whether the computation of the residuals and/or jacobians was successful or not.
+   */
+  bool Evaluate(double const* const* parameters,
+                double* residuals,
+                double** jacobians) const override
+  {
+    double position_pred_x;
+    double position_pred_y;
+    double yaw_pred;
+    double vel_linear_pred_x;
+    double vel_linear_pred_y;
+    double vel_yaw_pred;
+    double acc_linear_pred_x;
+    double acc_linear_pred_y;
+    predict(
+      parameters[0][0],  // position1_x
+      parameters[0][1],  // position1_y
+      parameters[1][0],  // yaw1
+      parameters[2][0],  // vel_linear1_x
+      parameters[2][1],  // vel_linear1_y
+      parameters[3][0],  // vel_yaw1
+      parameters[4][0],  // acc_linear1_x
+      parameters[4][1],  // acc_linear1_y
+      dt_,
+      position_pred_x,
+      position_pred_y,
+      yaw_pred,
+      vel_linear_pred_x,
+      vel_linear_pred_y,
+      vel_yaw_pred,
+      acc_linear_pred_x,
+      acc_linear_pred_y,
+      jacobians);
+
+    residuals[0] = parameters[5][0] - position_pred_x;
+    residuals[1] = parameters[5][1] - position_pred_y;
+    residuals[2] = parameters[6][0] - yaw_pred;
+    residuals[3] = parameters[7][0] - vel_linear_pred_x;
+    residuals[4] = parameters[7][1] - vel_linear_pred_y;
+    residuals[5] = parameters[8][0] - vel_yaw_pred;
+    residuals[6] = parameters[9][0] - acc_linear_pred_x;
+    residuals[7] = parameters[9][1] - acc_linear_pred_y;
+
+    fuse_core::wrapAngle2D(residuals[2]);
+
+    // Scale the residuals by the square root information matrix to account for
+    // the measurement uncertainty.
+    Eigen::Map<fuse_core::Vector8d> residuals_map(residuals);
+    residuals_map.applyOnTheLeft(A_);
+
+    if (jacobians)
+    {
+      // It might be possible to simplify the code below implementing something like this but using compile-time
+      // template recursion.
+      //
+      // // state1: (position1, yaw1, vel_linear1, vel_yaw1, acc_linear1)
+      // for (size_t i = 0; i < 5; ++i)
+      // {
+      //   if (jacobians[i])
+      //   {
+      //     Eigen::Map<fuse_core::Matrix<double, 8, ParameterDims::GetDim(i)>> jacobian(jacobians[i]);
+      //     jacobian.applyOnTheLeft(-A_);
+      //   }
+      // }
+
+      // Update jacobian wrt position1
+      if (jacobians[0])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[0]);
+        jacobian.applyOnTheLeft(-A_);
+      }
+
+      // Update jacobian wrt pyaw1
+      if (jacobians[1])
+      {
+        Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[1]);
+        jacobian.applyOnTheLeft(-A_);
+      }
+
+      // Update jacobian wrt pvel_linear1
+      if (jacobians[2])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[2]);
+        jacobian.applyOnTheLeft(-A_);
+      }
+
+      // Update jacobian wrt pvel_yaw1
+      if (jacobians[3])
+      {
+        Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[3]);
+        jacobian.applyOnTheLeft(-A_);
+      }
+
+      // Update jacobian wrt pacc_linear1
+      if (jacobians[4])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[4]);
+        jacobian.applyOnTheLeft(-A_);
+      }
+
+      // It might be possible to simplify the code below implementing something like this but using compile-time
+      // template recursion.
+      //
+      // // state2: (position2, yaw2, vel_linear2, vel_yaw2, acc_linear2)
+      // for (size_t i = 5, offset = 0; i < ParameterDims::kNumParameterBlocks; ++i)
+      // {
+      //   constexpr auto dim = ParameterDims::GetDim(i);
+
+      //   if (jacobians[i])
+      //   {
+      //     Eigen::Map<fuse_core::Matrix<double, 8, dim>> jacobian(jacobians[i]);
+      //     jacobian = A_.block<8, dim>(0, offset);
+      //   }
+
+      //   offset += dim;
+      // }
+
+      // Jacobian wrt position2
+      if (jacobians[5])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[5]);
+        jacobian = A_.block<8, 2>(0, 0);
+      }
+
+      // Jacobian wrt yaw2
+      if (jacobians[6])
+      {
+        Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[6]);
+        jacobian = A_.col(2);
+      }
+
+      // Jacobian wrt vel_linear2
+      if (jacobians[7])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[7]);
+        jacobian = A_.block<8, 2>(0, 3);
+      }
+
+      // Jacobian wrt vel_yaw2
+      if (jacobians[8])
+      {
+        Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[8]);
+        jacobian = A_.col(5);
+      }
+
+      // Jacobian wrt acc_linear2
+      if (jacobians[9])
+      {
+        Eigen::Map<Eigen::Matrix<double, 8, 2, Eigen::RowMajor>> jacobian(jacobians[9]);
+        jacobian = A_.block<8, 2>(0, 6);
+      }
+    }
+
+    return true;
+  }
+
+private:
+  double dt_;
+  fuse_core::Matrix8d A_;  //!< The residual weighting matrix, most likely the square root information matrix
+};
+
+Unicycle2DStateCostFunction::Unicycle2DStateCostFunction(const double dt, const fuse_core::Matrix8d& A) :
+  dt_(dt),
+  A_(A)
+{
+}
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_UNICYCLE_2D_STATE_COST_FUNCTION_H

--- a/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
+++ b/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_models/unicycle_2d_state_kinematic_constraint.h>
-#include <fuse_models/unicycle_2d_state_cost_functor.h>
+#include <fuse_models/unicycle_2d_state_cost_function.h>
 
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -42,7 +42,6 @@
 #include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
-#include <ceres/autodiff_cost_function.h>
 #include <Eigen/Dense>
 
 #include <ostream>
@@ -103,8 +102,16 @@ void Unicycle2DStateKinematicConstraint::print(std::ostream& stream) const
 
 ceres::CostFunction* Unicycle2DStateKinematicConstraint::costFunction() const
 {
-  return new ceres::AutoDiffCostFunction<Unicycle2DStateCostFunctor, 8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>(
-    new Unicycle2DStateCostFunctor(dt_, sqrt_information_));
+  // Here we return a cost function that computes the analytic derivatives/jacobians, but we could use automatic
+  // differentiation as follows:
+  //
+  // return new ceres::AutoDiffCostFunction<Unicycle2DStateCostFunctor, 8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>(
+  //   new Unicycle2DStateCostFunctor(dt_, sqrt_information_));
+  //
+  // which requires:
+  //
+  // #include <fuse_models/unicycle_2d_state_cost_functor.h>
+  return new Unicycle2DStateCostFunction(dt_, sqrt_information_);
 }
 
 }  // namespace fuse_models

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -103,7 +103,9 @@ TEST(CostFunction, evaluateCostFunction)
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;
-  EXPECT_TRUE(gradient_checker.Probe(parameters, 1e-9, &probe_results)) << probe_results.error_log;
+  // TODO(efernandez) probe_results segfaults when it's destroyed at the end of this TEST function, but Probe actually
+  // returns true and the jacobians are correct according to the gradient checker numeric differentiation
+  // EXPECT_TRUE(gradient_checker.Probe(parameters, 1e-9, &probe_results)) << probe_results.error_log;
 
   // Create cost function using automatic differentiation on the cost functor
   ceres::AutoDiffCostFunction<fuse_models::Unicycle2DStateCostFunctor, 8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -1,0 +1,139 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_models/unicycle_2d_state_cost_function.h>
+#include <fuse_models/unicycle_2d_state_cost_functor.h>
+
+#include <gtest/gtest.h>
+#include <fuse_core/eigen_gtest.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <ceres/gradient_checker.h>
+#include <Eigen/Dense>
+
+#include <limits>
+#include <vector>
+
+
+TEST(CostFunction, evaluateCostFunction)
+{
+  // Create cost function
+  const double process_noise_diagonal[] = { 1e-3, 1e-3, 1e-2, 1e-6, 1e-6, 1e-4, 1e-9, 1e-9 };
+  const fuse_core::Matrix8d covariance = fuse_core::Vector8d(process_noise_diagonal).asDiagonal();
+
+  const double dt{ 0.1 };
+  const fuse_core::Matrix8d sqrt_information{ covariance.inverse().llt().matrixU() };
+
+  const fuse_models::Unicycle2DStateCostFunction cost_function{ dt, sqrt_information };
+
+  // Evaluate cost function
+  const double position1[] = {0.0, 0.0};
+  const double yaw1[] = {0.0};
+  const double vel_linear1[] = {1.0, 0.0};
+  const double vel_yaw1[] = {1.570796327};
+  const double acc_linear1[] = {1.0, 0.0};
+
+  const double position2[] = {0.105, 0.0};
+  const double yaw2[] = {0.1570796327};
+  const double vel_linear2[] = {1.1, 0.0};
+  const double vel_yaw2[] = {1.570796327};
+  const double acc_linear2[] = {1.0, 0.0};
+
+  const double* parameters[] =
+  {
+    position1, yaw1, vel_linear1, vel_yaw1, acc_linear1,
+    position2, yaw2, vel_linear2, vel_yaw2, acc_linear2
+  };
+
+  fuse_core::Vector8d residuals;
+
+  const auto& block_sizes = cost_function.parameter_block_sizes();
+  const auto num_parameter_blocks = block_sizes.size();
+
+  const auto num_residuals = cost_function.num_residuals();
+
+  std::vector<fuse_core::MatrixXd> J(num_parameter_blocks);
+  std::vector<double*> jacobians(num_parameter_blocks);
+
+  for (size_t i = 0; i < num_parameter_blocks; ++i)
+  {
+    J[i].resize(num_residuals, block_sizes[i]);
+    jacobians[i] = J[i].data();
+  }
+
+  EXPECT_TRUE(cost_function.Evaluate(parameters, residuals.data(), jacobians.data()));
+
+  // We cannot use std::numeric_limits<double>::epsilon() tolerance because with the expected state2 above the residuals
+  // are not zero for position2.x = -4.389e-16 and yaw2 = -2.776e-16
+  EXPECT_MATRIX_NEAR(fuse_core::Vector8d::Zero(), residuals, 1e-15);
+
+  // Check jacobians are correct using a gradient checker
+  ceres::NumericDiffOptions numeric_diff_options;
+  ceres::GradientChecker gradient_checker(&cost_function, NULL, numeric_diff_options);
+
+  // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
+  ceres::GradientChecker::ProbeResults probe_results;
+  EXPECT_TRUE(gradient_checker.Probe(parameters, 1e-9, &probe_results)) << probe_results.error_log;
+
+  // Create cost function using automatic differentiation on the cost functor
+  ceres::AutoDiffCostFunction<fuse_models::Unicycle2DStateCostFunctor, 8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>
+      cost_function_autodiff(new fuse_models::Unicycle2DStateCostFunctor(dt, sqrt_information));
+
+  // Evaluate cost function that uses automatic differentiation
+  std::vector<fuse_core::MatrixXd> J_autodiff(num_parameter_blocks);
+  std::vector<double*> jacobians_autodiff(num_parameter_blocks);
+
+  for (size_t i = 0; i < num_parameter_blocks; ++i)
+  {
+    J_autodiff[i].resize(num_residuals, block_sizes[i]);
+    jacobians_autodiff[i] = J_autodiff[i].data();
+  }
+
+  EXPECT_TRUE(cost_function_autodiff.Evaluate(parameters, residuals.data(), jacobians_autodiff.data()));
+
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
+  for (size_t i = 0; i < num_parameter_blocks; ++i)
+  {
+    EXPECT_MATRIX_NEAR(J_autodiff[i], J[i], std::numeric_limits<double>::epsilon())
+      << "Autodiff Jacobian[" << i << "] =\n" << J_autodiff[i].format(HeavyFmt)
+      << "\nAnalytic Jacobian[" << i << "] =\n" << J[i].format(HeavyFmt);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a continuation of https://github.com/locusrobotics/fuse/pull/109 that provides the following:
1. Compute the jacobians of the motion model `predict` free function
    and a new cost function for the `unicycle_2d` state, that is equivalent to
    the cost functor, following the documentation regarding the jacobians
    layout: http://ceres-solver.org/nnls_modeling.html#costfunction . That is,
    the jacobians are computed per parameter blocks.

2. Add a unit test for the new cost function. The gradient checker is disabled because
    if we call `Probe` on the gradient checker the check passes successfully,
    but the probe results produces at segfault when it's destroyed at the
    end of the `TEST` scope.
    
    This also happens if we create an dummy cost function and probe the
    gradient checker on it, taking the gradient checker test from ceres
    source code. This suggest either an issue in the gradient checker itself
    or likely some compile or link issue.

    Fortunately, a similar check is done with automatic differentiation, w/o any issues.
    And it's still possible to enable the gradient checker check (currently commented out)
    locally, and confirm that it also passes.

3. Update previous code, specially to convert between `Eigen` matrices that
    store the full jacobian and ceres jacobians layout.

After this PR we should be able to merge the `predict` functions and the cost function and functor following http://ceres-solver.org/interfacing_with_autodiff.html . This could be discussed as part of this PR, but IMHO it'd make the diff too large and make the review harder. But there certainly a few things that are still in WIP status.