### PR TITLE
Cleanup validation checks

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -260,6 +260,31 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Eigen tests
+  catkin_add_gtest(test_eigen
+    test/test_eigen.cpp
+  )
+  add_dependencies(test_eigen
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_eigen
+    PRIVATE
+      include
+      ${Boost_INCLUDE_DIRS}
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${EIGEN3_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_eigen
+    ${PROJECT_NAME}
+  )
+  set_target_properties(test_eigen
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Local Parameterization tests
   catkin_add_gtest(test_local_parameterization
     test/test_local_parameterization.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -377,6 +377,31 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Util tests
+  add_rostest_gtest(test_util
+    test/util.test
+    test/test_util.cpp
+  )
+  add_dependencies(test_util
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_util
+    PRIVATE
+      include
+      ${Boost_INCLUDE_DIRS}
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${EIGEN3_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_util
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_util
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # UUID tests
   catkin_add_gtest(test_uuid
     test/test_uuid.cpp

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -70,6 +70,17 @@ using Matrix9d = Eigen::Matrix<double, 9, 9, Eigen::RowMajor>;
 template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
 using Matrix = Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Eigen::RowMajor>;
 
+/**
+ * @brief Serialize a matrix into an std::string using this format:
+ *
+ * [1, 2, 3]
+ * [4, 5, 6]
+ * [7, 8, 9]
+ *
+ * @param[in] m - The matrix to serialize into an std::string.
+ * @param[in] precision - The precision to print the matrix elements with.
+ * @return An std::string with the matrix serialized into it.
+ */
 template <typename Derived>
 std::string to_string(const Eigen::DenseBase<Derived>& m, const int precision = 4)
 {

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -80,6 +80,14 @@ std::string to_string(const Eigen::DenseBase<Derived>& m, const int precision = 
   return oss.str();
 }
 
+/**
+ * @brief Check if a matrix is symmetric.
+ *
+ * @param[in] m - Square matrix to check symmetry on
+ * @param[in] precision - Precision used to compared the matrix m with its transpose, which is the property used to
+ *                        check for symmetry.
+ * @return True if the matrix m is symmetric; False, otherwise.
+ */
 template <typename Derived>
 bool isSymmetric(const Eigen::DenseBase<Derived>& m,
                  const typename Eigen::DenseBase<Derived>::RealScalar precision =
@@ -88,6 +96,12 @@ bool isSymmetric(const Eigen::DenseBase<Derived>& m,
   return m.isApprox(m.transpose(), precision);
 }
 
+/**
+ * @brief Check if a matrix is Positive Definite (PD), i.e. all eigenvalues are `> 0.0`.
+ *
+ * @param[in] m - Square matrix to check PD-ness on.
+ * @return True if the matrix m is PD; False, otherwise.
+ */
 template <typename Derived>
 bool isPSD(const Eigen::DenseBase<Derived>& m)
 {

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -35,6 +35,7 @@
 #define FUSE_CORE_EIGEN_H
 
 #include <Eigen/Core>
+#include <Eigen/Eigenvalues>
 
 #include <sstream>
 #include <string>
@@ -77,6 +78,21 @@ std::string to_string(const Eigen::DenseBase<Derived>& m, const int precision = 
   std::ostringstream oss;
   oss << m.format(pretty) << '\n';
   return oss.str();
+}
+
+template <typename Derived>
+bool isSymmetric(const Eigen::DenseBase<Derived>& m,
+                 const typename Eigen::DenseBase<Derived>::RealScalar precision =
+                     Eigen::NumTraits<typename Eigen::DenseBase<Derived>::Scalar>::dummy_precision())
+{
+  return m.isApprox(m.transpose(), precision);
+}
+
+template <typename Derived>
+bool isPSD(const Eigen::DenseBase<Derived>& m)
+{
+  Eigen::SelfAdjointEigenSolver<Derived> solver(m);
+  return solver.eigenvalues().minCoeff() > 0.0;
 }
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -103,7 +103,7 @@ bool isSymmetric(const Eigen::DenseBase<Derived>& m,
  * @return True if the matrix m is PD; False, otherwise.
  */
 template <typename Derived>
-bool isPSD(const Eigen::DenseBase<Derived>& m)
+bool isPositiveDefinite(const Eigen::DenseBase<Derived>& m)
 {
   Eigen::SelfAdjointEigenSolver<Derived> solver(m);
   return solver.eigenvalues().minCoeff() > 0.0;

--- a/fuse_core/include/fuse_core/eigen.h
+++ b/fuse_core/include/fuse_core/eigen.h
@@ -93,7 +93,15 @@ bool isSymmetric(const Eigen::DenseBase<Derived>& m,
                  const typename Eigen::DenseBase<Derived>::RealScalar precision =
                      Eigen::NumTraits<typename Eigen::DenseBase<Derived>::Scalar>::dummy_precision())
 {
-  return m.isApprox(m.transpose(), precision);
+  // We do not use `isApprox`:
+  //
+  // return m.isApprox(m.transpose(), precision);
+  //
+  // because it does not play well when `m` is close to zero.
+  //
+  // See: https://eigen.tuxfamily.org/dox/classEigen_1_1DenseBase.html#ae8443357b808cd393be1b51974213f9c
+  const auto& derived = m.derived();
+  return (derived - derived.transpose()).cwiseAbs().maxCoeff() < precision;
 }
 
 /**

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -195,9 +195,9 @@ T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parame
  * @return The loaded (or default) covariance matrix, generated from the diagonal vector
  */
 template <int Size, typename Scalar = double>
-fuse_core::Matrix<Scalar, Size, Size> getCovarianceMatrixDiagonalParam(const ros::NodeHandle& node_handle,
-                                                                       const std::string& parameter_name,
-                                                                       Scalar default_value)
+fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::NodeHandle& node_handle,
+                                                                 const std::string& parameter_name,
+                                                                 Scalar default_value)
 {
   using Vector = typename Eigen::Matrix<Scalar, Size, 1>;
 

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -37,11 +37,14 @@
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
+#include <fuse_core/eigen.h>
+
 #include <ceres/jet.h>
 #include <Eigen/Core>
 
 #include <cmath>
 #include <string>
+#include <vector>
 
 
 namespace fuse_core
@@ -176,6 +179,45 @@ T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parame
     value = default_value;
   }
   return value;
+}
+
+/**
+ * @brief Helper function that loads a covariance matrix diagonal vector from the parameter server and checks the size
+ * and the values are invalid, i.e. they are positive.
+ *
+ * @tparam Scalar - A scalar type, defaults to double
+ * @tparam Size - An int size that specifies the expected size of the covariance matrix (rows and columns)
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in] default_value - A default value to use for all the diagonal elements if the provided parameter name does
+ *                            not exist
+ * @return The loaded (or default) covariance matrix, generated from the diagonal vector
+ */
+template <int Size, typename Scalar = double>
+fuse_core::Matrix<Scalar, Size, Size> getCovarianceMatrixDiagonalParam(const ros::NodeHandle& node_handle,
+                                                                       const std::string& parameter_name,
+                                                                       Scalar default_value)
+{
+  using Vector = typename Eigen::Matrix<Scalar, Size, 1>;
+
+  std::vector<Scalar> diagonal(Size, default_value);
+  node_handle.param(parameter_name, diagonal, diagonal);
+
+  const auto diagonal_size = diagonal.size();
+  if (diagonal_size != Size)
+  {
+    throw std::invalid_argument("Invalid size of " + std::to_string(diagonal_size) + ", expected " +
+                                std::to_string(Size));
+  }
+
+  if (std::any_of(diagonal.begin(), diagonal.end(),
+                  [](const auto& value) { return value < Scalar(0); }))  // NOLINT(whitespace/braces)
+  {
+    throw std::invalid_argument("Invalid negative diagonal values in " + fuse_core::to_string(Vector(diagonal.data())));
+  }
+
+  return Vector(diagonal.data()).asDiagonal();
 }
 
 }  // namespace fuse_core

--- a/fuse_core/test/test_eigen.cpp
+++ b/fuse_core/test/test_eigen.cpp
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/eigen.h>
+
+#include <gtest/gtest.h>
+
+
+TEST(Eigen, isSymmetric)
+{
+  const auto random_matrix = fuse_core::Matrix3d::Random().eval();
+
+  // A symmetric matrix:
+  const auto symmetric_matrix = (0.5 * (random_matrix + random_matrix.transpose())).eval();
+
+  EXPECT_TRUE(fuse_core::isSymmetric(symmetric_matrix)) << "Matrix\n"
+                                                        << symmetric_matrix << "\n expected to be symmetric.";
+
+  // A non-symmetric matrix:
+  const double asymmetry_error = 1.0e-6;
+
+  auto non_symmetric_matrix = symmetric_matrix;
+  non_symmetric_matrix(0, 1) += asymmetry_error;
+
+  EXPECT_FALSE(fuse_core::isSymmetric(non_symmetric_matrix))
+      << "Matrix\n"
+      << non_symmetric_matrix << "\n expected to not be symmetric.";
+
+  // Checking symmetry with precision larger than asymmetry error in non-symmetric matrix:
+  const double precision = 1.0e2 * asymmetry_error;
+
+  EXPECT_TRUE(fuse_core::isSymmetric(non_symmetric_matrix, precision))
+      << "Matrix\n"
+      << non_symmetric_matrix << "\n expected to be symmetric with precision " << precision << ".";
+
+  // fuse_core::isSymmetric is not defined for non-square matrices. The following will simply fail to compile because it
+  // is not allowed, as intended:
+  //
+  // const auto non_square_matrix = fuse_core::Matrix<double, 2, 3>::Random().eval();
+  //
+  // EXPECT_FALSE(fuse_core::isSymmetric(non_square_matrix));
+}
+
+TEST(Eigen, isPSD)
+{
+  const auto random_matrix = fuse_core::Matrix3d::Random().eval();
+
+  // A PSD matrix:
+  const auto symmetric_matrix = (0.5 * (random_matrix + random_matrix.transpose())).eval();
+  const auto psd_matrix = (symmetric_matrix + 3 * fuse_core::Matrix3d::Identity()).eval();
+
+  EXPECT_TRUE(fuse_core::isPSD(psd_matrix)) << "Matrix\n" << psd_matrix << "\n expected to be PSD.";
+
+  // A non-PSD matrix:
+  auto non_psd_matrix = psd_matrix;
+  non_psd_matrix(0, 0) *= -1.0;
+
+  EXPECT_FALSE(fuse_core::isPSD(non_psd_matrix)) << "Matrix\n" << non_psd_matrix << "\n expected to not be PSD.";
+
+  // fuse_core::isPSD is not defined for non-square matrices. The following will simply fail to compile because it is
+  // allowed, as intended:
+  //
+  // const auto non_square_matrix = fuse_core::Matrix<double, 2, 3>::Random().eval();
+  //
+  // EXPECT_FALSE(fuse_core::isPSD(non_square_matrix));
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_core/test/test_eigen.cpp
+++ b/fuse_core/test/test_eigen.cpp
@@ -71,28 +71,31 @@ TEST(Eigen, isSymmetric)
   // EXPECT_FALSE(fuse_core::isSymmetric(non_square_matrix));
 }
 
-TEST(Eigen, isPSD)
+TEST(Eigen, isPositiveDefinite)
 {
   const auto random_matrix = fuse_core::Matrix3d::Random().eval();
 
-  // A PSD matrix:
+  // A Positive Definite matrix:
   const auto symmetric_matrix = (0.5 * (random_matrix + random_matrix.transpose())).eval();
   const auto psd_matrix = (symmetric_matrix + 3 * fuse_core::Matrix3d::Identity()).eval();
 
-  EXPECT_TRUE(fuse_core::isPSD(psd_matrix)) << "Matrix\n" << psd_matrix << "\n expected to be PSD.";
+  EXPECT_TRUE(fuse_core::isPositiveDefinite(psd_matrix)) << "Matrix\n"
+                                                         << psd_matrix << "\n expected to be Positive Definite.";
 
-  // A non-PSD matrix:
+  // A non Positive Definite matrix:
   auto non_psd_matrix = psd_matrix;
   non_psd_matrix(0, 0) *= -1.0;
 
-  EXPECT_FALSE(fuse_core::isPSD(non_psd_matrix)) << "Matrix\n" << non_psd_matrix << "\n expected to not be PSD.";
+  EXPECT_FALSE(fuse_core::isPositiveDefinite(non_psd_matrix))
+      << "Matrix\n"
+      << non_psd_matrix << "\n expected to not be Positive Definite.";
 
-  // fuse_core::isPSD is not defined for non-square matrices. The following will simply fail to compile because it is
-  // allowed, as intended:
+  // fuse_core::isPositiveDefinite is not defined for non-square matrices. The following will simply fail to compile
+  // because it is allowed, as intended:
   //
   // const auto non_square_matrix = fuse_core::Matrix<double, 2, 3>::Random().eval();
   //
-  // EXPECT_FALSE(fuse_core::isPSD(non_square_matrix));
+  // EXPECT_FALSE(fuse_core::isPositiveDefinite(non_square_matrix));
 }
 
 int main(int argc, char **argv)

--- a/fuse_core/test/test_util.cpp
+++ b/fuse_core/test/test_util.cpp
@@ -39,7 +39,7 @@
 #include <numeric>
 #include <string>
 
-TEST(Util, GetCovarianceMatrixDiagonalParam)
+TEST(Util, GetCovarianceDiagonalParam)
 {
   // Build expected covariance matrix:
   constexpr int Size = 3;
@@ -64,7 +64,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
     try
     {
       const auto covariance =
-          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
 
       EXPECT_EQ(Size, covariance.rows());
       EXPECT_EQ(Size, covariance.cols());
@@ -88,7 +88,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
     try
     {
       const auto covariance =
-          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
 
       EXPECT_EQ(Size, covariance.rows());
       EXPECT_EQ(Size, covariance.cols());
@@ -109,7 +109,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
 
     ASSERT_TRUE(node_handle.hasParam(parameter_name));
 
-    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
                  std::invalid_argument);
   }
 
@@ -119,7 +119,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
 
     ASSERT_TRUE(node_handle.hasParam(parameter_name));
 
-    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
                  std::invalid_argument);
   }
 
@@ -129,7 +129,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
 
     ASSERT_TRUE(node_handle.hasParam(parameter_name));
 
-    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
                  std::invalid_argument);
   }
 
@@ -143,7 +143,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
     try
     {
       const auto covariance =
-          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
 
       EXPECT_EQ(Size, covariance.rows());
       EXPECT_EQ(Size, covariance.cols());
@@ -168,7 +168,7 @@ TEST(Util, GetCovarianceMatrixDiagonalParam)
     try
     {
       const auto covariance =
-          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
 
       EXPECT_EQ(Size, covariance.rows());
       EXPECT_EQ(Size, covariance.cols());

--- a/fuse_core/test/test_util.cpp
+++ b/fuse_core/test/test_util.cpp
@@ -1,0 +1,198 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/util.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <string>
+
+TEST(Util, GetCovarianceMatrixDiagonalParam)
+{
+  // Build expected covariance matrix:
+  constexpr int Size = 3;
+  constexpr double variance = 1.0e-3;
+  constexpr double default_variance = 0.0;
+
+  fuse_core::Matrix3d expected_covariance = fuse_core::Matrix3d::Identity();
+  expected_covariance *= variance;
+
+  fuse_core::Matrix3d default_covariance = fuse_core::Matrix3d::Identity();
+  default_covariance *= default_variance;
+
+  // Load covariance matrix diagonal from the parameter server:
+  ros::NodeHandle node_handle;
+
+  // A covariance diagonal with the expected size and valid should be the same as the expected one:
+  {
+    const std::string parameter_name{ "covariance_diagonal" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(expected_covariance.rows() * expected_covariance.cols(),
+                expected_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << expected_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // If the parameter does not exist we should get the default covariance:
+  {
+    const std::string parameter_name{ "non_existent_parameter" };
+
+    ASSERT_FALSE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // A covariance diagonal with negative values should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_negative_values" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with size 2, smaller than expected, should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_size_2" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with size 4, larger than expected, should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_size_4" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
+  // default covariance:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_strings" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
+  // default covariance:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_string" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceMatrixDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "util_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/fuse_core/test/util.test
+++ b/fuse_core/test/util.test
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <rosparam file="$(find fuse_core)/test/util.yaml" command="load"/>
+
+  <test test-name="Util" pkg="fuse_core" type="test_util" />
+</launch>

--- a/fuse_core/test/util.yaml
+++ b/fuse_core/test/util.yaml
@@ -1,0 +1,17 @@
+# Covariance diagonal with expected size (3) and valid:
+covariance_diagonal: [1.0e-3, 1.0e-3, 1.0e-3]
+
+# Covariance diagonal with negative values:
+covariance_diagonal_with_negative_values: [1.0e-3, 1.0e-3, -1.0e-3]
+
+# Covariance diagonal with size 2, smaller than expected (3):
+covariance_diagonal_with_size_2: [1.0e-3, 1.0e-3]
+
+# Covariance diagonal with size 4, larger than expected (3):
+covariance_diagonal_with_size_4: [1.0e-3, 1.0e-3, 1.0e-3, 1.0e-3]
+
+# Covariance diagonal with invalid element type:
+covariance_diagonal_with_strings: ["NaN", "NaN", "NaN"]
+
+# Covariance diagonal with invalid type:
+covariance_diagonal_with_string: "NaN"

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -238,6 +238,11 @@ if(CATKIN_ENABLE_TESTING)
         ${catkin_LIBRARIES}
         ${CERES_LIBRARIES}
       )
+      set_target_properties(benchmark_unicycle_2d_state_cost_function
+        PROPERTIES
+          CXX_STANDARD 14
+          CXX_STANDARD_REQUIRED YES
+      )
     endif()
   endif()
 endif()

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -205,7 +205,7 @@ inline void validatePartialMeasurement(
                              fuse_core::to_string(covariance_partial, Eigen::FullPrecision));
   }
 
-  if (!fuse_core::isPSD(covariance_partial))
+  if (!fuse_core::isPositiveDefinite(covariance_partial))
   {
     throw std::runtime_error("Non-positive-definite partial covariance matrix\n" +
                              fuse_core::to_string(covariance_partial, Eigen::FullPrecision));

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -60,8 +60,6 @@
 #include <tf2_2d/tf2_2d.h>
 #include <tf2_2d/transform.h>
 
-#include <Eigen/Eigenvalues>
-
 #include <boost/range/join.hpp>
 
 #include <algorithm>
@@ -201,18 +199,16 @@ inline void validatePartialMeasurement(
     throw std::runtime_error("Invalid partial mean " + fuse_core::to_string(mean_partial));
   }
 
-  if (!covariance_partial.isApprox(covariance_partial.transpose(), precision))
+  if (!fuse_core::isSymmetric(covariance_partial, precision))
   {
     throw std::runtime_error("Non-symmetric partial covariance matrix\n" +
                              fuse_core::to_string(covariance_partial, Eigen::FullPrecision));
   }
 
-  Eigen::SelfAdjointEigenSolver<fuse_core::MatrixXd> solver(covariance_partial);
-  if (solver.eigenvalues().minCoeff() <= 0.0)
+  if (!fuse_core::isPSD(covariance_partial))
   {
     throw std::runtime_error("Non-positive-definite partial covariance matrix\n" +
-                             fuse_core::to_string(covariance_partial, Eigen::FullPrecision) + "\n with eigenvalues\n" +
-                             fuse_core::to_string(solver.eigenvalues(), Eigen::FullPrecision));
+                             fuse_core::to_string(covariance_partial, Eigen::FullPrecision));
   }
 }
 

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -86,7 +86,7 @@ struct Imu2DParams : public ParameterBase
         if (!independent)
         {
           minimum_pose_relative_covariance =
-              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
+              fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/util.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
@@ -84,24 +85,8 @@ struct Imu2DParams : public ParameterBase
 
         if (!independent)
         {
-          std::vector<double> minimum_pose_relative_covariance_diagonal(3, 0.0);
-          nh.param("minimum_pose_relative_covariance_diagonal", minimum_pose_relative_covariance_diagonal,
-                   minimum_pose_relative_covariance_diagonal);
-
-          if (minimum_pose_relative_covariance_diagonal.size() != 3)
-          {
-            throw std::runtime_error("Minimum pose relative covariance diagonal must be of length 3!");
-          }
-
-          if (std::any_of(minimum_pose_relative_covariance_diagonal.begin(),
-                          minimum_pose_relative_covariance_diagonal.end(),
-                          [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
-          {
-            throw std::runtime_error("All minimum pose relative covariance diagonal entries must be positive!");
-          }
-
           minimum_pose_relative_covariance =
-              fuse_core::Vector3d(minimum_pose_relative_covariance_diagonal.data()).asDiagonal();
+              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
@@ -91,24 +92,8 @@ struct Odometry2DParams : public ParameterBase
         {
           nh.getParam("use_twist_covariance", use_twist_covariance);
 
-          std::vector<double> minimum_pose_relative_covariance_diagonal(3, 0.0);
-          nh.param("minimum_pose_relative_covariance_diagonal", minimum_pose_relative_covariance_diagonal,
-                   minimum_pose_relative_covariance_diagonal);
-
-          if (minimum_pose_relative_covariance_diagonal.size() != 3)
-          {
-            throw std::runtime_error("Minimum pose relative covariance diagonal must be of length 3!");
-          }
-
-          if (std::any_of(minimum_pose_relative_covariance_diagonal.begin(),
-                          minimum_pose_relative_covariance_diagonal.end(),
-                          [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
-          {
-            throw std::runtime_error("All minimum pose relative covariance diagonal entries must be positive!");
-          }
-
           minimum_pose_relative_covariance =
-              fuse_core::Vector3d(minimum_pose_relative_covariance_diagonal.data()).asDiagonal();
+              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -93,7 +93,7 @@ struct Odometry2DParams : public ParameterBase
           nh.getParam("use_twist_covariance", use_twist_covariance);
 
           minimum_pose_relative_covariance =
-              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
+              fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -77,7 +77,7 @@ public:
     nh.getParam("predict_with_acceleration", predict_with_acceleration);
     nh.getParam("publish_frequency", publish_frequency);
 
-    process_noise_covariance = fuse_core::getCovarianceMatrixDiagonalParam<8>(nh, "process_noise_diagonal", 0.0);
+    process_noise_covariance = fuse_core::getCovarianceDiagonalParam<8>(nh, "process_noise_diagonal", 0.0);
     nh.param("scale_process_noise", scale_process_noise, scale_process_noise);
     nh.param("velocity_norm_min", velocity_norm_min, velocity_norm_min);
 

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -38,6 +38,7 @@
 
 #include <fuse_core/ceres_options.h>
 #include <fuse_core/eigen.h>
+#include <fuse_core/util.h>
 
 #include <ros/console.h>
 #include <ros/node_handle.h>
@@ -76,22 +77,7 @@ public:
     nh.getParam("predict_with_acceleration", predict_with_acceleration);
     nh.getParam("publish_frequency", publish_frequency);
 
-    std::vector<double> process_noise_diagonal(8, 0.0);
-    nh.param("process_noise_diagonal", process_noise_diagonal, process_noise_diagonal);
-
-    if (process_noise_diagonal.size() != 8)
-    {
-      throw std::runtime_error("Process noise diagonal must be of length 8!");
-    }
-
-    if (std::any_of(process_noise_diagonal.begin(), process_noise_diagonal.end(),
-                    [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
-    {
-      throw std::runtime_error("All process noise diagonal entries must be positive!");
-    }
-
-    process_noise_covariance = fuse_core::Vector8d(process_noise_diagonal.data()).asDiagonal();
-
+    process_noise_covariance = fuse_core::getCovarianceMatrixDiagonalParam<8>(nh, "process_noise_diagonal", 0.0);
     nh.param("scale_process_noise", scale_process_noise, scale_process_noise);
     nh.param("velocity_norm_min", velocity_norm_min, velocity_norm_min);
 

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <ros/node_handle.h>
@@ -79,24 +80,8 @@ struct Pose2DParams : public ParameterBase
 
         if (!independent)
         {
-          std::vector<double> minimum_pose_relative_covariance_diagonal(3, 0.0);
-          nh.param("minimum_pose_relative_covariance_diagonal", minimum_pose_relative_covariance_diagonal,
-                   minimum_pose_relative_covariance_diagonal);
-
-          if (minimum_pose_relative_covariance_diagonal.size() != 3)
-          {
-            throw std::runtime_error("Minimum pose relative covariance diagonal must be of length 3!");
-          }
-
-          if (std::any_of(minimum_pose_relative_covariance_diagonal.begin(),
-                          minimum_pose_relative_covariance_diagonal.end(),
-                          [](const auto& v) { return v < 0.0; }))  // NOLINT(whitespace/braces)
-          {
-            throw std::runtime_error("All minimum pose relative covariance diagonal entries must be positive!");
-          }
-
           minimum_pose_relative_covariance =
-              fuse_core::Vector3d(minimum_pose_relative_covariance_diagonal.data()).asDiagonal();
+              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -81,7 +81,7 @@ struct Pose2DParams : public ParameterBase
         if (!independent)
         {
           minimum_pose_relative_covariance =
-              fuse_core::getCovarianceMatrixDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
+              fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
         }
       }
 

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -210,7 +210,7 @@ void Unicycle2DIgnition::process(const geometry_msgs::PoseWithCovarianceStamped&
     throw std::invalid_argument("Attempting to set the pose with a non-symmetric position covariance matri\n " +
                                 fuse_core::to_string(position_cov, Eigen::FullPrecision) + ".");
   }
-  if (!fuse_core::isPSD(position_cov))
+  if (!fuse_core::isPositiveDefinite(position_cov))
   {
     throw std::invalid_argument("Attempting to set the pose with a non-positive-definite position covariance matrix\n" +
                                 fuse_core::to_string(position_cov, Eigen::FullPrecision) + ".");

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -57,7 +57,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
 
 #include <exception>
 #include <stdexcept>
@@ -206,25 +205,22 @@ void Unicycle2DIgnition::process(const geometry_msgs::PoseWithCovarianceStamped&
   auto position_cov = fuse_core::Matrix2d();
   position_cov << pose.pose.covariance[0], pose.pose.covariance[1],
                   pose.pose.covariance[6], pose.pose.covariance[7];
-  if (!position_cov.isApprox(position_cov.transpose()))
+  if (!fuse_core::isSymmetric(position_cov))
   {
-    throw std::invalid_argument("Attempting to set the pose with a non-symmetric position covariance matrix [" +
-                                std::to_string(position_cov(0)) + ", " + std::to_string(position_cov(1)) + " ; " +
-                                std::to_string(position_cov(2)) + ", " + std::to_string(position_cov(3)) + "].");
+    throw std::invalid_argument("Attempting to set the pose with a non-symmetric position covariance matri\n " +
+                                fuse_core::to_string(position_cov, Eigen::FullPrecision) + ".");
   }
-  Eigen::SelfAdjointEigenSolver<fuse_core::Matrix2d> solver(position_cov);
-  if (solver.eigenvalues().minCoeff() <= 0.0)
+  if (!fuse_core::isPSD(position_cov))
   {
-    throw std::invalid_argument("Attempting to set the pose with a non-positive-definite position covariance matrix [" +
-                                std::to_string(position_cov(0)) + ", " + std::to_string(position_cov(1)) + " ; " +
-                                std::to_string(position_cov(2)) + ", " + std::to_string(position_cov(3)) + "].");
+    throw std::invalid_argument("Attempting to set the pose with a non-positive-definite position covariance matrix\n" +
+                                fuse_core::to_string(position_cov, Eigen::FullPrecision) + ".");
   }
   auto orientation_cov = fuse_core::Matrix1d();
   orientation_cov << pose.pose.covariance[35];
   if (orientation_cov(0) <= 0.0)
   {
     throw std::invalid_argument("Attempting to set the pose with a non-positive-definite orientation covariance "
-                                "matrix [" + std::to_string(orientation_cov(0)) + "].");
+                                "matrix " + fuse_core::to_string(orientation_cov) + ".");
   }
 
   // Tell the optimizer to reset before providing the initial state


### PR DESCRIPTION
This PR is on top of https://github.com/locusrobotics/fuse/pull/137 and https://github.com/locusrobotics/fuse/pull/138 because it changes code contributed in those.

This provides the following:

1. Add` getCovarianceMatrixDiagonalParam` helper function, that allows to load a covariance matrix from the parameter server, provided in a list with the diagonal values.
2. Add unit test for `util.h`. This only tests the `getCovarianceMatrixDiagonalParam` helper function for now.
3. Add `isSymmetric` and `isPSD` helper functions
4. Add unit test for `eigen.h`. Only tests `isSymmetric` and `isPSD`.