### PR TITLE
[RST-2784] Only allow exact timestamp transformations

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -193,34 +193,16 @@ template <typename T>
 bool transformMessage(const tf2_ros::Buffer& tf_buffer, const T& input, T& output)
 {
   geometry_msgs::TransformStamped trans;
-
-  bool have_transform = false;
-
   if (tf_buffer.canTransform(output.header.frame_id, input.header.frame_id, input.header.stamp))
   {
     try
     {
       trans = tf_buffer.lookupTransform(output.header.frame_id, input.header.frame_id, input.header.stamp);
-      have_transform = true;
     }
     catch (const tf2::TransformException& ex)
     {
       ROS_WARN_STREAM_THROTTLE(5.0, "Could not transform message from " << input.header.frame_id << " to " <<
-        output.header.frame_id << ". Error was " << ex.what() << " Will attempt to use latest transform instead.");
-    }
-  }
-
-  if (!have_transform)
-  {
-    try
-    {
-      trans = tf_buffer.lookupTransform(output.header.frame_id, input.header.frame_id, ros::Time(0));
-    }
-    catch (const tf2::TransformException& ex)
-    {
-      ROS_ERROR_STREAM_THROTTLE(5.0, "Could not transform message from " << input.header.frame_id << " to " <<
         output.header.frame_id << ". Error was " << ex.what());
-
       return false;
     }
   }


### PR DESCRIPTION
Only allow exact timestamp transformations. Using the latest transform mixes information across time, making it ambiguous what time should apply to the resulting constraint.