### PR TITLE
C++14 for test_unicycle_2d_state_cost_function

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -183,14 +183,17 @@ if(CATKIN_ENABLE_TESTING)
     test_unicycle_2d_state_cost_function
     test/test_unicycle_2d_state_cost_function.cpp
   )
-  if(TARGET test_unicycle_2d_state_cost_function)
-    target_link_libraries(
-      test_unicycle_2d_state_cost_function
-      ${PROJECT_NAME}
-      ${catkin_LIBRARIES}
-      ${CERES_LIBRARIES}
-    )
-  endif()
+  target_link_libraries(
+    test_unicycle_2d_state_cost_function
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+  )
+  set_target_properties(test_unicycle_2d_state_cost_function
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
 
   # Ignition tests
   add_rostest_gtest(


### PR DESCRIPTION
The `test_unicycle_2d_state_cost_function` also needs `c++14`. This PR does that and also remove the `if(TARGET` block, which isn't used by other test targets.

Without this, I get the following compilation error when running `make run_tests`:
``` bash
In file included from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/unicycle_2d_predict.h:38:0,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h:37,
                 from /home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/test/test_unicycle_2d_state_cost_function.cpp:34:
/opt/clearpath/2.18/include/fuse_core/util.h: In function ‘fuse_core::Matrix<Scalar, Size, Size> fuse_core::getCovarianceDiagonalParam(const ros::NodeHandle&, const string&, Scalar)’:
/opt/clearpath/2.18/include/fuse_core/util.h:215:28: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
                   [](const auto& value) { return value < Scalar(0); }))  // NOLINT(whitespace/braces)
                            ^
CMakeFiles/test_unicycle_2d_state_cost_function.dir/build.make:62: recipe for target 'CMakeFiles/test_unicycle_2d_state_cost_function.dir/test/test_unicycle_2d_state_cost_function.cpp.o' failed
```