### PR TITLE
Test getConstraints with lvalue iterator

### DIFF
--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -101,6 +101,23 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(expected1, actual1);
   EXPECT_EQ(expected2, actual2);
   EXPECT_EQ(expected3, actual3);
+
+  auto actual0_iter = actual0.begin();
+  vars.getConstraints(0u, actual0_iter);
+
+  auto actual1_iter = actual1.begin();
+  vars.getConstraints(1u, actual1_iter);
+
+  auto actual2_iter = actual2.begin();
+  vars.getConstraints(2u, actual2_iter);
+
+  auto actual3_iter = actual3.begin();
+  vars.getConstraints(3u, actual3_iter);
+
+  EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
+  EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));
+  EXPECT_EQ(expected2.size(), std::distance(actual2.begin(), actual2_iter));
+  EXPECT_EQ(expected3.size(), std::distance(actual3.begin(), actual3_iter));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This fails to change the `iterator` from the caller frame, since
all changes happen in the local copy of the iterator into the
`getConstraints` method.

This PR is only to demonstrate `getConstraints` is broken for this use case, which is the one exercised in https://github.com/locusrobotics/fuse/blob/900680df67f9622279ad9f8ac0d588e6294411b4/fuse_constraints/src/marginalize_variables.cpp#L100-L109, where `*p_iter` is always `0` because of this.

It looks like that code has never produced the correct values for the `p` array.