### PR TITLE
Const deserialize

### DIFF
--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -73,7 +73,7 @@ public:
    * @param[in]  msg  The SerializedGraph message to be deserialized
    * @return          A unique_ptr to a derived Graph object
    */
-  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg);
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg) const;
 
   /**
    * @brief Deserialize a SerializedGraph message into a fuse Graph object.
@@ -84,13 +84,15 @@ public:
    * @param[in]  msg  The SerializedGraph message to be deserialized
    * @return          A unique_ptr to a derived Graph object
    */
-  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg);
+  fuse_core::Graph::UniquePtr deserialize(const fuse_msgs::SerializedGraph& msg) const;
 
 private:
   pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;      //!< Pluginlib class loader for Variable types
   pluginlib::ClassLoader<fuse_core::Constraint> constraint_loader_;  //!< Pluginlib class loader for Constraint types
   pluginlib::ClassLoader<fuse_core::Loss> loss_loader_;              //!< Pluginlib class loader for Loss types
-  pluginlib::ClassLoader<fuse_core::Graph> graph_loader_;            //!< Pluginlib class loader for Graph types
+  // TODO(efernandez) Try to make pluginlib::ClassLoader<T>::createUnmanagedInstance() method const, so we can remove
+  // the mutable modifier here and still have the deserialize methods const
+  mutable pluginlib::ClassLoader<fuse_core::Graph> graph_loader_;    //!< Pluginlib class loader for Graph types
 };
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/transaction_deserializer.h
+++ b/fuse_core/include/fuse_core/transaction_deserializer.h
@@ -73,7 +73,7 @@ public:
    * @param[IN]  msg  The SerializedTransaction message to be deserialized
    * @return          A fuse Transaction object
    */
-  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg);
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg) const;
 
   /**
    * @brief Deserialize a SerializedTransaction message into a fuse Transaction object.
@@ -84,7 +84,7 @@ public:
    * @param[IN]  msg  The SerializedTransaction message to be deserialized
    * @return          A fuse Transaction object
    */
-  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction& msg);
+  fuse_core::Transaction deserialize(const fuse_msgs::SerializedTransaction& msg) const;
 
 private:
   pluginlib::ClassLoader<fuse_core::Variable> variable_loader_;      //!< Pluginlib class loader for Variable types

--- a/fuse_core/src/graph_deserializer.cpp
+++ b/fuse_core/src/graph_deserializer.cpp
@@ -78,12 +78,12 @@ GraphDeserializer::GraphDeserializer() :
   }
 }
 
-fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph::ConstPtr& msg) const
 {
   return deserialize(*msg);
 }
 
-fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph& msg)
+fuse_core::Graph::UniquePtr GraphDeserializer::deserialize(const fuse_msgs::SerializedGraph& msg) const
 {
   // Create a Graph object using pluginlib. This will throw if the plugin name is not found.
   // The unique ptr returned by pluginlib has a custom deleter. This makes it annoying to return

--- a/fuse_core/src/transaction_deserializer.cpp
+++ b/fuse_core/src/transaction_deserializer.cpp
@@ -75,12 +75,12 @@ TransactionDeserializer::TransactionDeserializer() :
   }
 }
 
-fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction::ConstPtr& msg) const
 {
   return deserialize(*msg);
 }
 
-fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction& msg)
+fuse_core::Transaction TransactionDeserializer::deserialize(const fuse_msgs::SerializedTransaction& msg) const
 {
   // The Transaction object is not a plugin and has no derived types. That makes it much easier to use.
   auto transaction = fuse_core::Transaction();


### PR DESCRIPTION
This makes the `fuse_core::GraphDeserializer` and `fuse_core::TransactionDeserializer` `deserialize` method `const`.

In the particular case of the `fuse_core::GraphDeserializer` I had to set the `graph_loader_` `mutable` for the reason explain in the code with a `TODO` comment. I think this is better than not making the methods `const`, because otherwise any method from another class using this deserializer cannot be `const`.