### PR TITLE
Fix Unicycle2DIgnition set_pose

### DIFF
--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -38,6 +38,7 @@
 #include <fuse_core/uuid.h>
 
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/empty.hpp>
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <suitesparse/ccolamd.h>

--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -150,6 +150,13 @@ public:
   const_uuid_range removedVariables() const { return removed_variables_; }
 
   /**
+   * @brief Check if the transaction is empty, i.e. it has no added or removed constraints or variables
+   *
+   * @return  True if the transaction is empty, false otherwise
+   */
+  bool empty() const;
+
+  /**
    * @brief Add a timestamp to the "involved stamps" collection
    *
    * Duplicate timestamps will be ignored, so adding a stamp multiple times will have no effect.

--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -150,7 +150,8 @@ public:
   const_uuid_range removedVariables() const { return removed_variables_; }
 
   /**
-   * @brief Check if the transaction is empty, i.e. it has no added or removed constraints or variables
+   * @brief Check if the transaction is empty, i.e. it has no added or removed constraints or variables, and no involved
+   * stamps
    *
    * @return  True if the transaction is empty, false otherwise
    */

--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -156,6 +156,11 @@ void TimestampManager::query(
     // Insert the last timestamp into the motion model history, but with no constraints. The last entry in the motion
     // model history will always contain no constraints.
     motion_model_history_.emplace(last_stamp, MotionModelSegment());
+
+    // Call the motion model generator so it inserts the last timestamp into its state history.
+    std::vector<Constraint::SharedPtr> constraints;
+    std::vector<Variable::SharedPtr> variables;
+    generator_(last_stamp, last_stamp, constraints, variables);
   }
   // Purge any old entries from the motion model history
   purgeHistory();

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -39,6 +39,7 @@
 #include <ros/time.h>
 
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/empty.hpp>
 
 #include <algorithm>
 #include <ostream>
@@ -125,6 +126,12 @@ Transaction::const_variable_range Transaction::addedVariables() const
   return const_variable_range(
     boost::make_transform_iterator(added_variables_.cbegin(), to_variable_ref),
     boost::make_transform_iterator(added_variables_.cend(), to_variable_ref));
+}
+
+bool Transaction::empty() const
+{
+  return boost::empty(added_variables_) && boost::empty(removed_variables_) && boost::empty(added_constraints_) &&
+         boost::empty(removed_constraints_);
 }
 
 void Transaction::addVariable(Variable::SharedPtr variable, bool overwrite)

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -130,8 +130,8 @@ Transaction::const_variable_range Transaction::addedVariables() const
 
 bool Transaction::empty() const
 {
-  return boost::empty(added_variables_) && boost::empty(removed_variables_) && boost::empty(added_constraints_) &&
-         boost::empty(removed_constraints_);
+  return boost::empty(added_variables_) && boost::empty(removed_variables_) &&
+         boost::empty(added_constraints_) && boost::empty(removed_constraints_) && involved_stamps_.empty();
 }
 
 void Transaction::addVariable(Variable::SharedPtr variable, bool overwrite)

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -542,7 +542,7 @@ TEST_F(TimestampManagerTestFixture, MultiSegment)
   ASSERT_EQ(0ul, generated_time_spans.size());
 }
 
-TEST_F(TimestampManagerTestFixture, MultiSegmentBeforBeginning)
+TEST_F(TimestampManagerTestFixture, MultiSegmentBeforeBeginning)
 {
   // Test:
   // Existing: |------111111112222222233333333-------> t

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -112,9 +112,12 @@ TEST_F(TimestampManagerTestFixture, Empty)
   EXPECT_EQ(ros::Time(20, 0), *stamp_range_iter);
 
   // Verify the expected queries were performed
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(20, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(20, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, Exceptions)
@@ -420,9 +423,12 @@ TEST_F(TimestampManagerTestFixture, AfterEndAligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
@@ -455,11 +461,14 @@ TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(3ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
+  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
@@ -492,13 +501,16 @@ TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(3ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(4ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(30, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[2].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[3].first);
+  EXPECT_EQ(generated_time_spans[3].first, generated_time_spans[3].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegment)
@@ -591,9 +603,12 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastEnd)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
@@ -626,11 +641,14 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(3ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(5, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
+  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, SplitBeginning)

--- a/fuse_core/test/test_transaction.cpp
+++ b/fuse_core/test/test_transaction.cpp
@@ -288,6 +288,68 @@ bool testRemovedVariables(const UuidRange& expected, const Transaction& transact
   return true;
 }
 
+TEST(Transaction, Empty)
+{
+  // The default constructed transaction must be empty
+  {
+    Transaction transaction;
+
+    EXPECT_TRUE(transaction.empty());
+  }
+
+  // A transaction with added constraints cannot be empty
+  {
+    const auto variable_uuid = fuse_core::uuid::generate();
+    const auto constraint =
+        ExampleConstraint::make_shared("test", std::initializer_list<UUID>{ variable_uuid });  // NOLINT
+
+    Transaction transaction;
+    transaction.addConstraint(constraint);
+
+    EXPECT_FALSE(transaction.empty());
+  }
+
+  // A transaction with removed constraints cannot be empty
+  {
+    const auto constraint_uuid = fuse_core::uuid::generate();
+
+    Transaction transaction;
+    transaction.removeConstraint(constraint_uuid);
+
+    EXPECT_FALSE(transaction.empty());
+  }
+
+  // A transaction with added variables cannot be empty
+  {
+    const auto variable = ExampleVariable::make_shared();
+
+    Transaction transaction;
+    transaction.addVariable(variable);
+
+    EXPECT_FALSE(transaction.empty());
+  }
+
+  // A transaction with removed variables cannot be empty
+  {
+    const auto variable_uuid = fuse_core::uuid::generate();
+
+    Transaction transaction;
+    transaction.removeVariable(variable_uuid);
+
+    EXPECT_FALSE(transaction.empty());
+  }
+
+  // A transaction with involved stamps cannot be empty
+  {
+    const ros::Time involved_stamp(12345, 6789);
+
+    Transaction transaction;
+    transaction.addInvolvedStamp(involved_stamp);
+
+    EXPECT_FALSE(transaction.empty());
+  }
+}
+
 TEST(Transaction, AddConstraint)
 {
   // Add a single constraint and verify it exists in the added constraints

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -101,7 +101,7 @@ protected:
     fuse_core::UUID acc_linear_uuid;      //!< The uuid of the associated orientation variable
     tf2_2d::Transform pose;               //!< Map-frame pose
     tf2_2d::Vector2 velocity_linear;      //!< Body-frame linear velocity
-    double velocity_yaw;                  //!< Body-frame yaw velocity
+    double velocity_yaw{ 0.0 };           //!< Body-frame yaw velocity
     tf2_2d::Vector2 acceleration_linear;  //!< Body-frame linear acceleration
 
     void print(std::ostream& stream = std::cout) const;

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -172,6 +172,8 @@ protected:
   std::mutex pending_transactions_mutex_;  //!< Synchronize modification of the pending_transactions_ container
   ros::Time start_time_;  //!< The timestamp of the first ignition sensor transaction
   bool started_;  //!< Flag indicating the optimizer is ready/has received a transaction from an ignition sensor
+  bool ignited_;  //!< Flag indicating the optimizer has received a transaction from an ignition sensor and it is queued
+                  //!< but not processed yet
   VariableStampIndex timestamp_tracking_;  //!< Object that tracks the timestamp associated with each variable
 
   // Ordering ROS objects with callbacks last

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -290,21 +290,48 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
                        element.sensor_name << " is not an ignition sensor transaction. " <<
                        "This transaction will not be processed individually.");
     }
-    else if (applyMotionModels(element.sensor_name, *element.transaction))
-    {
-      // Processing was successful. Add the results to the final transaction, delete this one, and return, so the
-      // transaction from the ignition sensor is processed individually.
-      transaction.merge(*element.transaction, true);
-      erase(pending_transactions_, transaction_rbegin);
-      return;
-    }
     else
     {
-      // The motion model processing failed. When this happens to an ignition sensor transaction there is no point on
-      // trying again next time, so we ignore this transaction.
-      ROS_ERROR_STREAM("The queued ignition transaction with timestamp " << element.stamp() << " from sensor " <<
-                       element.sensor_name << " could not be processed. Ignoring this transaction.");
-      erase(pending_transactions_, transaction_rbegin);
+      if (applyMotionModels(element.sensor_name, *element.transaction))
+      {
+        // Processing was successful. Add the results to the final transaction, delete this one, and return, so the
+        // transaction from the ignition sensor is processed individually.
+        transaction.merge(*element.transaction, true);
+        erase(pending_transactions_, transaction_rbegin);
+      }
+      else
+      {
+        // The motion model processing failed. When this happens to an ignition sensor transaction there is no point on
+        // trying again next time, so we ignore this transaction.
+        ROS_ERROR_STREAM("The queued ignition transaction with timestamp " << element.stamp() << " from sensor " <<
+                         element.sensor_name << " could not be processed. Ignoring this ignition transaction.");
+
+        // Remove the ignition transaction that just failed and purge all transactions after it. But if we find another
+        // ignition transaction, we schedule it to be processed in the next optimization cycle.
+        erase(pending_transactions_, transaction_rbegin);
+
+        const auto pending_ignition_transaction_iter =
+            std::find_if(pending_transactions_.rbegin(), pending_transactions_.rend(),
+                         [this](const auto& element) {  // NOLINT(whitespace/braces)
+                           return std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(),
+                                                     element.sensor_name);
+                         });  // NOLINT(whitespace/braces)
+        if (pending_ignition_transaction_iter == pending_transactions_.rend())
+        {
+          // There is no other ignition transaction pending. We simply roll back to not started state and all other
+          // pending transactions will be handled later in the transaction callback, as usual.
+          started_ = false;
+        }
+        else
+        {
+          // Erase all transactions before the other ignition transaction pending. This other ignition transaction will
+          // be processed in the next optimization cycle.
+          pending_transactions_.erase(pending_ignition_transaction_iter.base(), pending_transactions_.rbegin().base());
+          ignited_ = true;
+        }
+      }
+
+      return;
     }
   }
 

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -337,6 +337,8 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
         }
       }
 
+      // There are no more pending transactions to process in this optimization cycle, or they should be processed in
+      // the next one.
       return;
     }
   }

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -197,6 +197,12 @@ void FixedLagSmoother::optimizationLoop()
       //         queue and obtaining the lock for the graph. But we have now obtained two different locks. If we are
       //         not extremely careful, we could get a deadlock.
       processQueue(*new_transaction);
+      // Skip this optimization cycle if the transaction is empty because something failed while processing the pending
+      // transactions queue.
+      if (new_transaction->empty())
+      {
+        continue;
+      }
       // Prepare for selecting the marginal variables
       preprocessMarginalization(*new_transaction);
       // Combine the new transactions with any marginal transaction from the end of the last cycle

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -85,7 +85,8 @@ FixedLagSmoother::FixedLagSmoother(
     optimization_request_(false),
     optimization_running_(true),
     start_time_(ros::TIME_MAX),
-    started_(false)
+    started_(false),
+    ignited_(false)
 {
   params_.loadFromROS(private_node_handle);
 
@@ -255,12 +256,58 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
 {
   // We need to get the pending transactions from the queue
   std::lock_guard<std::mutex> pending_transactions_lock(pending_transactions_mutex_);
-  // Use the most recent transaction time as the current time
-  auto current_time = ros::Time(0, 0);
-  if (!pending_transactions_.empty())
+
+  if (pending_transactions_.empty())
   {
-    current_time = pending_transactions_.front().stamp();
+    return;
   }
+
+  // Use the most recent transaction time as the current time
+  const auto current_time = pending_transactions_.front().stamp();
+
+  // If we just started because an ignition sensor transaction was received, we try to process it individually. This is
+  // important because we need to update the graph with the ignition sensor transaction in order to get the motion
+  // models notified of the initial state. The motion models will typically maintain a state history in order to create
+  // motion model constraints with the optimized variables from the updated graph. If we do not process the ignition
+  // sensor transaction individually, the motion model constraints created for the other queued transactions will not be
+  // able to use any optimized variables from the graph because it is not been optimized yet, and they will have to use
+  // a default zero state instead. This can easily lead to local minima because the variables in the graph are not
+  // initialized properly, i.e. they do not take the ignition sensor transaction into account.
+  if (ignited_)
+  {
+    // The ignition sensor transaction is assumed to be at the end of the queue, because it must be the oldest one.
+    // If there is more than one ignition sensor transaction in the queue, it is always the oldest one that started
+    // things up.
+    ignited_ = false;
+
+    const auto transaction_rbegin = pending_transactions_.rbegin();
+    const auto& element = *transaction_rbegin;
+    if (!std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), element.sensor_name))
+    {
+      // We just started, but the oldest transaction is not from an ignition sensor. We will still process the
+      // transaction, but we do not enforce it is processed individually.
+      ROS_ERROR_STREAM("The queued transaction with timestamp " << element.stamp() << " from sensor " <<
+                       element.sensor_name << " is not an ignition sensor transaction. " <<
+                       "This transaction will not be processed individually.");
+    }
+    else if (applyMotionModels(element.sensor_name, *element.transaction))
+    {
+      // Processing was successful. Add the results to the final transaction, delete this one, and return, so the
+      // transaction from the ignition sensor is processed individually.
+      transaction.merge(*element.transaction, true);
+      erase(pending_transactions_, transaction_rbegin);
+      return;
+    }
+    else
+    {
+      // The motion model processing failed. When this happens to an ignition sensor transaction there is no point on
+      // trying again next time, so we ignore this transaction.
+      ROS_ERROR_STREAM("The queued ignition transaction with timestamp " << element.stamp() << " from sensor " <<
+                       element.sensor_name << " could not be processed. Ignoring this transaction.");
+      erase(pending_transactions_, transaction_rbegin);
+    }
+  }
+
   // Attempt to process each pending transaction
   auto sensor_blacklist = std::vector<std::string>();
   auto transaction_riter = pending_transactions_.rbegin();
@@ -308,6 +355,7 @@ bool FixedLagSmoother::resetServiceCallback(std_srvs::Empty::Request&, std_srvs:
   stopPlugins();
   // Reset the optimizer state
   started_ = false;
+  ignited_ = false;
   start_time_ = ros::TIME_MAX;
   optimization_request_ = false;
   // DANGER: The optimizationLoop() function obtains the lock optimization_mutex_ lock and the
@@ -370,6 +418,7 @@ void FixedLagSmoother::transactionCallback(
       if (std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), sensor_name))
       {
         started_ = true;
+        ignited_ = true;
         start_time_ = transaction_time;
       }
       // And purge out old transactions


### PR DESCRIPTION
Sometimes the pose set with the `set_pose` service/topic using the `Unicycle2DIgnition` sensor model is ignored and the pose is set at a wrong, different location, typically at the origin of the map. This happens when the other sensor models include the `Odometry2D` using the `differential` mode.

This PR fixes several bugs that all contributed to this issue. In particular, it provides the following fixes:
1. Initialize `StateHistoryElement::velocity_yaw` which was used uninitialized: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/include/fuse_models/unicycle_2d.h#L102
    - This impacted prediction in https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L177 because `base_state` is default constructed when the `beginning_stamp` isn't  in the state history: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L139-L150
    - This produced incorrect predictions starting from the first state in the history.
    - And it also propagated into other states because the resulting predicted state is stored in the history: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L234-L235
    - The history and predicted states are used to set the initial value of the variables in the motion model constraint: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L206-L221 https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L246-L258, and these variables overwrite the ones from other constraints: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L83 https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_core/src/timestamp_manager.cpp#L163, so the optimization ends up using a bad initialization and cannot converge to the correct solution.

2. Process ignition transactions individually. This is important because the state history is only updated on graph updates: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95
    - If the ignition transactions that contains the `set_pose` is processed together with some relative constraints from `differential` mode `Odometry2D` measurements (or equivalent), the state history cannot be updated.
    - Therefore, the state defaults to `0`/identity: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L139-L150 https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L177 That state is used for the previous pose variable in the relative constraints when they're connected to the variable of the `set_pose` absolute constraint.
    - The solution consists on processing the ignition transaction individually. This way the state history is updated to the `set_pose` value when it receives the new updated graph in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95

3. Call motion model generator with last stamp in order to update its state history.
    - When the history is empty or the `last_stamp` is newer than any stamp in the history, the motion model history is updated to include it in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_core/src/timestamp_manager.cpp#L154-L159
    - However, the `Unicycle2D` motion model state history is not updated.
    - As a consequence, the `set_pose` doesn't get any entry into the state history and it cannot be updated when a new graph is received in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95
    - We can workaround this issue by calling the motion model `generator_` with the `last_stamp` as beginning and ending stamp. This will add a single entry because the predicted state will be the same as the beginning one: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L234-L235 We don't need the constraint and variables generated, so we discard them. All we're looking for is an entry in the state history, so it can be updated when the graph is received.