### PR TITLE
Revert "Fix build with ceres 2.0 with CMake < 3.8 (#106)"

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(SuiteSparse REQUIRED COMPONENTS CCOLAMD)
@@ -59,7 +58,6 @@ add_library(${PROJECT_NAME}
   src/uuid_ordering.cpp
   src/variable_constraints.cpp
 )
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_generic_lambdas)
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
 )
@@ -217,7 +215,6 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(test_marginal_constraint
     ${catkin_EXPORTED_TARGETS}
   )
-  target_compile_features(test_marginal_constraint PRIVATE cxx_generic_lambdas)
   target_include_directories(test_marginal_constraint
     PRIVATE
       include
@@ -235,7 +232,6 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(test_marginalize_variables
     ${catkin_EXPORTED_TARGETS}
   )
-  target_compile_features(test_marginalize_variables PRIVATE cxx_generic_lambdas)
   target_include_directories(test_marginalize_variables
     PRIVATE
       include

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -10,7 +10,6 @@ set(build_depends
 find_package(catkin REQUIRED COMPONENTS
   ${build_depends}
 )
-set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Boost REQUIRED COMPONENTS serialization)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -50,7 +49,6 @@ add_library(${PROJECT_NAME}
   src/uuid.cpp
   src/variable.cpp
 )
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_generic_lambdas)
 add_dependencies(${PROJECT_NAME}
   ${catkin_EXPORTED_TARGETS}
 )


### PR DESCRIPTION
This reverts commit 9933456ecc24ba9b649a8a2885be3f852306efee which is NOT needed after #112 
This should be done before merging #119 , that does NOT remove these two instances of `target_compile_features`:
``` bash
fuse_constraints/CMakeLists.txt
219:  target_compile_features(test_marginal_constraint PRIVATE cxx_generic_lambdas)
237:  target_compile_features(test_marginalize_variables PRIVATE cxx_generic_lambdas)
```