### PR TITLE
Wait for reset service existence

### DIFF
--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -230,6 +230,12 @@ void Unicycle2DIgnition::process(const geometry_msgs::PoseWithCovarianceStamped&
   // Tell the optimizer to reset before providing the initial state
   if (!params_.reset_service.empty())
   {
+    // Wait for the reset service
+    while (!reset_client_.waitForExistence(ros::Duration(10.0)) && ros::ok())
+    {
+      ROS_WARN_STREAM("Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
+    }
+
     auto srv = std_srvs::Empty();
     if (!reset_client_.call(srv))
     {


### PR DESCRIPTION
There are some cases where the `reset` service might not be available yet if the `set_pose` is set very early when the node is launched. This waits for the `reset` service to be available in the `onInit` method, so it's guaranteed to be available later when it's called.