### PR TITLE
Support ScaledLoss

### DIFF
--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -31,12 +31,13 @@ catkin_package(
 add_compile_options(-Wall -Werror)
 
 add_library(${PROJECT_NAME}
-  src/trivial_loss.cpp
-  src/huber_loss.cpp
-  src/softlone_loss.cpp
-  src/cauchy_loss.cpp
   src/arctan_loss.cpp
+  src/cauchy_loss.cpp
+  src/huber_loss.cpp
+  src/scaled_loss.cpp
+  src/softlone_loss.cpp
   src/tolerant_loss.cpp
+  src/trivial_loss.cpp
   src/tukey_loss.cpp
 )
 target_include_directories(${PROJECT_NAME}
@@ -106,6 +107,30 @@ if(CATKIN_ENABLE_TESTING)
     ${CERES_LIBRARIES}
   )
   set_target_properties(test_huber_loss
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
+  # Scaled Loss Tests
+  catkin_add_gtest(test_scaled_loss
+    test/test_scaled_loss.cpp
+  )
+  add_dependencies(test_scaled_loss
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_scaled_loss
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_scaled_loss
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+  )
+  set_target_properties(test_scaled_loss
     PROPERTIES
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES

--- a/fuse_loss/fuse_plugins.xml
+++ b/fuse_loss/fuse_plugins.xml
@@ -1,42 +1,14 @@
 <library path="lib/libfuse_loss">
-  <class type="fuse_loss::TrivialLoss" base_class_type="fuse_core::Loss">
-    <description>
-    This corresponds to no robustification. It is not normally necessary to use this, as setting not loss function
-    accomplishes the same thing.
+  <!--
+  Loss functions are M-estimators that take the squared norm of a residual block 'r' and try to reduce the effect of
+  outliers by replacing the squared residuals 's = r^2' used in the standard Least-Squares problem by another function
+  of the squared residuals `rho(s)`.
 
-    f(s) = s
-    </description>
-  </class>
-  <class type="fuse_loss::HuberLoss" base_class_type="fuse_core::Loss">
-    <description>
-    Huber loss function with scaling parameter 'a', defined as follows for the residual 's':
+  For this reason loss functions are also known as robustifiers.
 
-    f(s) = 2 * a * sqrt(s) - b  if s > b   // outlier region
-         = s                    otherwise  // inlier region
-
-    where b = a^2.
-    </description>
-  </class>
-  <class type="fuse_loss::SoftLOneLoss" base_class_type="fuse_core::Loss">
-    <description>
-    Soft L1 loss function with scaling parameter 'a', that is similar to Huber but smooth, defined as follows for the
-    residual 's':
-
-    f(s) = 2 * b * (sqrt(1 + s * c) - 1)
-
-    where b = a^2 and c = 1 / b.
-    </description>
-  </class>
-  <class type="fuse_loss::CauchyLoss" base_class_type="fuse_core::Loss">
-    <description>
-    Loss function inspired by the Cauchy distribution, with scaling parameter 'a', defined as follows for the residual
-    's':
-
-    f(s) = b * log(1 + s * c)
-
-    where b = a^2 and c = 1 / b.
-    </description>
-  </class>
+  In the notation used here, `rho(s)` takes the squared residuals `s` as an input, not the residuals `r`, as in Ceres
+  solver.
+  -->
   <class type="fuse_loss::ArctanLoss" base_class_type="fuse_core::Loss">
     <description>
     Loss function that is capped beyond a certain level using the arc-tangent function, with scaling parameter 'a' that
@@ -44,7 +16,51 @@
     like TrivialLoss, and for values much larger than 'a' the value asymptotically approaches the constant value of
     'a * PI / 2'. It is defined as follows for the residual 's':
 
-    f(s) = a * atan2(s, a)
+    rho(s) = a * atan2(s, a)
+    </description>
+  </class>
+  <class type="fuse_loss::CauchyLoss" base_class_type="fuse_core::Loss">
+    <description>
+    Loss function inspired by the Cauchy distribution, with scaling parameter 'a', defined as follows for the residual
+    's':
+
+    rho(s) = b * log(1 + s * c)
+
+    where b = a^2 and c = 1 / b.
+    </description>
+  </class>
+  <class type="fuse_loss::HuberLoss" base_class_type="fuse_core::Loss">
+    <description>
+    Huber loss function with scaling parameter 'a', defined as follows for the residual 's':
+
+    rho(s) = 2 * a * sqrt(s) - b  if s > b   // outlier region
+           = s                    otherwise  // inlier region
+
+    where b = a^2.
+    </description>
+  </class>
+  <class type="fuse_loss::ScaledLoss" base_class_type="fuse_core::Loss">
+    <description>
+      The other basic loss function has to do with length scaling, i.e. they affect the space in which 's' is measured.
+      Sometimes you want to simply scale the output value of the robustifier.
+
+      If '\hat{rho}' is the wrapped robustifier, then this simply outputs:
+
+      rho(s) = a * \hat{rho(s)}
+
+      If '\hat{rho}' is not given, it is set as NULL and is treated as the Trivial loss function, so we get:
+
+      rho(s) = a * s
+    </description>
+  </class>
+  <class type="fuse_loss::SoftLOneLoss" base_class_type="fuse_core::Loss">
+    <description>
+    Soft L1 loss function with scaling parameter 'a', that is similar to Huber but smooth, defined as follows for the
+    residual 's':
+
+    rho(s) = 2 * b * (sqrt(1 + s * c) - 1)
+
+    where b = a^2 and c = 1 / b.
     </description>
   </class>
   <class type="fuse_loss::TolerantLoss" base_class_type="fuse_core::Loss">
@@ -52,12 +68,20 @@
     Loss function that maps to approximately zero cost in a range around the origin, and reverts to linear in error
     (quadratic in cost) beyond this range. The tolerance parameter 'a' sets the nominal point at which the transition
     occurs, and the transition size parameter 'b' sets the nominal distance over which most of the transition occurs.
-    Both 'a' and 'b' must be reater than zero, and typically 'b' will be set to a fraction of 'a'. It is defined as
+    Both 'a' and 'b' must be greater than zero, and typically 'b' will be set to a fraction of 'a'. It is defined as
     follows for the residual 's':
 
-    f(s) = b * log(1 + exp((s - a) / b)) - c0
+    rho(s) = b * log(1 + exp((s - a) / b)) - c0
 
     where c0 = b * log(1 + exp(-a / b)).
+    </description>
+  </class>
+  <class type="fuse_loss::TrivialLoss" base_class_type="fuse_core::Loss">
+    <description>
+    This corresponds to no robustification. It is not normally necessary to use this, as not not setting a loss function
+    accomplishes the same thing.
+
+    rho(s) = s
     </description>
   </class>
   <class type="fuse_loss::TukeyLoss" base_class_type="fuse_core::Loss">
@@ -65,8 +89,8 @@
     Tukey biweight loss function which aggressively attempts to suppress large errors, with scaling parameter 'a',
     defined as follows for the residual 's':
 
-    f(s) = a^2 / 6                    if s > a^2  // inlier region
-         = a^2 / 6 * (1 - (1 - s / a^2)^3)  otherwise   // outlier region
+    rho(s) = a^2 / 6                          if s > a^2  // inlier region
+           = a^2 / 6 * (1 - (1 - s / a^2)^3)  otherwise   // outlier region
     </description>
   </class>
 </library>

--- a/fuse_loss/include/fuse_loss/scaled_loss.h
+++ b/fuse_loss/include/fuse_loss/scaled_loss.h
@@ -1,0 +1,169 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_LOSS_SCALED_LOSS_H
+#define FUSE_LOSS_SCALED_LOSS_H
+
+#include <fuse_core/loss.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+#include <ostream>
+#include <string>
+
+
+namespace fuse_loss
+{
+
+/**
+ * @brief The ScaledLoss loss function.
+ *
+ * This class encapsulates the ceres::ScaledLoss class, adding the ability to serialize it and load it dynamically.
+ *
+ * See the Ceres documentation for more details: http://ceres-solver.org/nnls_modeling.html#lossfunction
+ */
+class ScaledLoss : public fuse_core::Loss
+{
+public:
+  FUSE_LOSS_DEFINITIONS(ScaledLoss);
+
+  /**
+   * @brief Constructor
+   *
+   * @param[in] a ScaledLoss parameter 'a'. See Ceres documentation for more details.
+   * @param[in] loss The loss function to scale. Its output is scaled/multiplied by 'a'.
+   */
+  explicit ScaledLoss(const double a = 1.0, const std::shared_ptr<fuse_core::Loss>& loss = nullptr);
+
+  /**
+   * @brief Destructor
+   */
+  ~ScaledLoss() override = default;
+
+  /**
+   * @brief Perform any required post-construction initialization, such as reading from the parameter server.
+   *
+   * This will be called on each plugin after construction.
+   *
+   * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
+   */
+  void initialize(const std::string& name) override;
+
+  /**
+   * @brief Print a human-readable description of the loss function to the provided stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  void print(std::ostream& stream = std::cout) const override;
+
+  /**
+   * @brief Return a raw pointer to a ceres::LossFunction that implements the loss function.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
+   * delete the loss function when it is done. Additionally, Fuse promises that the Loss object will outlive any
+   * generated loss functions (i.e. the Ceres objects will be destroyed before the Loss Function objects). This
+   * guarantee may allow optimizations for the creation of the loss function objects.
+   *
+   * @return A base pointer to an instance of a derived ceres::LossFunction.
+   */
+  ceres::LossFunction* lossFunction() const override;
+
+  /**
+   * @brief Parameter 'a' accessor.
+   *
+   * @return Parameter 'a'.
+   */
+  double a() const
+  {
+    return a_;
+  }
+
+  /**
+   * @brief Parameter 'loss' accessor.
+   *
+   * @return Parameter 'loss'.
+   */
+  std::shared_ptr<fuse_core::Loss> loss() const
+  {
+    return loss_;
+  }
+
+  /**
+   * @brief Parameter 'a' mutator.
+   *
+   * @param[in] a Parameter 'a'.
+   */
+  void a(const double a)
+  {
+    a_ = a;
+  }
+
+  /**
+   * @brief Parameter 'loss' mutator.
+   *
+   * @param[in] loss Parameter 'loss'.
+   */
+  void loss(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    loss_ = loss;
+  }
+
+private:
+  double a_{ 1.0 };  //<! ScaledLoss parameter 'a'. See Ceres documentation for more details
+  std::shared_ptr<fuse_core::Loss> loss_{ nullptr };  //!< The loss function to scale
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Loss>(*this);
+    archive & a_;
+    archive & loss_;
+  }
+};
+
+}  // namespace fuse_loss
+
+BOOST_CLASS_EXPORT_KEY(fuse_loss::ScaledLoss);
+
+#endif  // FUSE_LOSS_SCALED_LOSS_H

--- a/fuse_loss/test/test_scaled_loss.cpp
+++ b/fuse_loss/test/test_scaled_loss.cpp
@@ -1,0 +1,216 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/serialization.h>
+#include <fuse_loss/huber_loss.h>
+#include <fuse_loss/scaled_loss.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
+#include <gtest/gtest.h>
+
+TEST(ScaledLoss, Constructor)
+{
+  // Create a default loss
+  {
+    fuse_loss::ScaledLoss scaled_loss;
+    EXPECT_EQ(1.0, scaled_loss.a());
+    EXPECT_EQ(nullptr, scaled_loss.loss());
+  }
+
+  // Create a loss with a parameter
+  {
+    const double a{ 0.3 };
+    fuse_loss::ScaledLoss scaled_loss(a);
+    EXPECT_EQ(a, scaled_loss.a());
+    EXPECT_EQ(nullptr, scaled_loss.loss());
+  }
+
+  // Create a loss with a parameter and loss function to scale
+  {
+    std::shared_ptr<fuse_loss::HuberLoss> loss{ new fuse_loss::HuberLoss };
+
+    const double a{ 0.3 };
+    fuse_loss::ScaledLoss scaled_loss(a, loss);
+    EXPECT_EQ(a, scaled_loss.a());
+    EXPECT_NE(nullptr, scaled_loss.loss());
+    EXPECT_EQ(loss.get(), scaled_loss.loss().get());
+  }
+}
+
+struct CostFunctor
+{
+  explicit CostFunctor(const double data)
+    : data(data)
+  {}
+
+  template <typename T> bool operator()(const T* const x, T* residual) const
+  {
+    residual[0] = x[0] - T(data);
+    return true;
+  }
+
+  double data{ 0.0 };
+};
+
+TEST(ScaledLoss, Optimization)
+{
+  // Create a simple parameter
+  double x{ 5.0 };
+
+  // Create a simple inlier constraint
+  const double inlier{ 1.0 };
+
+  // Create a simple outlier constraint
+  const double outlier{ 10.0 };
+  ceres::CostFunction* cost_function_outlier =
+      new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(new CostFunctor(outlier));
+
+  // Create loss
+  const double a{ 0.1 };
+  std::shared_ptr<fuse_loss::HuberLoss> loss{ new fuse_loss::HuberLoss(a) };
+
+  // Create a scaled loss, which should not have a significant impact in this test
+  const double scaled_a{ 0.7 };
+  fuse_loss::ScaledLoss scaled_loss(scaled_a, loss);
+
+  // Build the problem.
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+
+  ceres::Problem problem(problem_options);
+
+  const size_t num_inliers{ 1000 };
+  for (size_t i = 0; i < num_inliers; ++i)
+  {
+    problem.AddResidualBlock(
+      new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(new CostFunctor(inlier)),
+      scaled_loss.lossFunction(),  // A nullptr here would produce a slightly better solution
+      &x);
+  }
+
+  // Add outlier constraints
+  const size_t num_outliers{ 9 };
+  for (size_t i = 0; i < num_outliers; ++i)
+  {
+    problem.AddResidualBlock(
+      cost_function_outlier,
+      scaled_loss.lossFunction(),
+      &x);
+  }
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+
+  // Check
+  EXPECT_NEAR(inlier, x, 1.0e-3);
+
+  // Evaluate problem cost
+  double cost = 0.0;
+  problem.Evaluate(ceres::Problem::EvaluateOptions(), &cost, nullptr, nullptr, nullptr);
+
+  // Evaluate problem without applying the loss
+  ceres::Problem::EvaluateOptions evaluate_options;
+  evaluate_options.apply_loss_function = false;
+
+  double raw_cost = 0.0;
+  problem.Evaluate(evaluate_options, &raw_cost, nullptr, nullptr, nullptr);
+
+  // Check the cost with loss is lower
+  EXPECT_LT(cost, raw_cost);
+}
+
+TEST(ScaledLoss, Serialization)
+{
+  // Construct a loss
+  const double loss_a{ 0.3 };
+  std::shared_ptr<fuse_loss::HuberLoss> loss{ new fuse_loss::HuberLoss(loss_a) };
+
+  // Construct a scaled loss
+  const double a{ 0.7 };
+  fuse_loss::ScaledLoss expected(a, loss);
+
+  // Serialize the loss into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new loss from that same stream
+  fuse_loss::ScaledLoss actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.a(), actual.a());
+  EXPECT_NE(nullptr, actual.lossFunction());
+  EXPECT_NE(nullptr, actual.loss());
+
+  // Test inlier (s <= loss_a*loss_a)
+  const double s = 0.95 * loss_a * loss_a;
+  double rho[3] = {0.0};
+  actual.lossFunction()->Evaluate(s, rho);
+
+  EXPECT_EQ(a * s, rho[0]);
+  EXPECT_EQ(a, rho[1]);
+  EXPECT_EQ(0.0, rho[2]);
+
+  // Test outlier
+  const double s_outlier = 1.05 * loss_a * loss_a;
+  actual.lossFunction()->Evaluate(s_outlier, rho);
+
+  // In the outlier region rho() satisfies:
+  //
+  //   rho(s) < s
+  //   rho'(s) < 1
+  //   rho''(s) < 0
+  //
+  // where rho(s) is rho[0], rho'(s) is rho[1] and rho''(s) is rho[2]
+  //
+  // But with the scaled loss, everything is multiplied by a.
+  EXPECT_GT(a * s_outlier, rho[0]);
+  EXPECT_GT(a, rho[1]);
+  EXPECT_GT(0.0, rho[2]);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/parameter.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -77,7 +78,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);
-      getParamRequired(nh, "topic", topic);
+      fuse_core::getParamRequired(nh, "topic", topic);
 
       if (differential)
       {
@@ -92,22 +93,22 @@ struct Imu2DParams : public ParameterBase
 
       if (!linear_acceleration_indices.empty())
       {
-        getParamRequired(nh, "acceleration_target_frame", acceleration_target_frame);
+        fuse_core::getParamRequired(nh, "acceleration_target_frame", acceleration_target_frame);
       }
 
       if (!orientation_indices.empty())
       {
-        getParamRequired(nh, "orientation_target_frame", orientation_target_frame);
+        fuse_core::getParamRequired(nh, "orientation_target_frame", orientation_target_frame);
       }
 
       if (!angular_velocity_indices.empty())
       {
-        getParamRequired(nh, "twist_target_frame", twist_target_frame);
+        fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
       }
 
-      pose_loss = loadLossConfig(nh, "pose_loss");
-      angular_velocity_loss = loadLossConfig(nh, "angular_velocity_loss");
-      linear_acceleration_loss = loadLossConfig(nh, "linear_acceleration_loss");
+      pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
+      angular_velocity_loss = fuse_core::loadLossConfig(nh, "angular_velocity_loss");
+      linear_acceleration_loss = fuse_core::loadLossConfig(nh, "linear_acceleration_loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/parameter.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
@@ -77,12 +78,12 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
-      getParamRequired(nh, "topic", topic);
-      getParamRequired(nh, "twist_target_frame", twist_target_frame);
+      fuse_core::getParamRequired(nh, "topic", topic);
+      fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
 
       if (!differential)
       {
-        getParamRequired(nh, "pose_target_frame", pose_target_frame);
+        fuse_core::getParamRequired(nh, "pose_target_frame", pose_target_frame);
       }
       else
       {
@@ -97,9 +98,9 @@ struct Odometry2DParams : public ParameterBase
         }
       }
 
-      pose_loss = loadLossConfig(nh, "pose_loss");
-      linear_velocity_loss = loadLossConfig(nh, "linear_velocity_loss");
-      angular_velocity_loss = loadLossConfig(nh, "angular_velocity_loss");
+      pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
+      linear_velocity_loss = fuse_core::loadLossConfig(nh, "linear_velocity_loss");
+      angular_velocity_loss = fuse_core::loadLossConfig(nh, "angular_velocity_loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/parameter_base.h
+++ b/fuse_models/include/fuse_models/parameters/parameter_base.h
@@ -34,7 +34,6 @@
 #ifndef FUSE_MODELS_PARAMETERS_PARAMETER_BASE_H
 #define FUSE_MODELS_PARAMETERS_PARAMETER_BASE_H
 
-#include <fuse_core/loss_loader.h>
 #include <fuse_models/common/sensor_config.h>
 
 #include <ros/node_handle.h>
@@ -64,24 +63,14 @@ struct ParameterBase
 };
 
 /**
- * @brief Utility method for handling required ROS params
+ * @brief Utility method to load a sensor configuration, i.e. the dimension indices
+ *
+ * @tparam T - The variable type the dimension indices belong to
  *
  * @param[in] nh - The ROS node handle with which to load parameters
- * @param[in] key - The ROS parameter key for the required parameter
- * @param[out] value - The ROS parameter value for the \p key
- * @throws std::runtime_error if the parameter does not exist
+ * @param[in] name - The ROS parameter name for the sensor configuration parameter
+ * @return A vector with the dimension indices, that would be empty if the parameter does not exist
  */
-template <typename T>
-void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)
-{
-  if (!nh.getParam(key, value))
-  {
-    const std::string error = "Could not find required parameter " + key + " in namespace " + nh.getNamespace();
-    ROS_FATAL_STREAM(error);
-    throw std::runtime_error(error);
-  }
-}
-
 template <typename T>
 inline std::vector<size_t> loadSensorConfig(const ros::NodeHandle& nh, const std::string& name)
 {
@@ -92,22 +81,6 @@ inline std::vector<size_t> loadSensorConfig(const ros::NodeHandle& nh, const std
   }
 
   return {};
-}
-
-inline fuse_core::Loss::SharedPtr loadLossConfig(const ros::NodeHandle& nh, const std::string& name)
-{
-  if (!nh.hasParam(name))
-  {
-    return {};
-  }
-
-  std::string loss_type;
-  getParamRequired(nh, name + "/type", loss_type);
-
-  auto loss = fuse_core::createUniqueLoss(loss_type);
-  loss->initialize(nh.resolveName(name));
-
-  return loss;
 }
 
 }  // namespace parameters

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/parameter.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
@@ -71,8 +72,8 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
-      getParamRequired(nh, "topic", topic);
-      getParamRequired(nh, "target_frame", target_frame);
+      fuse_core::getParamRequired(nh, "topic", topic);
+      fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
       if (differential)
       {
@@ -85,7 +86,7 @@ struct Pose2DParams : public ParameterBase
         }
       }
 
-      loss = loadLossConfig(nh, "loss");
+      loss = fuse_core::loadLossConfig(nh, "loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/parameter.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 #include <ros/node_handle.h>
@@ -69,11 +70,11 @@ struct Twist2DParams : public ParameterBase
 
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
-      getParamRequired(nh, "topic", topic);
-      getParamRequired(nh, "target_frame", target_frame);
+      fuse_core::getParamRequired(nh, "topic", topic);
+      fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
-      linear_loss = loadLossConfig(nh, "linear_loss");
-      angular_loss = loadLossConfig(nh, "angular_loss");
+      linear_loss = fuse_core::loadLossConfig(nh, "linear_loss");
+      angular_loss = fuse_core::loadLossConfig(nh, "angular_loss");
     }
 
     bool disable_checks { false };

--- a/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
+++ b/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/parameter_base.h>
 
 #include <fuse_core/loss.h>
+#include <fuse_core/parameter.h>
 #include <ros/node_handle.h>
 
 #include <algorithm>
@@ -111,7 +112,7 @@ struct Unicycle2DIgnitionParams : public ParameterBase
         initial_state.swap(state_vector);
       }
 
-      loss = loadLossConfig(nh, "loss");
+      loss = fuse_core::loadLossConfig(nh, "loss");
     }
 
 


### PR DESCRIPTION
This adds supports to `ceres::ScaledLoss`: https://github.com/ceres-solver/ceres-solver/blob/032d5844c2db412e25f780c6acf95ecc7a0b7975/include/ceres/loss_function.h#L311-L349

This allows to scale the output of a loss function by a scalar factor `a`.

This is useful if we want to scale the loss function influence of a particular source more than others, or even to workaround the incorrect implementation of the `TukeyLoss`: https://github.com/ceres-solver/ceres-solver/blob/032d5844c2db412e25f780c6acf95ecc7a0b7975/internal/ceres/loss_function.cc#L118-L132, that should be multiplied by `2` because the cost multiplies the output of the loss function `Evaluate` method by `0.5`, which is Ceres solver convention.