### PR TITLE
Publish linear acceleration

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -43,6 +43,7 @@
 #include <fuse_core/variable.h>
 #include <fuse_publishers/stamped_variable_synchronizer.h>
 
+#include <geometry_msgs/AccelWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <ros/ros.h>
 #include <tf2_ros/buffer.h>
@@ -142,7 +143,10 @@ protected:
    * @param[out] orientation_uuid The UUID of the orientation variable that gets extracted from the graph
    * @param[out] velocity_linear_uuid The UUID of the linear velocity variable that gets extracted from the graph
    * @param[out] velocity_angular_uuid The UUID of the angular velocity variable that gets extracted from the graph
-   * @param[out] state All of the fuse variable values get packed into this structure
+   * @param[out] acceleration_linear_uuid The UUID of the linear acceleration variable that gets extracted from the
+   *                                      graph
+   * @param[out] odometry All of the fuse pose and velocity variable values get packed into this structure
+   * @param[out] acceleration All of the fuse acceleration variable values get packed into this structure
    * @return true if the checks pass, false otherwise
    */
   bool getState(
@@ -153,7 +157,9 @@ protected:
     fuse_core::UUID& orientation_uuid,
     fuse_core::UUID& velocity_linear_uuid,
     fuse_core::UUID& velocity_angular_uuid,
-    nav_msgs::Odometry& state);
+    fuse_core::UUID& acceleration_linear_uuid,
+    nav_msgs::Odometry& odometry,
+    geometry_msgs::AccelWithCovarianceStamped& acceleration);
 
   /**
    * @brief Timer callback method for the filtered state publication and tf broadcasting
@@ -179,11 +185,15 @@ protected:
 
   nav_msgs::Odometry odom_output_;
 
+  geometry_msgs::AccelWithCovarianceStamped acceleration_output_;
+
   Synchronizer synchronizer_;  //!< Object that tracks the latest common timestamp of multiple variables
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
 
   ros::Publisher odom_pub_;
+
+  ros::Publisher acceleration_pub_;
 
   tf2_ros::TransformBroadcaster tf_broadcaster_;
 

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -134,7 +134,7 @@ public:
 
   bool publish_tf { true };
   bool predict_to_current_time { false };
-  bool predict_with_acceleration { true };
+  bool predict_with_acceleration { false };
   double publish_frequency { 10.0 };
   fuse_core::Matrix8d process_noise_covariance;   //!< Process noise covariance matrix
   ros::Duration tf_cache_time { 10.0 };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -73,6 +73,7 @@ public:
   {
     nh.getParam("publish_tf", publish_tf);
     nh.getParam("predict_to_current_time", predict_to_current_time);
+    nh.getParam("predict_with_acceleration", predict_with_acceleration);
     nh.getParam("publish_frequency", publish_frequency);
 
     std::vector<double> process_noise_diagonal(8, 0.0);
@@ -126,12 +127,14 @@ public:
     }
 
     nh.getParam("topic", topic);
+    nh.getParam("acceleration_topic", acceleration_topic);
 
     fuse_core::loadCovarianceOptionsFromROS(ros::NodeHandle(nh, "covariance_options"), covariance_options);
   }
 
   bool publish_tf { true };
   bool predict_to_current_time { false };
+  bool predict_with_acceleration { true };
   double publish_frequency { 10.0 };
   fuse_core::Matrix8d process_noise_covariance;   //!< Process noise covariance matrix
   ros::Duration tf_cache_time { 10.0 };
@@ -143,6 +146,7 @@ public:
   std::string base_link_output_frame_id { base_link_frame_id };
   std::string world_frame_id { odom_frame_id };
   std::string topic { "odometry/filtered" };
+  std::string acceleration_topic { "acceleration/filtered" };
   ceres::Covariance::Options covariance_options;
 };
 

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -38,6 +38,7 @@
 #include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 
+#include <geometry_msgs/AccelWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <pluginlib/class_list_macros.h>
 #include <tf2_2d/tf2_2d.h>
@@ -78,6 +79,8 @@ void Odometry2DPublisher::onInit()
   }
 
   odom_pub_ = node_handle_.advertise<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size);
+  acceleration_pub_ = node_handle_.advertise<geometry_msgs::AccelWithCovarianceStamped>(
+      ros::names::resolve(params_.acceleration_topic), params_.queue_size);
 
   publish_timer_ = node_handle_.createTimer(
     ros::Duration(1.0 / params_.publish_frequency),
@@ -105,6 +108,7 @@ void Odometry2DPublisher::notifyCallback(
   fuse_core::UUID orientation_uuid;
   fuse_core::UUID velocity_linear_uuid;
   fuse_core::UUID velocity_angular_uuid;
+  fuse_core::UUID acceleration_linear_uuid;
 
   if (!getState(
          *graph,
@@ -114,7 +118,9 @@ void Odometry2DPublisher::notifyCallback(
          orientation_uuid,
          velocity_linear_uuid,
          velocity_angular_uuid,
-         odom_output_))
+         acceleration_linear_uuid,
+         odom_output_,
+         acceleration_output_))
   {
     return;
   }
@@ -123,8 +129,11 @@ void Odometry2DPublisher::notifyCallback(
   odom_output_.header.stamp = latest_stamp_;
   odom_output_.child_frame_id = params_.base_link_output_frame_id;
 
+  acceleration_output_.header.frame_id = params_.base_link_output_frame_id;
+  acceleration_output_.header.stamp = latest_stamp_;
+
   // Don't waste CPU computing the covariance if nobody is listening
-  if (odom_pub_.getNumSubscribers() > 0)
+  if (odom_pub_.getNumSubscribers() > 0 || acceleration_pub_.getNumSubscribers() > 0)
   {
     try
     {
@@ -135,6 +144,7 @@ void Odometry2DPublisher::notifyCallback(
       covariance_requests.emplace_back(velocity_linear_uuid, velocity_linear_uuid);
       covariance_requests.emplace_back(velocity_linear_uuid, velocity_angular_uuid);
       covariance_requests.emplace_back(velocity_angular_uuid, velocity_angular_uuid);
+      covariance_requests.emplace_back(acceleration_linear_uuid, acceleration_linear_uuid);
 
       std::vector<std::vector<double>> covariance_matrices;
       graph->getCovariance(covariance_requests, covariance_matrices, params_.covariance_options);
@@ -159,6 +169,11 @@ void Odometry2DPublisher::notifyCallback(
       odom_output_.twist.covariance[31] = covariance_matrices[4][1];
       odom_output_.twist.covariance[35] = covariance_matrices[5][0];
 
+      acceleration_output_.accel.covariance[0] = covariance_matrices[6][0];
+      acceleration_output_.accel.covariance[1] = covariance_matrices[6][1];
+      acceleration_output_.accel.covariance[6] = covariance_matrices[6][2];
+      acceleration_output_.accel.covariance[7] = covariance_matrices[6][3];
+
       latest_covariance_stamp_ = latest_stamp_;
     }
     catch (const std::exception& e)
@@ -167,6 +182,7 @@ void Odometry2DPublisher::notifyCallback(
                       "The covariance will be set to zero.\n" << e.what());
       std::fill(odom_output_.pose.covariance.begin(), odom_output_.pose.covariance.end(), 0.0);
       std::fill(odom_output_.twist.covariance.begin(), odom_output_.twist.covariance.end(), 0.0);
+      std::fill(acceleration_output_.accel.covariance.begin(), acceleration_output_.accel.covariance.end(), 0.0);
     }
   }
 }
@@ -176,6 +192,7 @@ void Odometry2DPublisher::onStart()
   synchronizer_ = Synchronizer(device_id_);
   latest_stamp_ = latest_covariance_stamp_ = Synchronizer::TIME_ZERO;
   odom_output_ = nav_msgs::Odometry();
+  acceleration_output_ = geometry_msgs::AccelWithCovarianceStamped();
   publish_timer_.start();
 }
 
@@ -192,7 +209,9 @@ bool Odometry2DPublisher::getState(
   fuse_core::UUID& orientation_uuid,
   fuse_core::UUID& velocity_linear_uuid,
   fuse_core::UUID& velocity_angular_uuid,
-  nav_msgs::Odometry& state)
+  fuse_core::UUID& acceleration_linear_uuid,
+  nav_msgs::Odometry& odometry,
+  geometry_msgs::AccelWithCovarianceStamped& acceleration)
 {
   try
   {
@@ -212,16 +231,27 @@ bool Odometry2DPublisher::getState(
     auto velocity_angular_variable = dynamic_cast<const fuse_variables::VelocityAngular2DStamped&>(
       graph.getVariable(velocity_angular_uuid));
 
-    state.pose.pose.position.x = position_variable.x();
-    state.pose.pose.position.y = position_variable.y();
-    state.pose.pose.position.z = 0.0;
-    state.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.yaw()));
-    state.twist.twist.linear.x = velocity_linear_variable.x();
-    state.twist.twist.linear.y = velocity_linear_variable.y();
-    state.twist.twist.linear.z = 0.0;
-    state.twist.twist.angular.x = 0.0;
-    state.twist.twist.angular.y = 0.0;
-    state.twist.twist.angular.z = velocity_angular_variable.yaw();
+    acceleration_linear_uuid = fuse_variables::AccelerationLinear2DStamped(stamp, device_id).uuid();
+    auto acceleration_linear_variable = dynamic_cast<const fuse_variables::AccelerationLinear2DStamped&>(
+      graph.getVariable(acceleration_linear_uuid));
+
+    odometry.pose.pose.position.x = position_variable.x();
+    odometry.pose.pose.position.y = position_variable.y();
+    odometry.pose.pose.position.z = 0.0;
+    odometry.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.yaw()));
+    odometry.twist.twist.linear.x = velocity_linear_variable.x();
+    odometry.twist.twist.linear.y = velocity_linear_variable.y();
+    odometry.twist.twist.linear.z = 0.0;
+    odometry.twist.twist.angular.x = 0.0;
+    odometry.twist.twist.angular.y = 0.0;
+    odometry.twist.twist.angular.z = velocity_angular_variable.yaw();
+
+    acceleration.accel.accel.linear.x = acceleration_linear_variable.x();
+    acceleration.accel.accel.linear.y = acceleration_linear_variable.y();
+    acceleration.accel.accel.linear.z = 0.0;
+    acceleration.accel.accel.angular.x = 0.0;
+    acceleration.accel.accel.angular.y = 0.0;
+    acceleration.accel.accel.angular.z = 0.0;
   }
   catch (const std::exception& e)
   {
@@ -258,21 +288,24 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 
     fuse_core::Matrix8d jacobian;
 
-    tf2_2d::Vector2 unused_acc;
+    tf2_2d::Vector2 acceleration_linear;
+    if (params_.predict_with_acceleration)
+    {
+      tf2::fromMsg(acceleration_output_.accel.accel.linear, acceleration_linear);
+    }
+
     double yaw_vel;
 
     predict(
       pose,
       velocity_linear,
       odom_output_.twist.twist.angular.z,
-      // TODO(efernandez) we should use the actual acceleration, both here and in the else, even if we don't care of
-      // the resulting acceleration, because it also affects other components
-      unused_acc,
+      acceleration_linear,
       dt,
       pose,
       velocity_linear,
       yaw_vel,
-      unused_acc,
+      acceleration_linear,
       jacobian);
 
     odom_output_.pose.pose.position.x = pose.getX();
@@ -283,13 +316,20 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
     odom_output_.twist.twist.linear.y = velocity_linear.y();
     odom_output_.twist.twist.angular.z = yaw_vel;
 
+    if (params_.predict_with_acceleration)
+    {
+      acceleration_output_.accel.accel.linear.x = acceleration_linear.x();
+      acceleration_output_.accel.accel.linear.y = acceleration_linear.y();
+    }
+
     odom_output_.header.stamp = event.current_real;
+    acceleration_output_.header.stamp = event.current_real;
 
     // Either the last covariance computation was skipped because there was no subscriber,
     // or it failed
     if (latest_covariance_stamp_ == latest_stamp_)
     {
-      Eigen::Matrix<double, 6, 6> covariance;
+      fuse_core::Matrix8d covariance;
       covariance(0, 0) = odom_output_.pose.covariance[0];
       covariance(0, 1) = odom_output_.pose.covariance[1];
       covariance(0, 2) = odom_output_.pose.covariance[5];
@@ -310,14 +350,21 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
       covariance(5, 4) = odom_output_.twist.covariance[31];
       covariance(5, 5) = odom_output_.twist.covariance[35];
 
-      // TODO(efernandez) for now we set the top right and bottom left corners to zero, but we could cache them in
-      // another attribute when we retrieve the covariance from the ceres problem
-      covariance.topRightCorner<3, 3>().setZero();
-      covariance.bottomLeftCorner<3, 3>().setZero();
+      covariance(6, 6) = acceleration_output_.accel.covariance[0];
+      covariance(6, 7) = acceleration_output_.accel.covariance[1];
+      covariance(7, 6) = acceleration_output_.accel.covariance[6];
+      covariance(7, 7) = acceleration_output_.accel.covariance[7];
 
-      const Eigen::Matrix<double, 6, 6> J = jacobian.topLeftCorner<6, 6>();
-      covariance = J * covariance * J.transpose();
-      covariance.noalias() += dt * params_.process_noise_covariance.topLeftCorner<6, 6>();
+      // TODO(efernandez) for now we set to zero the out-of-diagonal blocks with the correlations between pose, twist
+      // and acceleration, but we could cache them in another attribute when we retrieve the covariance from the ceres
+      // problem
+      covariance.topRightCorner<3, 5>().setZero();
+      covariance.bottomLeftCorner<5, 3>().setZero();
+      covariance.block<3, 2>(3, 6).setZero();
+      covariance.block<2, 3>(6, 3).setZero();
+
+      covariance = jacobian * covariance * jacobian.transpose();
+      covariance.noalias() += dt * params_.process_noise_covariance;
 
       odom_output_.pose.covariance[0] = covariance(0, 0);
       odom_output_.pose.covariance[1] = covariance(0, 1);
@@ -338,10 +385,16 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
       odom_output_.twist.covariance[30] = covariance(5, 3);
       odom_output_.twist.covariance[31] = covariance(5, 4);
       odom_output_.twist.covariance[35] = covariance(5, 5);
+
+      acceleration_output_.accel.covariance[0] = covariance(6, 6);
+      acceleration_output_.accel.covariance[1] = covariance(6, 7);
+      acceleration_output_.accel.covariance[6] = covariance(7, 6);
+      acceleration_output_.accel.covariance[7] = covariance(7, 7);
     }
   }
 
   odom_pub_.publish(odom_output_);
+  acceleration_pub_.publish(acceleration_output_);
 
   if (params_.publish_tf)
   {


### PR DESCRIPTION
This publishes the linear accelerations and uses them while predicting to the current time if the
new param `predict_with_acceleration` is `true` (default value).

Example output and forward / backwards manual command send to the robot:
![acceleration_Screenshot from 2020-01-13 16-07-52](https://user-images.githubusercontent.com/382167/72272101-5fad3500-3628-11ea-8473-b9b273126503.png)
