### PR TITLE
Support ceres 2.0 in tests

### DIFF
--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -35,6 +35,7 @@
 #define FUSE_CORE_AUTODIFF_LOCAL_PARAMETERIZATION_H
 
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/ceres_options.h>
 #include <fuse_core/macros.h>
 
 #include <ceres/internal/autodiff.h>
@@ -185,8 +186,13 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
 
   const double* parameter_ptrs[2] = {x, zero_delta};
   double* jacobian_ptrs[2] = {NULL, jacobian};
+#if !CERES_VERSION_AT_LEAST(2, 0, 0)
   return ceres::internal::AutoDiff<PlusFunctor, double, kGlobalSize, kLocalSize>
     ::Differentiate(*plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
+#else
+  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
+      *plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
+#endif
 }
 
 template <typename PlusFunctor, typename MinusFunctor, int kGlobalSize, int kLocalSize>
@@ -207,8 +213,13 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
 
   const double* parameter_ptrs[2] = {x, x};
   double* jacobian_ptrs[2] = {NULL, jacobian};
+#if !CERES_VERSION_AT_LEAST(2, 0, 0)
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
+#else
+  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
+      *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
+#endif
 }
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -152,12 +152,12 @@ inline bool StringToDumpFormatType(std::string value, DumpFormatType* type)
 namespace ceres
 {
 
-bool StringToLoggingType(std::string value, LoggingType* type)
+inline bool StringToLoggingType(std::string value, LoggingType* type)
 {
   return StringtoLoggingType(value, type);
 }
 
-bool StringToDumpFormatType(std::string value, DumpFormatType* type)
+inline bool StringToDumpFormatType(std::string value, DumpFormatType* type)
 {
   return StringtoDumpFormatType(value, type);
 }

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -37,6 +37,7 @@
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
+#include <ceres/version.h>
 #include <ceres/covariance.h>
 #include <ceres/problem.h>
 #include <ceres/solver.h>


### PR DESCRIPTION
* Update autodiff Differentiate for Ceres 2.0
    
    In Ceres 2.0 we should call `AutoDifferentiate<...>(...)` instead of
    `AutoDiff<...>::Differentiate(...)`.

* Make free functions inline for Ceres 2.0 patch
    
    Otherwise there's a linking error because the function is defined twice:
    once for the fixed lag smoother and once for the batch optimizer, which
    are built together into the same library.

* Include `ceres/version.h` to check ceres version
    
    Otherwise the `CERES_VERSION_*` preprocessor macros are NOT set.