### PR TITLE
Better validate partial measurement output

### DIFF
--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -70,9 +70,9 @@ template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
 using Matrix = Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Eigen::RowMajor>;
 
 template <typename Derived>
-std::string to_string(const Eigen::DenseBase<Derived>& m)
+std::string to_string(const Eigen::DenseBase<Derived>& m, const int precision = 4)
 {
-  static const Eigen::IOFormat pretty(4, 0, ", ", "\n", "[", "]");
+  static const Eigen::IOFormat pretty(precision, 0, ", ", "\n", "[", "]");
 
   std::ostringstream oss;
   oss << m.format(pretty) << '\n';

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -189,19 +189,22 @@ inline void populatePartialMeasurement(
  *
  * @param[in] mean_partial - The partial measurement mean we want to validate
  * @param[in] covariance_partial - The partial measurement covariance we want to validate
+ * @param[in] precision - The precision to validate the partial measurements covariance is symmetric
  */
 inline void validatePartialMeasurement(
   const fuse_core::VectorXd& mean_partial,
-  const fuse_core::MatrixXd& covariance_partial)
+  const fuse_core::MatrixXd& covariance_partial,
+  const double precision = Eigen::NumTraits<double>::dummy_precision())
 {
   if (!mean_partial.allFinite())
   {
     throw std::runtime_error("Invalid partial mean " + fuse_core::to_string(mean_partial));
   }
 
-  if (!covariance_partial.isApprox(covariance_partial.transpose()))
+  if (!covariance_partial.isApprox(covariance_partial.transpose(), precision))
   {
-    throw std::runtime_error("Non-symmetric partial covariance matrix " + fuse_core::to_string(covariance_partial));
+    throw std::runtime_error("Non-symmetric partial covariance matrix " +
+                             fuse_core::to_string(covariance_partial, Eigen::FullPrecision));
   }
 
   Eigen::SelfAdjointEigenSolver<fuse_core::MatrixXd> solver(covariance_partial);

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -211,7 +211,8 @@ inline void validatePartialMeasurement(
   if (solver.eigenvalues().minCoeff() <= 0.0)
   {
     throw std::runtime_error("Non-positive-definite partial covariance matrix\n" +
-                             fuse_core::to_string(covariance_partial));
+                             fuse_core::to_string(covariance_partial, Eigen::FullPrecision) + "\n with eigenvalues\n" +
+                             fuse_core::to_string(solver.eigenvalues(), Eigen::FullPrecision));
   }
 }
 

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -65,6 +65,7 @@ struct Acceleration2DParams : public ParameterBase
     {
       indices = loadSensorConfig<fuse_variables::AccelerationLinear2DStamped>(nh, "dimensions");
 
+      nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       getParamRequired(nh, "topic", topic);
       getParamRequired(nh, "target_frame", target_frame);
@@ -72,6 +73,7 @@ struct Acceleration2DParams : public ParameterBase
       loss = loadLossConfig(nh, "loss");
     }
 
+    bool disable_checks { false };
     int queue_size { 10 };
     std::string topic {};
     std::string target_frame {};

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -72,6 +72,7 @@ struct Imu2DParams : public ParameterBase
       orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(nh, "orientation_dimensions");
 
       nh.getParam("differential", differential);
+      nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);
@@ -98,6 +99,7 @@ struct Imu2DParams : public ParameterBase
     }
 
     bool differential { false };
+    bool disable_checks { false };
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
     double gravitational_acceleration { 9.80665 };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -74,6 +74,7 @@ struct Odometry2DParams : public ParameterBase
         loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(nh, "angular_velocity_dimensions");
 
       nh.getParam("differential", differential);
+      nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       getParamRequired(nh, "topic", topic);
       if (!differential)
@@ -88,6 +89,7 @@ struct Odometry2DParams : public ParameterBase
     }
 
     bool differential { false };
+    bool disable_checks { false };
     int queue_size { 10 };
     std::string topic {};
     std::string pose_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -68,6 +68,7 @@ struct Pose2DParams : public ParameterBase
       orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(nh, "orientation_dimensions");
 
       nh.getParam("differential", differential);
+      nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       getParamRequired(nh, "topic", topic);
       getParamRequired(nh, "target_frame", target_frame);
@@ -76,6 +77,7 @@ struct Pose2DParams : public ParameterBase
     }
 
     bool differential { false };
+    bool disable_checks { false };
     int queue_size { 10 };
     std::string topic {};
     std::string target_frame {};

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -67,6 +67,7 @@ struct Twist2DParams : public ParameterBase
       linear_indices = loadSensorConfig<fuse_variables::VelocityLinear2DStamped>(nh, "linear_dimensions");
       angular_indices = loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(nh, "angular_dimensions");
 
+      nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       getParamRequired(nh, "topic", topic);
       getParamRequired(nh, "target_frame", target_frame);
@@ -75,6 +76,7 @@ struct Twist2DParams : public ParameterBase
       angular_loss = loadLossConfig(nh, "angular_loss");
     }
 
+    bool disable_checks { false };
     int queue_size { 10 };
     std::string topic {};
     std::string target_frame {};

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -97,6 +97,7 @@ void Acceleration2D::process(const geometry_msgs::AccelWithCovarianceStamped::Co
     params_.target_frame,
     params_.indices,
     tf_buffer_,
+    !params_.disable_checks,
     *transaction);
 
   // Send the transaction object to the plugin's parent

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -112,6 +112,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
   pose->pose.covariance[34] = msg->orientation_covariance[7];
   pose->pose.covariance[35] = msg->orientation_covariance[8];
 
+  const bool validate = !params_.disable_checks;
+
   if (params_.differential)
   {
     if (previous_pose_)
@@ -124,6 +126,7 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
         params_.pose_loss,
         {},
         params_.orientation_indices,
+        validate,
         *transaction);
     }
 
@@ -140,6 +143,7 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
       {},
       params_.orientation_indices,
       tf_buffer_,
+      validate,
       *transaction);
   }
 
@@ -167,6 +171,7 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
     {},
     params_.angular_velocity_indices,
     tf_buffer_,
+    validate,
     *transaction);
 
   // Handle the acceleration data
@@ -206,6 +211,7 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
     params_.acceleration_target_frame,
     params_.linear_acceleration_indices,
     tf_buffer_,
+    validate,
     *transaction);
 
   // Send the transaction object to the plugin's parent

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -103,6 +103,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
   pose->header = msg->header;
   pose->pose = msg->pose;
 
+  const bool validate = !params_.disable_checks;
+
   if (params_.differential)
   {
     if (previous_pose_)
@@ -115,6 +117,7 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
         params_.pose_loss,
         params_.position_indices,
         params_.orientation_indices,
+        validate,
         *transaction);
     }
 
@@ -131,6 +134,7 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
       params_.position_indices,
       params_.orientation_indices,
       tf_buffer_,
+      validate,
       *transaction);
   }
 
@@ -150,6 +154,7 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
     params_.linear_velocity_indices,
     params_.angular_velocity_indices,
     tf_buffer_,
+    validate,
     *transaction);
 
   // Send the transaction object to the plugin's parent

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -91,6 +91,8 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
   auto transaction = fuse_core::Transaction::make_shared();
   transaction->stamp(msg->header.stamp);
 
+  const bool validate = !params_.disable_checks;
+
   if (params_.differential)
   {
     if (previous_pose_msg_)
@@ -103,6 +105,7 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
         params_.loss,
         params_.position_indices,
         params_.orientation_indices,
+        validate,
         *transaction);
     }
 
@@ -119,6 +122,7 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
       params_.position_indices,
       params_.orientation_indices,
       tf_buffer_,
+      validate,
       *transaction);
   }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -101,6 +101,7 @@ void Twist2D::process(const geometry_msgs::TwistWithCovarianceStamped::ConstPtr&
     params_.linear_indices,
     params_.angular_indices,
     tf_buffer_,
+    !params_.disable_checks,
     *transaction);
 
   // Send the transaction object to the plugin's parent


### PR DESCRIPTION
* Show source if validation fails
  * Also changes from throwing/crashing to `ROS_ERROR`.

* Add precision arg for covariance validation. This allows to:
    * Relax the default precision when validating the covariance matrix is
      symmetric.
    * Print the covariance matrix with `Eigen::FullPrecision` when the
      symmetry test fails with `isApprox`, so we can see the magnitude of
      the error.