### PR TITLE
Don't read pose_target_frame if differential

### DIFF
--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -75,7 +75,10 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("queue_size", queue_size);
       getParamRequired(nh, "topic", topic);
-      getParamRequired(nh, "pose_target_frame", pose_target_frame);
+      if (!differential)
+      {
+        getParamRequired(nh, "pose_target_frame", pose_target_frame);
+      }
       getParamRequired(nh, "twist_target_frame", twist_target_frame);
     }
 


### PR DESCRIPTION
If `differential` is `true`, the `pose_target_frame` is not used.