### PR TITLE
Test compute elimination order with orphan variables

### DIFF
--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -98,7 +98,7 @@ public:
    * Accessing a variable id that is not part of this container results in undefined behavior
    */
   template <typename OutputIterator>
-  void getConstraints(const unsigned int variable_id, OutputIterator&& result) const;
+  OutputIterator getConstraints(const unsigned int variable_id, OutputIterator result) const;
 
 private:
   using ConstraintCollection = std::unordered_set<unsigned int>;
@@ -117,10 +117,10 @@ void VariableConstraints::insert(const unsigned int constraint, VariableIndexIte
 }
 
 template<class OutputIterator>
-void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator&& result) const
+OutputIterator VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
 {
   const auto& constraints = variable_constraints_[variable_id];
-  result = std::copy(std::begin(constraints), std::end(constraints), result);
+  return std::copy(std::begin(constraints), std::end(constraints), result);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -98,7 +98,7 @@ public:
    * Accessing a variable id that is not part of this container results in undefined behavior
    */
   template <typename OutputIterator>
-  void getConstraints(const unsigned int variable_id, OutputIterator result) const;
+  void getConstraints(const unsigned int variable_id, OutputIterator&& result) const;
 
 private:
   using ConstraintCollection = std::unordered_set<unsigned int>;
@@ -117,10 +117,10 @@ void VariableConstraints::insert(const unsigned int constraint, VariableIndexIte
 }
 
 template<class OutputIterator>
-void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator result) const
+void VariableConstraints::getConstraints(const unsigned int variable_id, OutputIterator&& result) const
 {
   const auto& constraints = variable_constraints_[variable_id];
-  std::copy(std::begin(constraints), std::end(constraints), result);
+  result = std::copy(std::begin(constraints), std::end(constraints), result);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -103,7 +103,7 @@ UuidOrdering computeEliminationOrder(
   ++p_iter;
   for (unsigned int variable_index = 0u; variable_index < variable_order.size(); ++variable_index)
   {
-    variable_constraints.getConstraints(variable_index, A_iter);
+    A_iter = variable_constraints.getConstraints(variable_index, A_iter);
     *p_iter = std::distance(A.begin(), A_iter);
     ++p_iter;
   }

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -175,8 +175,8 @@ TEST(MarginalizeVariables, ComputeEliminationOrder)
   auto expected = fuse_constraints::UuidOrdering();
   expected.push_back(x1->uuid());
   expected.push_back(x2->uuid());
-  expected.push_back(x3->uuid());
   expected.push_back(l1->uuid());
+  expected.push_back(x3->uuid());
 
   // Check
   ASSERT_EQ(expected.size(), actual.size());

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -69,6 +69,11 @@ public:
     data_{}
   {}
 
+  GenericVariable(const fuse_core::UUID& uuid) :
+    fuse_core::Variable(uuid),
+    data_{}
+  {}
+
   size_t size() const override { return 1; }
 
   const double* data() const override { return &data_; }
@@ -184,6 +189,76 @@ TEST(MarginalizeVariables, ComputeEliminationOrder)
   {
     SCOPED_TRACE(i);
     EXPECT_EQ(fuse_core::uuid::to_string(expected.at(i)), fuse_core::uuid::to_string(actual.at(i)));
+  }
+}
+
+TEST(MarginalizeVariables, ComputeEliminationOrderWithOrphanVariables)
+{
+  // Create a graph
+  auto x1 = GenericVariable::make_shared();
+  auto x2 = GenericVariable::make_shared();
+  auto x3 = GenericVariable::make_shared();
+  auto l1 = GenericVariable::make_shared();
+  auto l2 = GenericVariable::make_shared();
+  auto c1 = GenericConstraint::make_shared(x1->uuid());
+  auto c2 = GenericConstraint::make_shared(x1->uuid(), x2->uuid());
+  auto c3 = GenericConstraint::make_shared(x2->uuid(), x3->uuid());
+  auto c4 = GenericConstraint::make_shared(x1->uuid(), l1->uuid());
+  auto c5 = GenericConstraint::make_shared(x2->uuid(), l1->uuid());
+  auto c6 = GenericConstraint::make_shared(x3->uuid(), l2->uuid());
+  auto graph = fuse_graphs::HashGraph();
+  graph.addVariable(x1);
+  graph.addVariable(x2);
+  graph.addVariable(x3);
+  graph.addVariable(l1);
+  graph.addVariable(l2);
+  graph.addConstraint(c1);
+  graph.addConstraint(c2);
+  graph.addConstraint(c3);
+  graph.addConstraint(c4);
+  graph.addConstraint(c5);
+  graph.addConstraint(c6);
+
+  // Add orphan variables (with explicit UUID so it's easier to identify them if any of the checks fail)
+  // With 1 or 2 orphan variables computeEliminationOrder throws an std::runtime_error exception because CCOLAMD fails
+  // With 3 or more orphan variables computeEliminationOrder crashes with `free(): invalid next size (fast)`
+  auto o1 = GenericVariable::make_shared(fuse_core::uuid::from_string("b726fbef-4015-4dc8-b4dd-cb57d4439c74"));
+  graph.addVariable(o1);
+
+  // Define the set of variables to be marginalized
+  auto to_be_marginalized = std::vector<fuse_core::UUID>{ x2->uuid(), x1->uuid(), o1->uuid() };
+
+  // Compute the ordering
+  fuse_constraints::UuidOrdering actual;
+  ASSERT_NO_THROW(actual = fuse_constraints::computeEliminationOrder(to_be_marginalized, graph));
+
+  // Define the expected order
+  auto expected = fuse_constraints::UuidOrdering();
+  expected.push_back(x1->uuid());
+  expected.push_back(x2->uuid());
+  expected.push_back(o1->uuid());
+  expected.push_back(l1->uuid());
+  expected.push_back(x3->uuid());
+
+  // Check
+  ASSERT_EQ(expected.size(), actual.size());
+  for (size_t i = 0; i < expected.size(); ++i)
+  {
+    SCOPED_TRACE(i);
+    EXPECT_EQ(fuse_core::uuid::to_string(expected.at(i)), fuse_core::uuid::to_string(actual.at(i)));
+  }
+
+  // Check all marginalized variables are in the elimination order
+  // This check is equivalent to the assert in marginalizeVariables
+  for (const auto& variable_uuid : to_be_marginalized)
+  {
+    SCOPED_TRACE(fuse_core::uuid::to_string(variable_uuid));
+
+    EXPECT_TRUE(actual.exists(variable_uuid));
+    if (actual.exists(variable_uuid))
+    {
+      EXPECT_GT(to_be_marginalized.size(), actual.at(variable_uuid));
+    }
   }
 }
 

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -182,7 +182,8 @@ TEST(MarginalizeVariables, ComputeEliminationOrder)
   ASSERT_EQ(expected.size(), actual.size());
   for (size_t i = 0; i < expected.size(); ++i)
   {
-    EXPECT_EQ(expected.at(i), actual.at(i));
+    SCOPED_TRACE(i);
+    EXPECT_EQ(fuse_core::uuid::to_string(expected.at(i)), fuse_core::uuid::to_string(actual.at(i)));
   }
 }
 

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -101,6 +101,23 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(expected1, actual1);
   EXPECT_EQ(expected2, actual2);
   EXPECT_EQ(expected3, actual3);
+
+  auto actual0_iter = actual0.begin();
+  vars.getConstraints(0u, actual0_iter);
+
+  auto actual1_iter = actual1.begin();
+  vars.getConstraints(1u, actual1_iter);
+
+  auto actual2_iter = actual2.begin();
+  vars.getConstraints(2u, actual2_iter);
+
+  auto actual3_iter = actual3.begin();
+  vars.getConstraints(3u, actual3_iter);
+
+  EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
+  EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));
+  EXPECT_EQ(expected2.size(), std::distance(actual2.begin(), actual2_iter));
+  EXPECT_EQ(expected3.size(), std::distance(actual3.begin(), actual3_iter));
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -114,10 +114,10 @@ TEST(VariableConstraints, GetConstraints)
   auto actual3_iter = actual3.begin();
   actual3_iter = vars.getConstraints(3u, actual3_iter);
 
-  EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
-  EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));
-  EXPECT_EQ(expected2.size(), std::distance(actual2.begin(), actual2_iter));
-  EXPECT_EQ(expected3.size(), std::distance(actual3.begin(), actual3_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected0.size()), std::distance(actual0.begin(), actual0_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected1.size()), std::distance(actual1.begin(), actual1_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected2.size()), std::distance(actual2.begin(), actual2_iter));
+  EXPECT_EQ(static_cast<std::ptrdiff_t>(expected3.size()), std::distance(actual3.begin(), actual3_iter));
 }
 
 int main(int argc, char **argv)

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -103,16 +103,16 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(expected3, actual3);
 
   auto actual0_iter = actual0.begin();
-  vars.getConstraints(0u, actual0_iter);
+  actual0_iter = vars.getConstraints(0u, actual0_iter);
 
   auto actual1_iter = actual1.begin();
-  vars.getConstraints(1u, actual1_iter);
+  actual1_iter = vars.getConstraints(1u, actual1_iter);
 
   auto actual2_iter = actual2.begin();
-  vars.getConstraints(2u, actual2_iter);
+  actual2_iter = vars.getConstraints(2u, actual2_iter);
 
   auto actual3_iter = actual3.begin();
-  vars.getConstraints(3u, actual3_iter);
+  actual3_iter = vars.getConstraints(3u, actual3_iter);
 
   EXPECT_EQ(expected0.size(), std::distance(actual0.begin(), actual0_iter));
   EXPECT_EQ(expected1.size(), std::distance(actual1.begin(), actual1_iter));


### PR DESCRIPTION
This tests `computeEliminationOrder` when there are orphan variables in the graph and in the list of variables to marginalize.

Orphan variables are variables with no constraints.

This test shows that when this happens, CCOLAMD fails. If the number of variables is sufficiently large we even get a crash because we end up accessing this `std::vector` out of range: https://github.com/locusrobotics/fuse/blob/devel/fuse_constraints/src/marginalize_variables.cpp#L117, because `variable_order` does NOT contain any entry for the orphan variables. Remember the `operator[]` automatically creates new entries increasing the size of a vector it maintains internally.

This PR is only to show the issue.

It's on top of https://github.com/locusrobotics/fuse/pull/134 because that bug impacts the same logic, although they're two different bugs.