### PR TITLE
Explicitly call boost::range::join

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -145,7 +145,7 @@ inline std::vector<size_t> mergeIndices(
   const std::vector<size_t>& rhs_indices,
   const size_t rhs_offset = 0u)
 {
-  auto merged_indices = boost::copy_range<std::vector<size_t>>(boost::join(lhs_indices, rhs_indices));
+  auto merged_indices = boost::copy_range<std::vector<size_t>>(boost::range::join(lhs_indices, rhs_indices));
 
   const auto rhs_it = merged_indices.begin() + lhs_indices.size();
   std::transform(


### PR DESCRIPTION
Otherwise we could get a compilation error due to an ambiguous
overloaded `join` function if some `boost/algorithm` headers are
included and somehow leak into `sensor_proc.h`.

The compilation error we'd get is like this:

```bash
In file included from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/src/odometry_2d_publisher.cpp:36:0:
/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/common/sensor_proc.h: In function ‘std::vector<long unsigned int> fuse_models::common::mergeIndices(const std::vector<long unsigned int>&, const std::vector<long unsigned int>&, size_t)’:
/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/common/sensor_proc.h:148:154: error: call of overloaded ‘join(const std::vector<long unsigned int>&, const std::vector<long unsigned int>&)’ is ambiguous
   auto merged_indices = boost::copy_range<std::vector<size_t>>(boost::join<const std::vector<size_t>, const std::vector<size_t>>(lhs_indices, rhs_indices));
                                                                                                                                                          ^
In file included from /usr/include/boost/algorithm/string.hpp:24:0,
                 from /home/efernandez/dev/ws/cpr_ws/src/pluginlib/include/pluginlib/./class_loader.hpp:37,
                 from /home/efernandez/dev/ws/cpr_ws/src/pluginlib/include/pluginlib/class_loader.h:35,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_core/include/fuse_core/loss_loader.h:38,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/parameters/parameter_base.h:37,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h:37,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/odometry_2d_publisher.h:37,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/src/odometry_2d_publisher.cpp:34:
/usr/include/boost/algorithm/string/join.hpp:46:9: note: candidate: typename boost::range_value<T>::type boost::algorithm::join(const SequenceSequenceT&, const Range1T&) [with SequenceSequenceT = const std::vector<long unsigned int>; Range1T = const std::vector<long unsigned int>; typename boost::range_value<T>::type = long unsigned int]
         join(
         ^
In file included from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/common/sensor_proc.h:65:0,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/src/odometry_2d_publisher.cpp:36:
/usr/include/boost/range/join.hpp:76:1: note: candidate: boost::range::joined_range<SinglePassRange1, SinglePassRange2> boost::range::join(SinglePassRange1&, SinglePassRange2&) [with SinglePassRange1 = const std::vector<long unsigned int>; SinglePassRange2 = const std::vector<long unsigned int>]
 join(SinglePassRange1& r1, SinglePassRange2& r2)
 ^
In file included from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/common/sensor_proc.h:65:0,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/src/odometry_2d_publisher.cpp:36:
/usr/include/boost/range/join.hpp:66:1: note: candidate: boost::range::joined_range<const SinglePassRange1, const SinglePassRange2> boost::range::join(const SinglePassRange1&, const SinglePassRange2&) [with SinglePassRange1 = const std::vector<long unsigned int>; SinglePassRange2 = const std::vector<long unsigned int>]
 join(const SinglePassRange1& r1, const SinglePassRange2& r2)
 ^
 ```