### PR TITLE
Use transaction stamp in SerializedPublisher

### DIFF
--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -70,7 +70,7 @@ void SerializedPublisher::notifyCallback(
   fuse_core::Transaction::ConstSharedPtr transaction,
   fuse_core::Graph::ConstSharedPtr graph)
 {
-  auto stamp = ros::Time::now();
+  const auto& stamp = transaction->stamp();
   if (graph_publisher_.getNumSubscribers() > 0)
   {
     fuse_msgs::SerializedGraph msg;


### PR DESCRIPTION
By using the transaction stamp instead of `ros::Time::now()` it's
possible to replay things with the same transaction and compare the
original and new generated graphs.