### PR TITLE
Support printing VariableConstraints objects

### DIFF
--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <initializer_list>
 #include <iterator>
+#include <iostream>
 #include <unordered_set>
 #include <vector>
 
@@ -100,6 +101,13 @@ public:
   template <typename OutputIterator>
   void getConstraints(const unsigned int variable_id, OutputIterator result) const;
 
+  /**
+   * @brief Print a human-readable description of the variable constraints to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  void print(std::ostream& stream = std::cout) const;
+
 private:
   using ConstraintCollection = std::unordered_set<unsigned int>;
   using ConstraintsByVariable = std::vector<ConstraintCollection>;
@@ -122,6 +130,11 @@ void VariableConstraints::getConstraints(const unsigned int variable_id, OutputI
   const auto& constraints = variable_constraints_[variable_id];
   std::copy(std::begin(constraints), std::end(constraints), result);
 }
+
+/**
+ * Stream operator for printing VariableConstraints objects.
+ */
+std::ostream& operator <<(std::ostream& stream, const VariableConstraints& variable_constraints);
 
 }  // namespace fuse_constraints
 

--- a/fuse_constraints/src/variable_constraints.cpp
+++ b/fuse_constraints/src/variable_constraints.cpp
@@ -78,4 +78,25 @@ void VariableConstraints::insert(const unsigned int constraint, std::initializer
   return insert(constraint, variable_list.begin(), variable_list.end());
 }
 
+void VariableConstraints::print(std::ostream& stream) const
+{
+  for (size_t variable = 0; variable < variable_constraints_.size(); ++variable)
+  {
+    stream << variable << ": [";
+
+    for (const auto& constraint : variable_constraints_[variable])
+    {
+      stream << constraint << ", ";
+    }
+
+    stream << "]\n";
+  }
+}
+
+std::ostream& operator <<(std::ostream& stream, const VariableConstraints& variable_constraints)
+{
+  variable_constraints.print(stream);
+  return stream;
+}
+
 }  // namespace fuse_constraints


### PR DESCRIPTION
This simply provides support for printing `VariableConstraints` objects, which could be useful if you're debugging code using objects of that class, e.g. https://github.com/locusrobotics/fuse/pull/134