### PR TITLE
Visualize loss

### DIFF
--- a/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_property.h
+++ b/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_property.h
@@ -106,8 +106,7 @@ private Q_SLOTS:
   void updateColor();
   void updateErrorLineAlpha();
   void updateErrorLineWidth();
-  void updateLossErrorLineAlpha();
-  void updateLossErrorLineWidth();
+  void updateLossMinBrightness();
   void updateRelativePoseAxesAlpha();
   void updateRelativePoseAxesScale();
   void updateRelativePoseLineAlpha();
@@ -119,8 +118,7 @@ private:
   void updateColor(const VisualPtr& constraint);
   void updateErrorLineAlpha(const VisualPtr& constraint);
   void updateErrorLineWidth(const VisualPtr& constraint);
-  void updateLossErrorLineAlpha(const VisualPtr& constraint);
-  void updateLossErrorLineWidth(const VisualPtr& constraint);
+  void updateLossMinBrightness(const VisualPtr& constraint);
   void updateRelativePoseAxesAlpha(const VisualPtr& constraint);
   void updateRelativePoseAxesScale(const VisualPtr& constraint);
   void updateRelativePoseLineAlpha(const VisualPtr& constraint);
@@ -140,8 +138,7 @@ private:
   FloatProperty* relative_pose_line_width_property_;
   FloatProperty* error_line_alpha_property_;
   FloatProperty* error_line_width_property_;
-  FloatProperty* loss_error_line_alpha_property_;
-  FloatProperty* loss_error_line_width_property_;
+  FloatProperty* loss_min_brightness_property_;
   MappedCovarianceProperty* covariance_property_;
 };
 

--- a/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_property.h
+++ b/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_property.h
@@ -106,6 +106,8 @@ private Q_SLOTS:
   void updateColor();
   void updateErrorLineAlpha();
   void updateErrorLineWidth();
+  void updateLossErrorLineAlpha();
+  void updateLossErrorLineWidth();
   void updateRelativePoseAxesAlpha();
   void updateRelativePoseAxesScale();
   void updateRelativePoseLineAlpha();
@@ -117,6 +119,8 @@ private:
   void updateColor(const VisualPtr& constraint);
   void updateErrorLineAlpha(const VisualPtr& constraint);
   void updateErrorLineWidth(const VisualPtr& constraint);
+  void updateLossErrorLineAlpha(const VisualPtr& constraint);
+  void updateLossErrorLineWidth(const VisualPtr& constraint);
   void updateRelativePoseAxesAlpha(const VisualPtr& constraint);
   void updateRelativePoseAxesScale(const VisualPtr& constraint);
   void updateRelativePoseLineAlpha(const VisualPtr& constraint);
@@ -136,6 +140,8 @@ private:
   FloatProperty* relative_pose_line_width_property_;
   FloatProperty* error_line_alpha_property_;
   FloatProperty* error_line_width_property_;
+  FloatProperty* loss_error_line_alpha_property_;
+  FloatProperty* loss_error_line_width_property_;
   MappedCovarianceProperty* covariance_property_;
 };
 

--- a/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_visual.h
+++ b/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_visual.h
@@ -140,9 +140,13 @@ public:
 
   void setErrorLineWidth(const float line_width);
 
+  void setLossErrorLineWidth(const float line_width);
+
   void setRelativePoseLineColor(const float r, const float g, const float b, const float a);
 
   void setErrorLineColor(const float r, const float g, const float b, const float a);
+
+  void setLossErrorLineColor(const float r, const float g, const float b, const float a);
 
   void setRelativePoseAxesAlpha(const float alpha);
 
@@ -188,11 +192,13 @@ private:
   Ogre::SceneNode* root_node_;
   Ogre::SceneNode* relative_pose_line_node_;
   Ogre::SceneNode* error_line_node_;
+  Ogre::SceneNode* loss_error_line_node_;
   Ogre::SceneNode* relative_pose_axes_node_;
   Ogre::SceneNode* text_node_;
 
   std::shared_ptr<BillboardLine> relative_pose_line_;
   std::shared_ptr<BillboardLine> error_line_;
+  std::shared_ptr<BillboardLine> loss_error_line_;
   std::shared_ptr<Axes> relative_pose_axes_;
   MovableText* text_;
   CovarianceVisualPtr covariance_;

--- a/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_visual.h
+++ b/fuse_viz/include/fuse_viz/relative_pose_2d_stamped_constraint_visual.h
@@ -140,13 +140,11 @@ public:
 
   void setErrorLineWidth(const float line_width);
 
-  void setLossErrorLineWidth(const float line_width);
+  void setLossMinBrightness(const float min_brightness);
 
   void setRelativePoseLineColor(const float r, const float g, const float b, const float a);
 
   void setErrorLineColor(const float r, const float g, const float b, const float a);
-
-  void setLossErrorLineColor(const float r, const float g, const float b, const float a);
 
   void setRelativePoseAxesAlpha(const float alpha);
 
@@ -192,17 +190,19 @@ private:
   Ogre::SceneNode* root_node_;
   Ogre::SceneNode* relative_pose_line_node_;
   Ogre::SceneNode* error_line_node_;
-  Ogre::SceneNode* loss_error_line_node_;
   Ogre::SceneNode* relative_pose_axes_node_;
   Ogre::SceneNode* text_node_;
 
   std::shared_ptr<BillboardLine> relative_pose_line_;
   std::shared_ptr<BillboardLine> error_line_;
-  std::shared_ptr<BillboardLine> loss_error_line_;
   std::shared_ptr<Axes> relative_pose_axes_;
   MovableText* text_;
   CovarianceVisualPtr covariance_;
   std::string source_;
+
+  float loss_scale_{ -1.0 };
+  float min_brightness_{ 0.0 };
+  Ogre::ColourValue error_line_color_;
 
   bool visible_;
 
@@ -213,6 +213,8 @@ private:
   void setColor(float r, float g, float b, float a) override{};
   const Ogre::Vector3& getPosition() override;
   const Ogre::Quaternion& getOrientation() override;
+
+  Ogre::ColourValue computeLossErrorLineColor(const Ogre::ColourValue& color, const float loss_scale);
 
   // Make RelativePose2DStampedConstraintProperty friend class so it create RelativePose2DStampedConstraintVisual
   // objects

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_property.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_property.cpp
@@ -88,6 +88,17 @@ RelativePose2DStampedConstraintProperty::RelativePose2DStampedConstraintProperty
                                                  SLOT(updateErrorLineWidth()));
   error_line_width_property_->setMin(0.0);
 
+  loss_error_line_alpha_property_ =
+      new FloatProperty("Loss Error Line Alpha", 0.75, "Alpha of constraint error line scaled by loss cost.", this,
+                        SLOT(updateLossErrorLineAlpha()));
+  loss_error_line_alpha_property_->setMin(0.0);
+  loss_error_line_alpha_property_->setMax(1.0);
+
+  loss_error_line_width_property_ =
+      new FloatProperty("Loss Error Line Width", 0.5, "Line width of constraint error line scaled by loss cost.", this,
+                        SLOT(updateLossErrorLineWidth()));
+  loss_error_line_width_property_->setMin(0.0);
+
   show_text_property_ =
       new BoolProperty("Show Text", false, "Show constraint source, type and UUID.", this, SLOT(updateShowText()));
 
@@ -130,6 +141,8 @@ RelativePose2DStampedConstraintProperty::VisualPtr RelativePose2DStampedConstrai
   updateColor(visual);
   updateErrorLineAlpha(visual);
   updateErrorLineWidth(visual);
+  updateLossErrorLineAlpha(visual);
+  updateLossErrorLineWidth(visual);
   updateRelativePoseAxesAlpha(visual);
   updateRelativePoseAxesScale(visual);
   updateRelativePoseLineAlpha(visual);
@@ -187,6 +200,22 @@ void RelativePose2DStampedConstraintProperty::updateErrorLineWidth()
   for (auto& entry : constraints_)
   {
     updateErrorLineWidth(entry.second);
+  }
+}
+
+void RelativePose2DStampedConstraintProperty::updateLossErrorLineAlpha()
+{
+  for (auto& entry : constraints_)
+  {
+    updateLossErrorLineAlpha(entry.second);
+  }
+}
+
+void RelativePose2DStampedConstraintProperty::updateLossErrorLineWidth()
+{
+  for (auto& entry : constraints_)
+  {
+    updateLossErrorLineWidth(entry.second);
   }
 }
 
@@ -257,6 +286,19 @@ void RelativePose2DStampedConstraintProperty::updateErrorLineAlpha(const VisualP
 void RelativePose2DStampedConstraintProperty::updateErrorLineWidth(const VisualPtr& constraint)
 {
   constraint->setErrorLineWidth(error_line_width_property_->getFloat());
+}
+
+void RelativePose2DStampedConstraintProperty::updateLossErrorLineAlpha(const VisualPtr& constraint)
+{
+  const auto color = color_property_->getColor();
+
+  constraint->setLossErrorLineColor(color.redF(), color.greenF(), color.blueF(),
+                                    loss_error_line_alpha_property_->getFloat());
+}
+
+void RelativePose2DStampedConstraintProperty::updateLossErrorLineWidth(const VisualPtr& constraint)
+{
+  constraint->setLossErrorLineWidth(loss_error_line_width_property_->getFloat());
 }
 
 void RelativePose2DStampedConstraintProperty::updateRelativePoseAxesAlpha(const VisualPtr& constraint)

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_property.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_property.cpp
@@ -88,16 +88,12 @@ RelativePose2DStampedConstraintProperty::RelativePose2DStampedConstraintProperty
                                                  SLOT(updateErrorLineWidth()));
   error_line_width_property_->setMin(0.0);
 
-  loss_error_line_alpha_property_ =
-      new FloatProperty("Loss Error Line Alpha", 0.75, "Alpha of constraint error line scaled by loss cost.", this,
-                        SLOT(updateLossErrorLineAlpha()));
-  loss_error_line_alpha_property_->setMin(0.0);
-  loss_error_line_alpha_property_->setMax(1.0);
-
-  loss_error_line_width_property_ =
-      new FloatProperty("Loss Error Line Width", 0.5, "Line width of constraint error line scaled by loss cost.", this,
-                        SLOT(updateLossErrorLineWidth()));
-  loss_error_line_width_property_->setMin(0.0);
+  loss_min_brightness_property_ = new FloatProperty("Loss Min Brightness", 0.25,
+                                                    "Min brightness to show the loss impact on the constraint error "
+                                                    "line.",
+                                                    this, SLOT(updateLossMinBrightness()));
+  loss_min_brightness_property_->setMin(0.0);
+  loss_min_brightness_property_->setMax(1.0);
 
   show_text_property_ =
       new BoolProperty("Show Text", false, "Show constraint source, type and UUID.", this, SLOT(updateShowText()));
@@ -141,8 +137,7 @@ RelativePose2DStampedConstraintProperty::VisualPtr RelativePose2DStampedConstrai
   updateColor(visual);
   updateErrorLineAlpha(visual);
   updateErrorLineWidth(visual);
-  updateLossErrorLineAlpha(visual);
-  updateLossErrorLineWidth(visual);
+  updateLossMinBrightness(visual);
   updateRelativePoseAxesAlpha(visual);
   updateRelativePoseAxesScale(visual);
   updateRelativePoseLineAlpha(visual);
@@ -203,19 +198,11 @@ void RelativePose2DStampedConstraintProperty::updateErrorLineWidth()
   }
 }
 
-void RelativePose2DStampedConstraintProperty::updateLossErrorLineAlpha()
+void RelativePose2DStampedConstraintProperty::updateLossMinBrightness()
 {
   for (auto& entry : constraints_)
   {
-    updateLossErrorLineAlpha(entry.second);
-  }
-}
-
-void RelativePose2DStampedConstraintProperty::updateLossErrorLineWidth()
-{
-  for (auto& entry : constraints_)
-  {
-    updateLossErrorLineWidth(entry.second);
+    updateLossMinBrightness(entry.second);
   }
 }
 
@@ -288,17 +275,11 @@ void RelativePose2DStampedConstraintProperty::updateErrorLineWidth(const VisualP
   constraint->setErrorLineWidth(error_line_width_property_->getFloat());
 }
 
-void RelativePose2DStampedConstraintProperty::updateLossErrorLineAlpha(const VisualPtr& constraint)
+void RelativePose2DStampedConstraintProperty::updateLossMinBrightness(const VisualPtr& constraint)
 {
-  const auto color = color_property_->getColor();
+  constraint->setLossMinBrightness(loss_min_brightness_property_->getFloat());
 
-  constraint->setLossErrorLineColor(color.redF(), color.greenF(), color.blueF(),
-                                    loss_error_line_alpha_property_->getFloat());
-}
-
-void RelativePose2DStampedConstraintProperty::updateLossErrorLineWidth(const VisualPtr& constraint)
-{
-  constraint->setLossErrorLineWidth(loss_error_line_width_property_->getFloat());
+  updateErrorLineAlpha(constraint);
 }
 
 void RelativePose2DStampedConstraintProperty::updateRelativePoseAxesAlpha(const VisualPtr& constraint)

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -50,6 +50,8 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
+#include <algorithm>
+
 namespace rviz
 {
 
@@ -72,12 +74,6 @@ RelativePose2DStampedConstraintVisual::RelativePose2DStampedConstraintVisual(
   error_line_ = std::make_shared<BillboardLine>(scene_manager_, error_line_node_);
   error_line_->setMaxPointsPerLine(2);
   error_line_->setNumLines(1);
-
-  // Create constraint loss error line:
-  loss_error_line_node_ = root_node_->createChildSceneNode();
-  loss_error_line_ = std::make_shared<BillboardLine>(scene_manager_, loss_error_line_node_);
-  loss_error_line_->setMaxPointsPerLine(2);
-  loss_error_line_->setNumLines(1);
 
   // Create constraint relative pose axes:
   relative_pose_axes_node_ = root_node_->createChildSceneNode();
@@ -104,7 +100,6 @@ RelativePose2DStampedConstraintVisual::~RelativePose2DStampedConstraintVisual()
   delete text_;
   scene_manager_->destroySceneNode(relative_pose_line_node_->getName());
   scene_manager_->destroySceneNode(error_line_node_->getName());
-  scene_manager_->destroySceneNode(loss_error_line_node_->getName());
   scene_manager_->destroySceneNode(relative_pose_axes_node_->getName());
   scene_manager_->destroySceneNode(text_node_->getName());
   scene_manager_->destroySceneNode(root_node_->getName());
@@ -145,9 +140,7 @@ void RelativePose2DStampedConstraintVisual::setConstraint(
   error_line_->addPoint(absolute_position_ogre);
   error_line_->addPoint(toOgre(pose2.getOrigin()));
 
-  // Update constraint loss error line:
-  loss_error_line_->clear();
-
+  // Set error line color brightness based on the loss function impact on the constraint cost:
   auto loss_function = constraint.lossFunction();
   if (loss_function)
   {
@@ -194,12 +187,12 @@ void RelativePose2DStampedConstraintVisual::setConstraint(
     //
     // Remember that in principle `rho[0] <= squared_norm`, with `rho[0] == squared_norm` for the inlier region, and
     // `rho[0] < squared_norm` for the outlier region:
-    const auto loss_scale = squared_norm == 0.0 ? 0.0 : rho[0] / squared_norm;
+    loss_scale_ = squared_norm == 0.0 ? 0.0 : rho[0] / squared_norm;
 
-    const auto loss_position = absolute_pose.getOrigin().lerp(pose2.getOrigin(), loss_scale);
-
-    loss_error_line_->addPoint(absolute_position_ogre);
-    loss_error_line_->addPoint(toOgre(loss_position));
+    // Compute error line color with the loss function impact:
+    const auto loss_error_line_color = computeLossErrorLineColor(error_line_color_, loss_scale_);
+    error_line_->setColor(loss_error_line_color.r, loss_error_line_color.g, loss_error_line_color.b,
+                          error_line_color_.a);
   }
 
   // Update constraint relative pose axes:
@@ -214,7 +207,6 @@ void RelativePose2DStampedConstraintVisual::setUserData(const Ogre::Any& data)
 {
   relative_pose_line_->setUserData(data);
   error_line_->setUserData(data);
-  loss_error_line_->setUserData(data);
   relative_pose_axes_->setUserData(data);
   covariance_->setUserData(data);
 }
@@ -229,9 +221,9 @@ void RelativePose2DStampedConstraintVisual::setErrorLineWidth(const float line_w
   error_line_->setLineWidth(line_width);
 }
 
-void RelativePose2DStampedConstraintVisual::setLossErrorLineWidth(const float line_width)
+void RelativePose2DStampedConstraintVisual::setLossMinBrightness(const float min_brightness)
 {
-  loss_error_line_->setLineWidth(line_width);
+  min_brightness_ = min_brightness;
 }
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseLineColor(const float r, const float g, const float b,
@@ -243,13 +235,19 @@ void RelativePose2DStampedConstraintVisual::setRelativePoseLineColor(const float
 void RelativePose2DStampedConstraintVisual::setErrorLineColor(const float r, const float g, const float b,
                                                               const float a)
 {
-  error_line_->setColor(r, g, b, a);
-}
+  // Cache error line color w/o the loss function impact, so we can change its darkness based on the loss function
+  // impact on the constraint cost:
+  // Note that we cannot recover/retrieve the color from the Ogre::BillboarrdLine error_line_ because its API does NOT
+  // support that.
+  error_line_color_.r = r;
+  error_line_color_.g = g;
+  error_line_color_.b = b;
+  error_line_color_.a = a;
 
-void RelativePose2DStampedConstraintVisual::setLossErrorLineColor(const float r, const float g, const float b,
-                                                                  const float a)
-{
-  loss_error_line_->setColor(r, g, b, a);
+  // Compute error line color with the impact of the loss function, in case the constraint has one:
+  const auto loss_error_line_color = computeLossErrorLineColor(error_line_color_, loss_scale_);
+  error_line_->setColor(loss_error_line_color.r, loss_error_line_color.r, loss_error_line_color.b,
+                        loss_error_line_color.a);
 }
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseAxesAlpha(const float alpha)
@@ -285,7 +283,6 @@ void RelativePose2DStampedConstraintVisual::setVisible(const bool visible)
 {
   relative_pose_line_node_->setVisible(visible);
   error_line_node_->setVisible(visible);
-  loss_error_line_node_->setVisible(visible);
   relative_pose_axes_node_->setVisible(visible);
 }
 
@@ -307,6 +304,37 @@ void RelativePose2DStampedConstraintVisual::setPosition(const Ogre::Vector3& pos
 void RelativePose2DStampedConstraintVisual::setOrientation(const Ogre::Quaternion& orientation)
 {
   root_node_->setOrientation(orientation);
+}
+
+Ogre::ColourValue RelativePose2DStampedConstraintVisual::computeLossErrorLineColor(const Ogre::ColourValue& color,
+                                                                                   const float loss_scale)
+{
+  // Skip if the loss scale is negative, which means the constraint has no loss:
+  if (loss_scale < 0.0)
+  {
+    return color;
+  }
+
+  // Get the error line color as HSB:
+  Ogre::ColourValue error_line_color(color.r, color.g, color.b);
+  Ogre::Real hue, saturation, brightness;
+  error_line_color.getHSB(&hue, &saturation, &brightness);
+
+  // We should correct the color brightness if it is smaller than minimum brightness. Otherwise, we would get an
+  // incorrect loss brightness.
+  //
+  // However, we cannot do this because it changes the color of the error line, which should be consistent for all
+  // constraints visuals. Instead, we clamp the minium brightness:
+  const auto min_brightness = std::min(min_brightness_, brightness);
+
+  // Scale brightness by the loss scale within the [min_brightness, 1] range:
+  const auto loss_brightness = min_brightness + (brightness - min_brightness) * loss_scale;
+
+  // Set error line color with the loss brightness:
+  Ogre::ColourValue loss_error_line_color;
+  loss_error_line_color.setHSB(hue, saturation, loss_brightness);
+
+  return Ogre::ColourValue(loss_error_line_color.r, loss_error_line_color.g, loss_error_line_color.b, color.a);
 }
 
 }  // namespace rviz


### PR DESCRIPTION
This PR shows the impact of a loss function into the constraint cost in the rviz display plugin for the graph.

There are two commits because the first one implements a different visualization approach I explain later. The second commit implements the final approach, that is explained below.

The error line brightness is scaled by the quotient of the constraint cost with and without loss, as it's explained in the code). This way, a dark error line means the cost is reduced significantly by the loss function, which is the expected behaviour when we get outliers, as shown in the screenshot below:

![74250011-4e6c4c80-4cea-11ea-87e1-14f6d849bef1](https://user-images.githubusercontent.com/382167/74550377-917c2900-4f51-11ea-89a0-78bf17009bdd.png)

The alternative visualization approach consisted on splitting the error line in two, using the aforementioned quotient to scaled the length of the line that belong to the loss and the rest. In this case, we'd get something like this:

![74046263-86178380-49ce-11ea-976e-3e23478ea74b](https://user-images.githubusercontent.com/382167/74550620-f899dd80-4f51-11ea-8c91-1d8e281f6c0e.png)

I used a different width in order to distinguish one segment from the other. They're highlighted in the next image:

![74214809-36bba680-4c9f-11ea-8158-6a4c9d417861](https://user-images.githubusercontent.com/382167/74550698-15ceac00-4f52-11ea-9942-300178111f78.png)

I'm open to suggestion and comments regarding the two approaches and whether you think the one I'm going with at the end is better or worse than the previous one (last one explained here). Or maybe I should combine them, but I'm quite happy with the end result for now.