### PR TITLE
Wrap normal delta pose 2d orientation angle error

### DIFF
--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
@@ -123,7 +123,7 @@ bool NormalDeltaPose2DCostFunctor::operator()(
   full_residuals_vector.template head<2>() =
     fuse_core::rotationMatrix2D(orientation1[0]).transpose() * (position2_vector - position1_vector) -
     b_.head<2>().template cast<T>();
-  full_residuals_vector(2) = fuse_core::wrapAngle2D(orientation2[0] - orientation1[0]) - T(b_(2));
+  full_residuals_vector(2) = fuse_core::wrapAngle2D(orientation2[0] - orientation1[0] - T(b_(2)));
 
   // Scale the residuals by the square root information matrix to account for
   // the measurement uncertainty.


### PR DESCRIPTION
If only the delta orientation angle is wrapped to the `(-pi, pi]` interval, it could still happen that the error is outside of that interval. Consider this example:
* `orientation2[0] == eps`
* `orientation1[0] == pi`
* `b_(2) == pi - eps`
where `eps` is a very small angle.

* With previous implementation we get: `2 * eps - 2 * pi`
* With the change proposed here we get: `2 * eps`

I guess in practice the `delta` would always be close to the observed `b_` value, but I believe this could still happen.