### PR TITLE
Plot loss

### DIFF
--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -89,6 +89,15 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
 
+  find_package(Qt5 REQUIRED COMPONENTS
+    Core
+    Widgets)
+
+  # Find Qwt using FindQwt.cmake copied from:
+  # https://gitlab.kitware.com/cmake/community/-/wikis/contrib/modules/FindQwt
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(Qwt REQUIRED)
+
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
   roslint_cpp()
@@ -141,6 +150,41 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
   )
+
+# Qwt Loss Plot Tests
+  catkin_add_gtest(test_qwt_loss_plot
+    test/test_qwt_loss_plot.cpp
+  )
+  add_dependencies(test_qwt_loss_plot
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_qwt_loss_plot
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${Qt5Core_INCLUDE_DIRS}
+      ${Qt5Widgets_INCLUDE_DIRS}
+      ${QWT_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_qwt_loss_plot
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+    ${Qt5Core_LIBRARIES}
+    ${Qt5Widgets_LIBRARIES}
+    ${QWT_LIBRARIES}
+  )
+  set_target_properties(test_qwt_loss_plot
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
+  option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
+  if(BUILD_WITH_INTERACTIVE_TESTS )
+    target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
+  endif()
 
   # Scaled Loss Tests
   catkin_add_gtest(test_scaled_loss

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -151,40 +151,43 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
-# Qwt Loss Plot Tests
-  catkin_add_gtest(test_qwt_loss_plot
-    test/test_qwt_loss_plot.cpp
-  )
-  add_dependencies(test_qwt_loss_plot
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_qwt_loss_plot
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-      ${Qt5Core_INCLUDE_DIRS}
-      ${Qt5Widgets_INCLUDE_DIRS}
-      ${QWT_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_qwt_loss_plot
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Widgets_LIBRARIES}
-    ${QWT_LIBRARIES}
-  )
-  set_target_properties(test_qwt_loss_plot
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
+  # Qwt Loss Plot Tests
+  option(BUILD_WITH_PLOT_TESTS "Build with plot tests. These test might fail to run in headless systems." OFF)
+  if(BUILD_WITH_PLOT_TESTS)
+    catkin_add_gtest(test_qwt_loss_plot
+      test/test_qwt_loss_plot.cpp
+    )
+    add_dependencies(test_qwt_loss_plot
+      ${catkin_EXPORTED_TARGETS}
+    )
+    target_include_directories(test_qwt_loss_plot
+      PRIVATE
+        include
+        ${catkin_INCLUDE_DIRS}
+        ${CERES_INCLUDE_DIRS}
+        ${Qt5Core_INCLUDE_DIRS}
+        ${Qt5Widgets_INCLUDE_DIRS}
+        ${QWT_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_qwt_loss_plot
+      ${PROJECT_NAME}
+      ${catkin_LIBRARIES}
+      ${CERES_LIBRARIES}
+      ${Qt5Core_LIBRARIES}
+      ${Qt5Widgets_LIBRARIES}
+      ${QWT_LIBRARIES}
+    )
+    set_target_properties(test_qwt_loss_plot
+      PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED YES
+    )
 
-  option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
-  if(BUILD_WITH_INTERACTIVE_TESTS )
-    target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
-  endif()
+    option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
+    if(BUILD_WITH_INTERACTIVE_TESTS)
+      target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
+    endif(BUILD_WITH_INTERACTIVE_TESTS)
+  endif(BUILD_WITH_PLOT_TESTS)
 
   # Scaled Loss Tests
   catkin_add_gtest(test_scaled_loss

--- a/fuse_loss/cmake/FindQwt.cmake
+++ b/fuse_loss/cmake/FindQwt.cmake
@@ -1,0 +1,118 @@
+# Qt Widgets for Technical Applications
+# available at http://www.http://qwt.sourceforge.net/
+#
+# The module defines the following variables:
+#  QWT_FOUND - the system has Qwt
+#  QWT_INCLUDE_DIR - where to find qwt_plot.h
+#  QWT_INCLUDE_DIRS - qwt includes
+#  QWT_LIBRARY - where to find the Qwt library
+#  QWT_LIBRARIES - aditional libraries
+#  QWT_MAJOR_VERSION - major version
+#  QWT_MINOR_VERSION - minor version
+#  QWT_PATCH_VERSION - patch version
+#  QWT_VERSION_STRING - version (ex. 5.2.1)
+#  QWT_ROOT_DIR - root dir (ex. /usr/local)
+
+#=============================================================================
+# Copyright 2010-2013, Julien Schueller
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met: 
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer. 
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution. 
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies, 
+# either expressed or implied, of the FreeBSD Project.
+#=============================================================================
+
+
+find_path ( QWT_INCLUDE_DIR
+  NAMES qwt_plot.h
+  HINTS ${QT_INCLUDE_DIR}
+  PATH_SUFFIXES qwt qwt-qt3 qwt-qt4 qwt-qt5
+)
+
+set ( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )
+
+# version
+set ( _VERSION_FILE ${QWT_INCLUDE_DIR}/qwt_global.h )
+if ( EXISTS ${_VERSION_FILE} )
+  file ( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+QWT_VERSION_STR" )
+  if ( _VERSION_LINE )
+    string ( REGEX REPLACE ".*define[ ]+QWT_VERSION_STR[ ]+\"(.*)\".*" "\\1" QWT_VERSION_STRING "${_VERSION_LINE}" )
+    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" QWT_MAJOR_VERSION "${QWT_VERSION_STRING}" )
+    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" QWT_MINOR_VERSION "${QWT_VERSION_STRING}" )
+    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\3" QWT_PATCH_VERSION "${QWT_VERSION_STRING}" )
+  endif ()
+endif ()
+
+
+# check version
+set ( _QWT_VERSION_MATCH TRUE )
+if ( Qwt_FIND_VERSION AND QWT_VERSION_STRING )
+  if ( Qwt_FIND_VERSION_EXACT )
+    if ( NOT Qwt_FIND_VERSION VERSION_EQUAL QWT_VERSION_STRING )
+      set ( _QWT_VERSION_MATCH FALSE )
+    endif ()
+  else ()
+    if ( QWT_VERSION_STRING VERSION_LESS Qwt_FIND_VERSION )
+      set ( _QWT_VERSION_MATCH FALSE )
+    endif ()
+  endif ()
+endif ()
+
+
+find_library ( QWT_LIBRARY
+  NAMES qwt qwt-qt3 qwt-qt4 qwt-qt5
+  HINTS ${QT_LIBRARY_DIR}
+)
+
+set ( QWT_LIBRARIES ${QWT_LIBRARY} )
+
+
+# try to guess root dir from include dir
+if ( QWT_INCLUDE_DIR )
+  string ( REGEX REPLACE "(.*)/include.*" "\\1" QWT_ROOT_DIR ${QWT_INCLUDE_DIR} )
+# try to guess root dir from library dir
+elseif ( QWT_LIBRARY )
+  string ( REGEX REPLACE "(.*)/lib[/|32|64].*" "\\1" QWT_ROOT_DIR ${QWT_LIBRARY} )
+endif ()
+
+
+# handle the QUIETLY and REQUIRED arguments
+include ( FindPackageHandleStandardArgs )
+if ( CMAKE_VERSION LESS 2.8.3 )
+  find_package_handle_standard_args( Qwt DEFAULT_MSG QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH )
+else ()
+  find_package_handle_standard_args( Qwt REQUIRED_VARS QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH VERSION_VAR QWT_VERSION_STRING )
+endif ()
+
+
+mark_as_advanced (
+  QWT_LIBRARY 
+  QWT_LIBRARIES
+  QWT_INCLUDE_DIR
+  QWT_INCLUDE_DIRS
+  QWT_MAJOR_VERSION
+  QWT_MINOR_VERSION
+  QWT_PATCH_VERSION
+  QWT_VERSION_STRING
+  QWT_ROOT_DIR
+)

--- a/fuse_loss/fuse_plugins.xml
+++ b/fuse_loss/fuse_plugins.xml
@@ -8,6 +8,37 @@
 
   In the notation used here, `rho(s)` takes the squared residuals `s` as an input, not the residuals `r`, as in Ceres
   solver.
+
+  For least squares problems where there are no outliers and standard squared loss is expected, it is not necessary to
+  create use a loss function.
+
+  For least squares problems where the optimization may encounter input terms that contain outliers, i.e. completely
+  bogus measurements, it is important to use a loss function that reduces their associated penalty cost.
+
+  Using a robust loss function, the cost for large residuals is reduced. This leads to outlier terms getting
+  downweighted so they do not overly influence the final solution of the problem.
+
+  Unfortunately, there is no principled way to select a robust loss function. It is encouraged to start with a
+  non-robust cost, then only experiment with robust loss functions if standard squared loss does not work.
+
+  See http://ceres-solver.org/nnls_modeling.html#lossfunction and
+  https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/loss_function.h for more information. Indeed,
+  the last paragraphs above have been either copied or adapted from there in order to give some basic guidelines.
+
+  Depending on how much the outliers are downweighted, the loss functions can be more or less aggressive. The more
+  aggressive ones would give a lower cost after applying the loss function. Therefore, we can order the loss functions
+  according to this criterion, starting from the Trivial loss, which is equivalent to the standard squared loss, i.e. no
+  loss (aka non-robust cost):
+
+    Trivial >= Huber >= SoftLOne >= Fair >= Cauchy >= DCS >= Arctan >= GemanMcClure >= Welsch >= Tukey
+
+  The Tolerant loss is more like the TrivialLoss, expect for the deadband for residuals with low cost. This is the only
+  loss function that downweights the residuals with small cost, as opossed to all other loss functions, that downweight
+  the residuals with large cost.
+
+  The test_qwt_loss_plot generates a set of plots that show how the \rho, influence (\phi) and weight functions look
+  like for all the loss functions. The order used to compared them above is based on the weight function, and it is
+  orientative. It is always better to look at the weight function directly.
   -->
   <class type="fuse_loss::ArctanLoss" base_class_type="fuse_core::Loss">
     <description>

--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -243,11 +243,14 @@ public:
     plot_.insertLegend(&legend_);
   }
 
+  static std::string getName(const std::string& type)
+  {
+    return type.substr(11, type.size() - 15);
+  }
+
   void plotRho(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    const auto loss_type = loss->type();
-
-    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
 
     curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.rho(loss->lossFunction())));
 
@@ -259,9 +262,7 @@ public:
 
   void plotInfluence(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    const auto loss_type = loss->type();
-
-    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
 
     curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.influence(loss->lossFunction())));
 
@@ -273,9 +274,7 @@ public:
 
   void plotWeight(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    const auto loss_type = loss->type();
-
-    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
 
     curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.weight(loss->lossFunction())));
 
@@ -287,9 +286,7 @@ public:
 
   void plotSecondDerivative(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    const auto loss_type = loss->type();
-
-    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
 
     curve->setSamples(residuals_,
                       QVector<double>::fromStdVector(loss_evaluator_.secondDerivative(loss->lossFunction())));

--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -1,0 +1,333 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_LOSS_QWT_LOSS_PLOT_H
+#define FUSE_LOSS_QWT_LOSS_PLOT_H
+
+
+#include <qwt_legend.h>
+#include <qwt_plot.h>
+#include <qwt_plot_curve.h>
+#include <qwt_plot_grid.h>
+#include <qwt_plot_magnifier.h>
+#include <qwt_plot_panner.h>
+#include <qwt_plot_renderer.h>
+#include <qwt_plot_zoomer.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+
+namespace fuse_loss
+{
+
+/**
+ * @brief HSV colormap that varies the hue H in the [0, 1) range with equidistant points for the given size.
+ * The hue H interval is open because the hue is the same for 0 and 1. Therefore, we never take hue == 1.
+ */
+class HSVColormap
+{
+public:
+  explicit HSVColormap(const size_t size = 256)
+  {
+    if (size == 0)
+    {
+      return;
+    }
+
+    colormap_.reserve(size);
+
+    double hue = 0.0;
+    const double hue_increment = 1.0 / size;
+    for (size_t i = 0; i < size; ++i, hue += hue_increment)
+    {
+      QColor color;
+      color.setHsvF(hue, 1.0, 1.0);
+
+      colormap_.push_back(color);
+    }
+  }
+
+  const QColor& operator[](const size_t i) const
+  {
+    return colormap_[i];
+  }
+
+  size_t size() const
+  {
+    return colormap_.size();
+  }
+
+private:
+  std::vector<QColor> colormap_;
+};
+
+class LossEvaluator
+{
+public:
+  explicit LossEvaluator(const std::vector<double>& residuals) : residuals_(residuals)
+  {
+  }
+
+  std::vector<double> rho(const ceres::LossFunction* loss_function) const
+  {
+    std::vector<double> rhos;
+    rhos.reserve(residuals_.size());
+
+    // Remember that the loss functions we use are like Ceres solver ones, i.e. they're defined as:
+    //
+    //   rho(s) = 2 * \rho(sqrt(s))
+    //
+    // where s = r^2, being r the residual.
+    //
+    // See: https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/residual_block.cc#L165
+    std::transform(residuals_.begin(), residuals_.end(), std::back_inserter(rhos),
+                   [&loss_function](const auto& r) {  // NOLINT(whitespace/braces)
+                     double rho[3];
+                     loss_function->Evaluate(r * r, rho);
+                     return 0.5 * rho[0];
+                   });  // NOLINT(whitespace/braces)
+
+    return rhos;
+  }
+
+  std::vector<double> influence(const ceres::LossFunction* loss_function) const
+  {
+    std::vector<double> influence;
+    influence.reserve(residuals_.size());
+
+    // The influence is defined as the first derivative of \rho wrt the residual r:
+    //
+    //             d \rho(r)
+    //   \phi(r) = ---------
+    //                dr
+    //
+    // However, the loss functions we use are like Ceres solver ones, i.e. they compute the first derivative of rho(s)
+    // wrt s = r^2 in rho[1] as:
+    //
+    //             d rho(s)
+    //   \phi(s) = --------
+    //                ds
+    //
+    // Therefore, we have the following equivalence:
+    //
+    //             d \rho(r)   d 0.5 * rho(r^2)         d rho(s)   d r^2                 d rho(s)       d rho(s)
+    //   \phi(r) = --------- = ---------------- = 0.5 * -------- * ----- = 0.5 * 2 * r * -------- = r * --------
+    //                dr             dr                    ds       dr                      ds             ds
+    //
+    // where \rho(r) = 0.5 * rho(r^2) is the inverse of rho(s) = 2 * \rho(sqrt(s)), because s = r^2 and r = sqrt(s).
+    std::transform(residuals_.begin(), residuals_.end(), std::back_inserter(influence),
+                   [&loss_function](const auto& r) {  // NOLINT(whitespace/braces)
+                     double rho[3];
+                     loss_function->Evaluate(r * r, rho);
+                     return r * rho[1];
+                   });  // NOLINT(whitespace/braces)
+
+    return influence;
+  }
+
+  std::vector<double> weight(const ceres::LossFunction* loss_function) const
+  {
+    std::vector<double> weight;
+    weight.reserve(residuals_.size());
+
+    // The weight is defined as the influence divided by the residual r:
+    //
+    //   w(r) = \phi(r) / r
+    //
+    // Since the loss functions we use are like Ceres solver ones, we have:
+    //
+    //              d rho(s)       d rho(s)
+    //   w(r) = r * -------- / r = --------
+    //                 ds             ds
+    //
+    // That is, rho[1].
+    std::transform(residuals_.begin(), residuals_.end(), std::back_inserter(weight),
+                   [&loss_function](const auto& r) {  // NOLINT(whitespace/braces)
+                     double rho[3];
+                     loss_function->Evaluate(r * r, rho);
+                     return rho[1];
+                   });  // NOLINT(whitespace/braces)
+
+    return weight;
+  }
+
+  std::vector<double> secondDerivative(const ceres::LossFunction* loss_function) const
+  {
+    std::vector<double> second_derivative;
+    second_derivative.reserve(residuals_.size());
+
+    // The second derivative is defined as:
+    //
+    //   d^2 rho(s)
+    //   ----------
+    //      ds^2
+    //
+    // That is, rho[2].
+    std::transform(residuals_.begin(), residuals_.end(), std::back_inserter(second_derivative),
+                   [&loss_function](const auto& r) {  // NOLINT(whitespace/braces)
+                     double rho[3];
+                     loss_function->Evaluate(r * r, rho);
+                     return rho[2];
+                   });  // NOLINT(whitespace/braces)
+
+    return second_derivative;
+  }
+
+  const std::vector<double>& getResiduals() const
+  {
+    return residuals_;
+  }
+
+private:
+  std::vector<double> residuals_;
+};
+
+class QwtLossPlot
+{
+public:
+  QwtLossPlot(const std::vector<double>& residuals, const HSVColormap& colormap)
+    : residuals_(QVector<double>::fromStdVector(residuals))
+    , loss_evaluator_(residuals)
+    , colormap_(colormap)
+    , magnifier_(plot_.canvas())
+    , zoomer_(plot_.canvas())
+    , panner_(plot_.canvas())
+  {
+    // Allocate one curve per colormap entry:
+    curves_.reserve(colormap_.size());
+
+    // Set background to white:
+    plot_.setCanvasBackground(Qt::white);
+
+    // Add grid:
+    grid_.setPen(Qt::lightGray, 0.0, Qt::DotLine);
+    grid_.attach(&plot_);
+
+    // Setup panner modifiers:
+    panner_.setMouseButton(Qt::LeftButton, Qt::ControlModifier);
+
+    // Add a legend:
+    plot_.insertLegend(&legend_);
+  }
+
+  void plotRho(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    const auto loss_type = loss->type();
+
+    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+
+    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.rho(loss->lossFunction())));
+
+    curve->setPen(colormap_[curves_.size()]);
+    curve->attach(&plot_);
+
+    curves_.push_back(curve);
+  }
+
+  void plotInfluence(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    const auto loss_type = loss->type();
+
+    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+
+    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.influence(loss->lossFunction())));
+
+    curve->setPen(colormap_[curves_.size()]);
+    curve->attach(&plot_);
+
+    curves_.push_back(curve);
+  }
+
+  void plotWeight(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    const auto loss_type = loss->type();
+
+    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+
+    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.weight(loss->lossFunction())));
+
+    curve->setPen(colormap_[curves_.size()]);
+    curve->attach(&plot_);
+
+    curves_.push_back(curve);
+  }
+
+  void plotSecondDerivative(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    const auto loss_type = loss->type();
+
+    QwtPlotCurve* curve = new QwtPlotCurve(loss_type.substr(11, loss_type.size() - 15).c_str());
+
+    curve->setSamples(residuals_,
+                      QVector<double>::fromStdVector(loss_evaluator_.secondDerivative(loss->lossFunction())));
+
+    curve->setPen(colormap_[curves_.size()]);
+    curve->attach(&plot_);
+
+    curves_.push_back(curve);
+  }
+
+  void save(const std::string& filename)
+  {
+    QwtPlotRenderer renderer;
+    renderer.renderDocument(&plot_, filename.c_str(), QSizeF(300, 200));
+  }
+
+  QwtPlot& plot()
+  {
+    return plot_;
+  }
+
+private:
+  QVector<double> residuals_;
+  LossEvaluator loss_evaluator_;
+
+  HSVColormap colormap_;
+  // We don't use an std::shared_ptr<QwtPlotCurve> because QwtPlot takes ownership of the curves attached to it and
+  // deletes them on destruction
+  std::vector<QwtPlotCurve*> curves_;
+
+  QwtPlot plot_;
+  QwtPlotGrid grid_;
+  QwtLegend legend_;
+  QwtPlotMagnifier magnifier_;
+  QwtPlotZoomer zoomer_;
+  QwtPlotPanner panner_;
+};
+
+}  // namespace fuse_loss
+
+#endif  // FUSE_LOSS_QWT_LOSS_PLOT_H

--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -248,53 +248,36 @@ public:
     return type.substr(11, type.size() - 15);
   }
 
-  void plotRho(const std::shared_ptr<fuse_core::Loss>& loss)
+  QwtPlotCurve* createCurve(const std::string& name, const std::vector<double>& values)
   {
-    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
+    QwtPlotCurve* curve = new QwtPlotCurve(name.c_str());
 
-    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.rho(loss->lossFunction())));
+    curve->setSamples(residuals_, QVector<double>::fromStdVector(values));
 
     curve->setPen(colormap_[curves_.size()]);
     curve->attach(&plot_);
 
-    curves_.push_back(curve);
+    return curve;
+  }
+
+  void plotRho(const std::shared_ptr<fuse_core::Loss>& loss)
+  {
+    curves_.push_back(createCurve(getName(loss->type()), loss_evaluator_.rho(loss->lossFunction())));
   }
 
   void plotInfluence(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
-
-    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.influence(loss->lossFunction())));
-
-    curve->setPen(colormap_[curves_.size()]);
-    curve->attach(&plot_);
-
-    curves_.push_back(curve);
+    curves_.push_back(createCurve(getName(loss->type()), loss_evaluator_.influence(loss->lossFunction())));
   }
 
   void plotWeight(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
-
-    curve->setSamples(residuals_, QVector<double>::fromStdVector(loss_evaluator_.weight(loss->lossFunction())));
-
-    curve->setPen(colormap_[curves_.size()]);
-    curve->attach(&plot_);
-
-    curves_.push_back(curve);
+    curves_.push_back(createCurve(getName(loss->type()), loss_evaluator_.weight(loss->lossFunction())));
   }
 
   void plotSecondDerivative(const std::shared_ptr<fuse_core::Loss>& loss)
   {
-    QwtPlotCurve* curve = new QwtPlotCurve(getName(loss->type()).c_str());
-
-    curve->setSamples(residuals_,
-                      QVector<double>::fromStdVector(loss_evaluator_.secondDerivative(loss->lossFunction())));
-
-    curve->setPen(colormap_[curves_.size()]);
-    curve->attach(&plot_);
-
-    curves_.push_back(curve);
+    curves_.push_back(createCurve(getName(loss->type()), loss_evaluator_.secondDerivative(loss->lossFunction())));
   }
 
   void save(const std::string& filename)

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -12,10 +12,14 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
+
+  <test_depend>qtbase5-dev</test_depend>
+  <test_depend>libqwt-qt5-dev</test_depend>
   <test_depend>roslint</test_depend>
 
   <export>

--- a/fuse_loss/test/test_qwt_loss_plot.cpp
+++ b/fuse_loss/test/test_qwt_loss_plot.cpp
@@ -1,0 +1,204 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_loss/arctan_loss.h>
+#include <fuse_loss/cauchy_loss.h>
+#include <fuse_loss/dcs_loss.h>
+#include <fuse_loss/fair_loss.h>
+#include <fuse_loss/geman_mcclure_loss.h>
+#include <fuse_loss/huber_loss.h>
+#include <fuse_loss/softlone_loss.h>
+#include <fuse_loss/tolerant_loss.h>
+#include <fuse_loss/trivial_loss.h>
+#include <fuse_loss/tukey_loss.h>
+#include <fuse_loss/welsch_loss.h>
+
+#include <fuse_loss/qwt_loss_plot.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+
+#include <vector>
+
+
+class QwtLossPlotTest : public testing::Test
+{
+public:
+  QwtLossPlotTest()
+  {
+    // Generate samples:
+    const double step{ 0.01 };
+    const size_t half_samples{ 1000 };
+    const double x_min = -(half_samples * step);
+
+    const size_t samples{ 2 * half_samples + 1 };
+
+    residuals.reserve(samples);
+
+    for (size_t i = 0; i < samples; ++i)
+    {
+      residuals.push_back(x_min + i * step);
+    }
+  }
+
+  std::vector<double> residuals;
+};
+
+TEST_F(QwtLossPlotTest, PlotLossQt)
+{
+  // Create losses
+  std::vector<std::shared_ptr<fuse_core::Loss>> losses{ {  // NOLINT(whitespace/braces)
+    std::make_shared<fuse_loss::ArctanLoss>(),
+    std::make_shared<fuse_loss::CauchyLoss>(),
+    std::make_shared<fuse_loss::DCSLoss>(),
+    std::make_shared<fuse_loss::FairLoss>(),
+    std::make_shared<fuse_loss::GemanMcClureLoss>(),
+    std::make_shared<fuse_loss::HuberLoss>(),
+    std::make_shared<fuse_loss::SoftLOneLoss>(),
+    std::make_shared<fuse_loss::TolerantLoss>(),
+    std::make_shared<fuse_loss::TrivialLoss>(),
+    std::make_shared<fuse_loss::TukeyLoss>(),
+    std::make_shared<fuse_loss::WelschLoss>()
+  } };
+
+  // Create a Qt application:
+  int argc = 0;
+  QApplication app(argc, nullptr);
+
+  auto palette = app.palette();
+  palette.setColor(QPalette::Window, Qt::white);
+  app.setPalette(palette);
+
+  // Create a loss plot for the rho function:
+  fuse_loss::HSVColormap colormap(losses.size());
+  fuse_loss::QwtLossPlot rho_loss_plot(residuals, colormap);
+
+  auto& plot = rho_loss_plot.plot();
+  plot.setTitle("rho function");
+  plot.setAxisTitle(QwtPlot::xBottom, "r");
+  plot.setAxisTitle(QwtPlot::yLeft, "rho(r)");
+  plot.setAxisScale(QwtPlot::yLeft, 0.0, 15.0);
+
+  // Create a curve for each loss rho function:
+  for (const auto& loss : losses)
+  {
+    rho_loss_plot.plotRho(loss);
+  }
+
+  plot.replot();
+
+  // Create a loss plot for the influence function:
+  fuse_loss::QwtLossPlot influence_loss_plot(residuals, colormap);
+
+  auto& influence_plot = influence_loss_plot.plot();
+  influence_plot.setTitle("influence");
+
+  influence_plot.setAxisTitle(QwtPlot::xBottom, "r");
+  influence_plot.setAxisTitle(QwtPlot::yLeft, "phi(r) = r * rho'(r)");
+  influence_plot.setAxisScale(QwtPlot::yLeft, -3.0, 3.0);
+
+  // Create a curve for each loss rho function:
+  for (const auto& loss : losses)
+  {
+    influence_loss_plot.plotInfluence(loss);
+  }
+
+  influence_plot.replot();
+
+  // Create a loss plot for the weight function:
+  fuse_loss::QwtLossPlot weight_loss_plot(residuals, colormap);
+
+  auto& weight_plot = weight_loss_plot.plot();
+  weight_plot.setTitle("weight");
+
+  weight_plot.setAxisTitle(QwtPlot::xBottom, "r");
+  weight_plot.setAxisTitle(QwtPlot::yLeft, "w(r) = rho'(r)");
+  weight_plot.setAxisScale(QwtPlot::yLeft, 0.0, 1.5);
+
+  // Create a curve for each loss rho function:
+  for (const auto& loss : losses)
+  {
+    weight_loss_plot.plotWeight(loss);
+  }
+
+  weight_plot.replot();
+
+  // Create a loss plot for the second derivative function:
+  fuse_loss::QwtLossPlot second_derivative_loss_plot(residuals, colormap);
+
+  auto& second_derivative_plot = second_derivative_loss_plot.plot();
+  second_derivative_plot.setTitle("2nd derivative");
+
+  second_derivative_plot.setAxisTitle(QwtPlot::xBottom, "r");
+  second_derivative_plot.setAxisTitle(QwtPlot::yLeft, "rho''(r)");
+  second_derivative_plot.setAxisScale(QwtPlot::yLeft, -0.15, 0.15);
+
+  // Create a curve for each loss rho function:
+  for (const auto& loss : losses)
+  {
+    second_derivative_loss_plot.plotSecondDerivative(loss);
+  }
+
+  second_derivative_plot.replot();
+
+#ifdef INTERACTIVE_TESTS
+  plot.show();
+  influence_plot.show();
+  weight_plot.show();
+  second_derivative_plot.show();
+#endif
+
+  // Save as an SVG image, that can be converted to PNG with (e.g. for the weight function SVG image file):
+  //
+  //   inkscape -z -e weight.png weight.svg
+  //
+  // In principle, we could use ImageMagick as well, but it might fail:
+  //
+  //   convert weight.svg weight.png
+  rho_loss_plot.save("rho.svg");
+  influence_loss_plot.save("influence.svg");
+  weight_loss_plot.save("weight.svg");
+  second_derivative_loss_plot.save("second_derivative.svg");
+
+#ifdef INTERACTIVE_TESTS
+  // Run application:
+  app.exec();
+#endif
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This adds a test that plots the loss functions `\rho`, influence (`\phi`) and weight functions, as explained in 

The test doesn't really perform any check, but it simply generates the plots, which are useful to understand how the loss functions look like. The fact that the plots are generated (saved as SVG files) is considered as the test not failing, in the sense that it didn't crashed. I couldn't think of a better way to get this in, but I'm open to suggestions.

The plots look like this:

| Function | Plot |
| ------------ | ------ |
| `\rho` | ![rho](https://user-images.githubusercontent.com/382167/74479218-12ceaf80-4eaf-11ea-8ff8-61efca0ef456.png) |
| influence (`\phi`)      | ![influence](https://user-images.githubusercontent.com/382167/74479236-195d2700-4eaf-11ea-81d7-2f57a8a16bf9.png) |
| weight     | ![weight](https://user-images.githubusercontent.com/382167/74479249-1eba7180-4eaf-11ea-8e24-08179c624edb.png) |

As mentioned in https://github.com/locusrobotics/fuse/pull/141, you can see the `TukeyLoss` weight function doesn't reach `1` when the residual `r == 0`. In fact, it reaches `0.5`. This is because I believe it has a bug and it should be multiplied by `2`.

There's a cmake option called `BUILD_WITH_INTERACTIVE_TESTS` that defaults to `OFF`. In this cases it only saves the plots as SVG. When it's turned `ON`, the plots are also shown in Qt windows, so you can zoom and pan to inspect them.

This PR is on top of https://github.com/locusrobotics/fuse/pull/142