### PR TITLE
Support dependent relative pose measurements

### DIFF
--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -73,11 +73,40 @@ struct Pose2DParams : public ParameterBase
       getParamRequired(nh, "topic", topic);
       getParamRequired(nh, "target_frame", target_frame);
 
+      if (differential)
+      {
+        nh.getParam("independent", independent);
+
+        if (!independent)
+        {
+          std::vector<double> minimum_pose_relative_covariance_diagonal(3, 0.0);
+          nh.param("minimum_pose_relative_covariance_diagonal", minimum_pose_relative_covariance_diagonal,
+                   minimum_pose_relative_covariance_diagonal);
+
+          if (minimum_pose_relative_covariance_diagonal.size() != 3)
+          {
+            throw std::runtime_error("Minimum pose relative covariance diagonal must be of length 3!");
+          }
+
+          if (std::any_of(minimum_pose_relative_covariance_diagonal.begin(),
+                          minimum_pose_relative_covariance_diagonal.end(),
+                          [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
+          {
+            throw std::runtime_error("All minimum pose relative covariance diagonal entries must be positive!");
+          }
+
+          minimum_pose_relative_covariance =
+              fuse_core::Vector3d(minimum_pose_relative_covariance_diagonal.data()).asDiagonal();
+        }
+      }
+
       loss = loadLossConfig(nh, "loss");
     }
 
     bool differential { false };
     bool disable_checks { false };
+    bool independent { true };
+    fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
     std::string topic {};
     std::string target_frame {};

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -123,6 +123,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
         device_id_,
         *previous_pose_,
         *pose,
+        params_.independent,
+        params_.minimum_pose_relative_covariance,
         params_.pose_loss,
         {},
         params_.orientation_indices,

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -114,6 +114,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
         device_id_,
         *previous_pose_,
         *pose,
+        params_.independent,
+        params_.minimum_pose_relative_covariance,
         params_.pose_loss,
         params_.position_indices,
         params_.orientation_indices,

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -102,6 +102,8 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
         device_id_,
         *previous_pose_msg_,
         *msg,
+        params_.independent,
+        params_.minimum_pose_relative_covariance,
         params_.loss,
         params_.position_indices,
         params_.orientation_indices,


### PR DESCRIPTION
* Add `independent` param if `differential == true`, that defaults to
  `true` to keep the current behaviour:
  * If `independent == true` the relative pose measurements are assumed
    independent and the covariance of each pose is propagated and added.
  * If `independent == false` the relative pose measurements are assumed
    dependent and the covariance of each pose is propagated and the
    first pose one is substracted from the second one.
* Add `minimum_pose_relative_covariance_diagonal` param if
  `independent == true`, that is added to the resulting pose relative
  covariance in order to guarantee that it's not zero or
  ill-conditioned.