### PR TITLE
Benchmark unicycle_2d state cost function

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -223,3 +223,26 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 endif()
+
+if(CATKIN_ENABLE_BENCHMARKING)
+  find_package(benchmark REQUIRED)
+
+  add_executable(benchmark_unicycle_2d_state_cost_function
+    benchmark/benchmark_unicycle_2d_state_cost_function.cpp
+  )
+  if(TARGET benchmark_unicycle_2d_state_cost_function)
+    target_link_libraries(
+      benchmark_unicycle_2d_state_cost_function
+      benchmark
+      ${PROJECT_NAME}
+      ${catkin_LIBRARIES}
+      ${CERES_LIBRARIES}
+    )
+  endif()
+
+  install(TARGETS benchmark_unicycle_2d_state_cost_function
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+endif()

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -222,27 +222,22 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
   )
-endif()
 
-if(CATKIN_ENABLE_BENCHMARKING)
-  find_package(benchmark REQUIRED)
+  # Benchmarks
+  find_package(benchmark QUIET)
 
-  add_executable(benchmark_unicycle_2d_state_cost_function
-    benchmark/benchmark_unicycle_2d_state_cost_function.cpp
-  )
-  if(TARGET benchmark_unicycle_2d_state_cost_function)
-    target_link_libraries(
-      benchmark_unicycle_2d_state_cost_function
-      benchmark
-      ${PROJECT_NAME}
-      ${catkin_LIBRARIES}
-      ${CERES_LIBRARIES}
+  if(benchmark_FOUND)
+    add_executable(benchmark_unicycle_2d_state_cost_function
+      benchmark/benchmark_unicycle_2d_state_cost_function.cpp
     )
+    if(TARGET benchmark_unicycle_2d_state_cost_function)
+      target_link_libraries(
+        benchmark_unicycle_2d_state_cost_function
+        benchmark
+        ${PROJECT_NAME}
+        ${catkin_LIBRARIES}
+        ${CERES_LIBRARIES}
+      )
+    endif()
   endif()
-
-  install(TARGETS benchmark_unicycle_2d_state_cost_function
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
 endif()

--- a/fuse_models/benchmark/benchmark_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/benchmark/benchmark_unicycle_2d_state_cost_function.cpp
@@ -1,0 +1,157 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_models/unicycle_2d_state_cost_function.h>
+#include <fuse_models/unicycle_2d_state_cost_functor.h>
+
+#include <benchmark/benchmark.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <Eigen/Dense>
+
+#include <vector>
+
+class Unicycle2DStateCostFunction : public benchmark::Fixture
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  Unicycle2DStateCostFunction()
+    : jacobians(num_parameter_blocks)
+    , J(num_parameter_blocks)
+  {
+    for (size_t i = 0; i < num_parameter_blocks; ++i)
+    {
+      J[i].resize(num_residuals, block_sizes[i]);
+      jacobians[i] = J[i].data();
+    }
+  }
+
+  // Analytic cost function
+  static constexpr double dt{ 0.1 };
+  static const fuse_core::Matrix8d sqrt_information;
+
+  static const fuse_models::Unicycle2DStateCostFunction cost_function;
+
+  // Parameters
+  static const double* parameters[];
+
+  // Residuals
+  fuse_core::Vector8d residuals;
+
+  static const std::vector<int32_t>& block_sizes;
+  static const size_t num_parameter_blocks;
+
+  static const size_t num_residuals;
+
+  // Jacobians
+  std::vector<double*> jacobians;
+
+private:
+  // Cost function process noise and covariance
+  static const double process_noise_diagonal[];
+
+  static const fuse_core::Matrix8d covariance;
+
+  // Parameter blocks
+  static const double position1[];
+  static const double yaw1[];
+  static const double vel_linear1[];
+  static const double vel_yaw1[];
+  static const double acc_linear1[];
+
+  static const double position2[];
+  static const double yaw2[];
+  static const double vel_linear2[];
+  static const double vel_yaw2[];
+  static const double acc_linear2[];
+
+  // Jacobian matrices
+  std::vector<fuse_core::MatrixXd> J;
+};
+
+// Cost function process noise and covariance
+const double Unicycle2DStateCostFunction::process_noise_diagonal[] = { 1e-3, 1e-3, 1e-2, 1e-6, 1e-6, 1e-4, 1e-9, 1e-9 };
+
+const fuse_core::Matrix8d Unicycle2DStateCostFunction::covariance =
+    fuse_core::Vector8d(process_noise_diagonal).asDiagonal();
+
+// Parameter blocks
+const double Unicycle2DStateCostFunction::position1[] = { 0.0, 0.0 };
+const double Unicycle2DStateCostFunction::yaw1[] = {0.0};
+const double Unicycle2DStateCostFunction::vel_linear1[] = {1.0, 0.0};
+const double Unicycle2DStateCostFunction::vel_yaw1[] = {1.570796327};
+const double Unicycle2DStateCostFunction::acc_linear1[] = {1.0, 0.0};
+
+const double Unicycle2DStateCostFunction::position2[] = {0.105, 0.0};
+const double Unicycle2DStateCostFunction::yaw2[] = {0.1570796327};
+const double Unicycle2DStateCostFunction::vel_linear2[] = {1.1, 0.0};
+const double Unicycle2DStateCostFunction::vel_yaw2[] = {1.570796327};
+const double Unicycle2DStateCostFunction::acc_linear2[] = {1.0, 0.0};
+
+// Analytic cost function
+const fuse_core::Matrix8d Unicycle2DStateCostFunction::sqrt_information(covariance.inverse().llt().matrixU());
+
+const fuse_models::Unicycle2DStateCostFunction Unicycle2DStateCostFunction::cost_function{ dt, sqrt_information };
+
+// Parameters
+const double* Unicycle2DStateCostFunction::parameters[] = {  // NOLINT(whitespace/braces)
+  position1, yaw1, vel_linear1, vel_yaw1, acc_linear1, position2, yaw2, vel_linear2, vel_yaw2, acc_linear2
+};
+
+const std::vector<int32_t>& Unicycle2DStateCostFunction::block_sizes = cost_function.parameter_block_sizes();
+const size_t Unicycle2DStateCostFunction::num_parameter_blocks = block_sizes.size();
+
+const size_t Unicycle2DStateCostFunction::num_residuals = cost_function.num_residuals();
+
+BENCHMARK_F(Unicycle2DStateCostFunction, AnalyticUnicycle2DCostFunction)(benchmark::State& state)
+{
+  for (auto _ : state)
+  {
+    cost_function.Evaluate(parameters, residuals.data(), jacobians.data());
+  }
+}
+
+BENCHMARK_F(Unicycle2DStateCostFunction, AutoDiffUnicycle2DStateCostFunction)(benchmark::State& state)
+{
+  // Create cost function using automatic differentiation on the cost functor
+  ceres::AutoDiffCostFunction<fuse_models::Unicycle2DStateCostFunctor, 8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>
+      cost_function_autodiff(new fuse_models::Unicycle2DStateCostFunctor(dt, sqrt_information));
+
+  for (auto _ : state)
+  {
+    cost_function_autodiff.Evaluate(parameters, residuals.data(), jacobians.data());
+  }
+}
+
+BENCHMARK_MAIN();

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>roslint</build_depend>
 
+  <depend>benchmark</depend>
   <depend>boost</depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -13,22 +13,6 @@
 
   <build_depend>roslint</build_depend>
 
-  <!-- The official rosdep doesn't have an entry for Google's benchmark deb:
-       https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml
-
-       There's an official deb named libbenchmark-dev available since Ubuntu Bionic:
-       https://packages.ubuntu.com/bionic/libbenchmark-dev
-
-       ROS Melodic officially supports Ubuntu Bionic:
-       https://www.ros.org/reps/rep-0003.html
-
-       This could be uncommented if we add a benchmark entry like this to the official rosdep:
-
-       benchmark:
-         ubuntu:
-           bionic: libbenchmark-dev
-  -->
-  <!--<depend>benchmark</depend>-->
   <depend>boost</depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>
@@ -53,6 +37,25 @@
 
   <exec_depend>message_runtime</exec_depend>
 
+  <!-- The official rosdep doesn't have an entry for Google's benchmark deb:
+       https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml
+
+       There's an official deb named libbenchmark-dev available since Ubuntu Bionic:
+       https://packages.ubuntu.com/bionic/libbenchmark-dev
+
+       ROS Melodic officially supports Ubuntu Bionic:
+       https://www.ros.org/reps/rep-0003.html
+
+       This could be uncommented if we add a benchmark entry like this to the official rosdep:
+
+       benchmark:
+         ubuntu:
+           bionic: [libbenchmark-dev]
+
+       There is PR requesting that still under review:
+       https://github.com/ros/rosdistro/pull/23163
+  -->
+  <!--<test_depend>benchmark</test_depend>-->
   <test_depend>rostest</test_depend>
 
   <export>

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -13,7 +13,22 @@
 
   <build_depend>roslint</build_depend>
 
-  <depend>benchmark</depend>
+  <!-- The official rosdep doesn't have an entry for Google's benchmark deb:
+       https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml
+
+       There's an official deb named libbenchmark-dev available since Ubuntu Bionic:
+       https://packages.ubuntu.com/bionic/libbenchmark-dev
+
+       ROS Melodic officially supports Ubuntu Bionic:
+       https://www.ros.org/reps/rep-0003.html
+
+       This could be uncommented if we add a benchmark entry like this to the official rosdep:
+
+       benchmark:
+         ubuntu:
+           bionic: libbenchmark-dev
+  -->
+  <!--<depend>benchmark</depend>-->
   <depend>boost</depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
This benchmarks the analytic vs automatic differentiation cost functions for the `unicycle_2d` state motion model implemented in https://github.com/locusrobotics/fuse/pull/115, giving the following results:

``` bash
$ sudo cpupower frequency-set --governor performance
Setting cpu: 0
Setting cpu: 1
Setting cpu: 2
Setting cpu: 3
Setting cpu: 4
Setting cpu: 5
Setting cpu: 6
Setting cpu: 7
Setting cpu: 8
Setting cpu: 9
Setting cpu: 10
Setting cpu: 11

$ rosrun fuse_models benchmark_unicycle_2d_state_cost_function
2019-11-21 11:29:36
Running /home/efernandez/dev/ws/cpr_ws/devel/lib/fuse_models/benchmark_unicycle_2d_state_cost_function
Run on (12 X 2201 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 9216K (x1)
Load Average: 0.99, 1.25, 1.38
----------------------------------------------------------------------------------------------------------
Benchmark                                                                Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------
Unicycle2DStateCostFunction/AnalyticUnicycle2DCostFunction             384 ns          384 ns      1587923
Unicycle2DStateCostFunction/AutoDiffUnicycle2DStateCostFunction       1491 ns         1491 ns       472094
```

refs CORE-15104

For this to get compiled you need to pass `-DCATKIN_ENABLE_BENCHMARKING=1` to `cmake` or `catkin --cmake-args`.

You also need the `benchmark` debian installed in your system for this to build successfully. You probably need to add it to your CI buildfarm for the build test to pass in this PR.

The benchmark shows the analytic version is almost 4 times faster than the automatic differentiation one. This is too good to be true, so maybe I'm not testing things properly, i.e maybe some initialization stuff is being benchmark for the automatic differentiation version, but I think I'm testing it right.

We could also try using plain arrays in the analytic version. I'd like to try that and benchmark it, but I'm not sure how to organize the code to do so. Should I create a new class that implements the analytic jacobians computation with plain array, so I have two classes (apart from the automatic differentiation) that I can benchmark simultaneously in the same workspace?

FYI @svwilliams 