### PR TITLE
Fix compute elimination order with orphan variables

### DIFF
--- a/fuse_constraints/include/fuse_constraints/variable_constraints.h
+++ b/fuse_constraints/include/fuse_constraints/variable_constraints.h
@@ -94,6 +94,11 @@ public:
   void insert(const unsigned int constraint, VariableIndexIterator first, VariableIndexIterator last);
 
   /**
+   * @brief Add a single orphan variable, i.e. a variable without constraints
+   */
+  void insert(const unsigned int variable);
+
+  /**
    * @brief Insert all of the constraints connected to the requested variable into the provided container
    *
    * Accessing a variable id that is not part of this container results in undefined behavior

--- a/fuse_constraints/src/variable_constraints.cpp
+++ b/fuse_constraints/src/variable_constraints.cpp
@@ -78,6 +78,15 @@ void VariableConstraints::insert(const unsigned int constraint, std::initializer
   return insert(constraint, variable_list.begin(), variable_list.end());
 }
 
+void VariableConstraints::insert(const unsigned int variable)
+{
+  if (variable >= variable_constraints_.size())
+  {
+    // This automatically create a new variable entry with an empty ConstraintCollection
+    variable_constraints_.resize(variable + 1);
+  }
+}
+
 void VariableConstraints::print(std::ostream& stream) const
 {
   for (size_t variable = 0; variable < variable_constraints_.size(); ++variable)

--- a/fuse_constraints/test/test_variable_constraints.cpp
+++ b/fuse_constraints/test/test_variable_constraints.cpp
@@ -120,6 +120,18 @@ TEST(VariableConstraints, GetConstraints)
   EXPECT_EQ(static_cast<std::ptrdiff_t>(expected3.size()), std::distance(actual3.begin(), actual3_iter));
 }
 
+TEST(VariableConstraints, InsertOrphanVariable)
+{
+  auto vars = VariableConstraints();
+
+  vars.insert(0u);
+
+  std::vector<size_t> actual;
+  vars.getConstraints(0u, std::back_inserter(actual));
+
+  EXPECT_TRUE(actual.empty());
+}
+
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This fixes https://github.com/locusrobotics/fuse/pull/135. See https://github.com/locusrobotics/fuse/pull/135 for more details.

This PR is on top of https://github.com/locusrobotics/fuse/pull/135