### PR TITLE
Print state history

### DIFF
--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -101,6 +101,8 @@ protected:
     tf2_2d::Vector2 velocity_linear;       //!< Body-frame linear velocity
     double velocity_yaw;                  //!< Body-frame yaw velocity
     tf2_2d::Vector2 acceleration_linear;  //!< Body-frame linear acceleration
+
+    void print(std::ostream& stream = std::cout) const;
   };
   using StateHistory = std::map<ros::Time, StateHistoryElement>;
   /**

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -86,6 +86,8 @@ public:
    */
   ~Unicycle2D() = default;
 
+  void print(std::ostream& stream = std::cout) const;
+
 protected:
   /**
    * @brief Structure used to maintain a history of "good" pose estimates
@@ -170,6 +172,8 @@ protected:
                                                    //!< process noise covariance
   StateHistory state_history_;                     //!< History of optimized graph pose estimates
 };
+
+std::ostream& operator<<(std::ostream& stream, const Unicycle2D& unicycle_2d);
 
 }  // namespace fuse_models
 

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -73,6 +73,19 @@ Unicycle2D::Unicycle2D() :
 {
 }
 
+void Unicycle2D::StateHistoryElement::print(std::ostream& stream) const
+{
+  stream << "  position uuid: " << position_uuid << "\n"
+         << "  yaw uuid: " << yaw_uuid << "\n"
+         << "  velocity linear uuid: " << vel_linear_uuid << "\n"
+         << "  velocity yaw uuid: " << vel_yaw_uuid << "\n"
+         << "  acceleration linear uuid: " << acc_linear_uuid << "\n"
+         << "  pose: " << pose << "\n"
+         << "  velocity linear: " << velocity_linear << "\n"
+         << "  velocity yaw: " << velocity_yaw << "\n"
+         << "  acceleration linear: " << acceleration_linear << "\n";
+}
+
 bool Unicycle2D::applyCallback(fuse_core::Transaction& transaction)
 {
   // Use the timestamp manager to generate just the required motion model segments. The timestamp manager, in turn,

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -73,6 +73,16 @@ Unicycle2D::Unicycle2D() :
 {
 }
 
+void Unicycle2D::print(std::ostream& stream) const
+{
+  stream << "state history:\n";
+  for (const auto& state : state_history_)
+  {
+    stream << "- stamp: " << state.first << "\n";
+    state.second.print(stream);
+  }
+}
+
 void Unicycle2D::StateHistoryElement::print(std::ostream& stream) const
 {
   stream << "  position uuid: " << position_uuid << "\n"
@@ -363,6 +373,12 @@ void Unicycle2D::updateStateHistoryEstimates(
         current_state.acceleration_linear);
     }
   }
+}
+
+std::ostream& operator<<(std::ostream& stream, const Unicycle2D& unicycle_2d)
+{
+  unicycle_2d.print(stream);
+  return stream;
 }
 
 }  // namespace fuse_models


### PR DESCRIPTION
This adds support to print the state history from the `Unicycle2D` motion model. Not sure if this is worth a PR, but it was useful while debugging things for https://github.com/locusrobotics/fuse/pull/154.

I'm happy to close, merge as is, or extend it to cover all the attributes in the `Unicycle2D` class.

TBH, printing the entire `state_history_` map is quite verbose, but that's better than nothing when trying to debug things. I'm all ears for suggestions on how to better debug the logic that handles the state and motion model history in `Unicycle2D` and the `TimeManager`. :smiley: 

Note this only contributes the printing support. Nothing is really printing anywhere. That part was added locally while debugging.