### PR TITLE
Validate partial measurements

### DIFF
--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -36,6 +36,9 @@
 
 #include <Eigen/Core>
 
+#include <sstream>
+#include <string>
+
 
 namespace fuse_core
 {
@@ -65,6 +68,16 @@ using Matrix9d = Eigen::Matrix<double, 9, 9, Eigen::RowMajor>;
 
 template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
 using Matrix = Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Eigen::RowMajor>;
+
+template <typename Derived>
+std::string to_string(const Eigen::DenseBase<Derived>& m)
+{
+  static const Eigen::IOFormat pretty(4, 0, ", ", "\n", "[", "]");
+
+  std::ostringstream oss;
+  oss << m.format(pretty) << '\n';
+  return oss.str();
+}
 
 }  // namespace fuse_core
 


### PR DESCRIPTION
This runs the following validation check for all partial measurements:

1. All `mean` values must be **finite**
2. The `covariance` must be **symmetric**
3. The `covariance` must be **positive-definite**

If any of the validation checks fail, and `std::runtime_error` exception is thrown.

In this implementation the exception is NOT caught, but it should be trivial to catch and do something like `ROS_WARN_STREAM("<message>: " << ex.what());` and correct the values/covariance, it that sounds like a better approach.