### PR TITLE
Fix get constraints with lvalue iterator input

### DIFF
--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -98,7 +98,7 @@ public:
    * Accessing a variable id that is not part of this container results in undefined behavior
    */
   template <typename OutputIterator>
-  void getConstraints(const unsigned int variable_id, OutputIterator&& result) const;
+  OutputIterator getConstraints(const unsigned int variable_id, OutputIterator result) const;
 
 private:
   using ConstraintCollection = std::unordered_set<unsigned int>;
@@ -117,10 +117,10 @@ void VariableConstraints::insert(const unsigned int constraint, VariableIndexIte
 }
 
 template<class OutputIterator>
-void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator&& result) const
+OutputIterator VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
 {
   const auto& constraints = variable_constraints_[variable_id];
-  result = std::copy(std::begin(constraints), std::end(constraints), result);
+  return std::copy(std::begin(constraints), std::end(constraints), result);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -98,7 +98,7 @@ public:
    * Accessing a variable id that is not part of this container results in undefined behavior
    */
   template <typename OutputIterator>
-  void getConstraints(const unsigned int variable_id, OutputIterator result) const;
+  void getConstraints(const unsigned int variable_id, OutputIterator&& result) const;
 
 private:
   using ConstraintCollection = std::unordered_set<unsigned int>;
@@ -117,10 +117,10 @@ void VariableConstraints::insert(const unsigned int constraint, VariableIndexIte
 }
 
 template<class OutputIterator>
-void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
+void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator&& result) const
 {
   const auto& constraints = variable_constraints_[variable_id];
-  std::copy(std::begin(constraints), std::end(constraints), result);
+  result = std::copy(std::begin(constraints), std::end(constraints), result);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -103,7 +103,7 @@ UuidOrdering computeEliminationOrder(
   ++p_iter;
   for (unsigned int variable_index = 0u; variable_index < variable_order.size(); ++variable_index)
   {
-    variable_constraints.getConstraints(variable_index, A_iter);
+    A_iter = variable_constraints.getConstraints(variable_index, A_iter);
     *p_iter = std::distance(A.begin(), A_iter);
     ++p_iter;
   }

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -175,8 +175,8 @@ TEST(MarginalizeVariables, ComputeEliminationOrder)
   auto expected = fuse_constraints::UuidOrdering();
   expected.push_back(x1->uuid());
   expected.push_back(x2->uuid());
-  expected.push_back(x3->uuid());
   expected.push_back(l1->uuid());
+  expected.push_back(x3->uuid());
 
   // Check
   ASSERT_EQ(expected.size(), actual.size());

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -182,7 +182,8 @@ TEST(MarginalizeVariables, ComputeEliminationOrder)
   ASSERT_EQ(expected.size(), actual.size());
   for (size_t i = 0; i < expected.size(); ++i)
   {
-    EXPECT_EQ(expected.at(i), actual.at(i));
+    SCOPED_TRACE(i);
+    EXPECT_EQ(fuse_core::uuid::to_string(expected.at(i)), fuse_core::uuid::to_string(actual.at(i)));
   }
 }
 

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -101,6 +101,23 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(expected1, actual1);
   EXPECT_EQ(expected2, actual2);
   EXPECT_EQ(expected3, actual3);
+
+  auto actual0_iter = actual0.begin();
+  vars.getConstraints(0u, actual0_iter);
+
+  auto actual1_iter = actual1.begin();
+  vars.getConstraints(1u, actual1_iter);
+
+  auto actual2_iter = actual2.begin();
+  vars.getConstraints(2u, actual2_iter);
+
+  auto actual3_iter = actual3.begin();
+  vars.getConstraints(3u, actual3_iter);
+
+  EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
+  EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));
+  EXPECT_EQ(expected2.size(), std::distance(actual2.begin(), actual2_iter));
+  EXPECT_EQ(expected3.size(), std::distance(actual3.begin(), actual3_iter));
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -114,10 +114,10 @@ TEST(VariableConstraints, GetConstraints)
   auto actual3_iter = actual3.begin();
   actual3_iter = vars.getConstraints(3u, actual3_iter);
 
-  EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
-  EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));
-  EXPECT_EQ(expected2.size(), std::distance(actual2.begin(), actual2_iter));
-  EXPECT_EQ(expected3.size(), std::distance(actual3.begin(), actual3_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected0.size()), std::distance(actual0.begin(), actual0_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected1.size()), std::distance(actual1.begin(), actual1_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected2.size()), std::distance(actual2.begin(), actual2_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected3.size()), std::distance(actual3.begin(), actual3_iter));
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -103,16 +103,16 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(expected3, actual3);
 
   auto actual0_iter = actual0.begin();
-  vars.getConstraints(0u, actual0_iter);
+  actual0_iter = vars.getConstraints(0u, actual0_iter);
 
   auto actual1_iter = actual1.begin();
-  vars.getConstraints(1u, actual1_iter);
+  actual1_iter = vars.getConstraints(1u, actual1_iter);
 
   auto actual2_iter = actual2.begin();
-  vars.getConstraints(2u, actual2_iter);
+  actual2_iter = vars.getConstraints(2u, actual2_iter);
 
   auto actual3_iter = actual3.begin();
-  vars.getConstraints(3u, actual3_iter);
+  actual3_iter = vars.getConstraints(3u, actual3_iter);
 
   EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
   EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));


### PR DESCRIPTION
This PR is on top of https://github.com/locusrobotics/fuse/pull/133, that extends the unit test for `getConstraints` to show a bug in the code that it's fixed here. See https://github.com/locusrobotics/fuse/pull/133 for more details.