### PR TITLE
Use twist covariance for differential dependent pose measurements

### DIFF
--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -89,6 +89,8 @@ struct Odometry2DParams : public ParameterBase
 
         if (!independent)
         {
+          nh.getParam("use_twist_covariance", use_twist_covariance);
+
           std::vector<double> minimum_pose_relative_covariance_diagonal(3, 0.0);
           nh.param("minimum_pose_relative_covariance_diagonal", minimum_pose_relative_covariance_diagonal,
                    minimum_pose_relative_covariance_diagonal);
@@ -118,6 +120,7 @@ struct Odometry2DParams : public ParameterBase
     bool differential { false };
     bool disable_checks { false };
     bool independent { true };
+    bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
     std::string topic {};


### PR DESCRIPTION
This PR is on top of https://github.com/locusrobotics/fuse/pull/137 and extends the support for `differential` `dependent` pose measurements for the specific case of the `fuse_modesl::Odometry2D` sensor models.

The suboptimal approach proposed in https://github.com/locusrobotics/fuse/pull/137 has not be discarded because it can still be used for other sensor models:

- `fuse_models::Imu2D`: https://github.com/locusrobotics/fuse/pull/137/files#diff-d5ec9b8db4843c97eab48d6481dedd3e
- `fuse_models::Pose2D`: https://github.com/locusrobotics/fuse/pull/137/files#diff-64dc3a4b2e0f4da6a2cbbb17d7f8562c

Here, for the `fuse_models::Odometry2D` a single commit is contributed, that does the following.

When `differential: true` and `independent: false`, the relative pose covariance should NOT be computed from the consecutive absolute pose covariance matrices because they grow unbounded, so the resulting relative pose covariance suffers from numerical issues.

Instead, we can use the twist covariance of the last pose to compute the relative pose covariance, using the time difference between the consecutive absolute poses. The twist covariance is usually equivalent to the relative pose covariance divided by time difference. Indeed, this is exactly what the `diff_drive_controller` odometry computation logic does in our fork: https://github.com/clearpathrobotics/ros_controllers/blob/indigo-devel/diff_drive_controller/src/odometry.cpp#L198

The only limitation is that we cannot throttle the input topics, because otherwise the twist covariance from the intermediate/throttled messages is missed. We'll have to throttle inside the sensor model, by integrating the intermediate messages. However, in practice, I've throttled the inputs and I haven't seen any issues.

Note that the `minimum_pose_relative_covariance` is still used, but now it can be set to values as small as `1e-18` (for a diagonal covariance matrix) without any issues (the resulting covariance is sane, it passes all the checks: symmetry, PSD-ness). It can still be used to handle the cases when the twist covariance is zero or almost zero. Also note its default value is zero, which should be fine if the producer of the input doesn't generate a zero twist covariance (even when the robot doesn't move).