### PR TITLE
Throttle optimization duration exceeded warning

### DIFF
--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -218,8 +218,8 @@ void FixedLagSmoother::optimizationLoop()
       auto optimization_complete = ros::Time::now();
       if (optimization_complete > optimization_deadline)
       {
-        ROS_WARN_STREAM("Optimization exceeded the configured duration by " <<
-                        (optimization_complete - optimization_deadline) << "s");
+        ROS_WARN_STREAM_THROTTLE(10.0, "Optimization exceeded the configured duration by "
+                                           << (optimization_complete - optimization_deadline) << "s");
       }
     }
     // Clear the request flag now that this optimization cycle is complete


### PR DESCRIPTION
When the optimization exceeds the configured duration, it's likely to happen quite often, so I think it's better to throttle the `ROS_WARN` message that reports that.

In a future PR we could also try to make the optimization duration available in the diagnostics.