### PR TITLE
Added unit test to illustrate variable initialization bug

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -129,6 +129,8 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(geometry_msgs REQUIRED)
+  find_package(nav_msgs REQUIRED)
 
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
@@ -179,4 +181,29 @@ if(CATKIN_ENABLE_TESTING)
   )
 
   add_rostest(test/optimizer.test ARGS config:=list DEPENDENCIES test_optimizer)
+
+  # Fixed-lag Ignition test
+  add_rostest_gtest(test_fixed_lag_ignition
+    test/fixed_lag_ignition.test
+    test/test_fixed_lag_ignition.cpp
+  )
+  target_include_directories(test_fixed_lag_ignition
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${geometry_msgs_INCLUDE_DIRS}
+      ${nav_msgs_INCLUDE_DIRS}
+      ${rostest_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_fixed_lag_ignition
+    ${catkin_LIBRARIES}
+    ${geometry_msgs_LIBRARIES}
+    ${nav_msgs_LIBRARIES}
+    ${rostest_LIBRARIES}
+  )
+  set_target_properties(test_fixed_lag_ignition
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
 endif()

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -23,6 +23,8 @@
   <depend>roscpp</depend>
   <depend>std_srvs</depend>
   <test_depend>fuse_models</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>nav_msgs</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 

--- a/fuse_optimizers/test/fixed_lag_ignition.test
+++ b/fuse_optimizers/test/fixed_lag_ignition.test
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>	
+<launch>
+  <node name="fixed_lag" pkg="fuse_optimizers" type="fixed_lag_smoother_node" output="screen">
+    <rosparam subst_value="true">
+      optimization_frequency: 1.0
+      transaction_timeout: 2.0
+      lag_duration: 2.0
+
+      ignition_sensors: ['unicycle_ignition_sensor']
+
+      solver_options:
+        max_num_iterations: 0
+
+      motion_models:
+        unicycle_motion_model:
+          type: fuse_models::Unicycle2D
+
+      sensor_models:
+        unicycle_ignition_sensor:
+          type: fuse_models::Unicycle2DIgnition
+          motion_models: [unicycle_motion_model]
+        pose_sensor:
+          type: fuse_models::Pose2D
+          motion_models: [unicycle_motion_model]
+      
+      publishers:
+        odometry_publisher:
+          type: fuse_models::Odometry2DPublisher
+      
+      unicycle_motion_model:
+        buffer_length: 2.0
+        process_noise_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      
+      unicycle_ignition_sensor:
+        publish_on_startup: false
+        initial_state: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        initial_sigma: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      
+      pose_sensor:
+        differential: true
+        topic: pose
+        target_frame: base_link
+        position_dimensions: ['x', 'y']
+        orientation_dimensions: ['yaw']
+      
+      odometry_publisher:
+        topic: odom
+        world_frame_id: map
+        publish_tf: false
+    </rosparam>
+  </node>
+
+  <test test-name="FixedLagIgnition" pkg="fuse_optimizers" type="test_fixed_lag_ignition" />
+</launch>

--- a/fuse_optimizers/test/fixed_lag_ignition.test
+++ b/fuse_optimizers/test/fixed_lag_ignition.test
@@ -2,9 +2,9 @@
 <launch>
   <node name="fixed_lag" pkg="fuse_optimizers" type="fixed_lag_smoother_node" output="screen">
     <rosparam subst_value="true">
-      optimization_frequency: 1.0
-      transaction_timeout: 2.0
-      lag_duration: 2.0
+      optimization_frequency: 2.0
+      transaction_timeout: 5.0
+      lag_duration: 5.0
 
       ignition_sensors: ['unicycle_ignition_sensor']
 
@@ -28,7 +28,7 @@
           type: fuse_models::Odometry2DPublisher
       
       unicycle_motion_model:
-        buffer_length: 2.0
+        buffer_length: 5.0
         process_noise_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
       
       unicycle_ignition_sensor:
@@ -38,7 +38,7 @@
       
       pose_sensor:
         differential: true
-        topic: pose
+        topic: relative_pose
         target_frame: base_link
         position_dimensions: ['x', 'y']
         orientation_dimensions: ['yaw']

--- a/fuse_optimizers/test/test_fixed_lag_ignition.cpp
+++ b/fuse_optimizers/test/test_fixed_lag_ignition.cpp
@@ -102,7 +102,7 @@ TEST(FixedLagIgnition, SetInitialState)
 
   // Wait for the optimizer to publish the first pose
   auto odom_msg = ros::topic::waitForMessage<nav_msgs::Odometry>("/odom", ros::Duration(1.0));
-  ASSERT_TRUE(odom_msg);
+  ASSERT_TRUE(static_cast<bool>(odom_msg));
 
   // The optimizer is configured for 0 iterations, so it should return the initial variable values
   // If we did our job correctly, the initial variable values should be the same as the service call state, give or

--- a/fuse_optimizers/test/test_fixed_lag_ignition.cpp
+++ b/fuse_optimizers/test/test_fixed_lag_ignition.cpp
@@ -67,9 +67,14 @@ TEST(FixedLagIgnition, SetInitialState)
 
   // The 'set_pose' service call triggers all of the sensors to resubscribe to their topics.
   // I need to wait for those subscribers to be ready before sending them sensor data.
-  // I'd love a ros::topic::waitForSubscriber() method, but that doesn't exist.
-  // I'm not sure what else to do, other than "wait a bit".
-  ros::Duration(0.5).sleep();
+  ros::Time timeout = ros::Time::now() + ros::Duration(1.0);
+  while ((pose_publisher.getNumSubscribers() == 0u) &&
+         (ros::Time::now() < timeout))
+  {
+    std::cout << "waiting..." << std::endl;
+    ros::Duration(0.1).sleep();
+  }
+  ASSERT_GT(pose_publisher.getNumSubscribers(), 0u);
 
   // Publish a relative pose
   auto pose_msg1 = geometry_msgs::PoseWithCovarianceStamped();

--- a/fuse_optimizers/test/test_fixed_lag_ignition.cpp
+++ b/fuse_optimizers/test/test_fixed_lag_ignition.cpp
@@ -68,13 +68,13 @@ TEST(FixedLagIgnition, SetInitialState)
   // The 'set_pose' service call triggers all of the sensors to resubscribe to their topics.
   // I need to wait for those subscribers to be ready before sending them sensor data.
   ros::Time timeout = ros::Time::now() + ros::Duration(1.0);
-  while ((pose_publisher.getNumSubscribers() == 0u) &&
+  while ((pose_publisher.getNumSubscribers() < 1u) &&
          (ros::Time::now() < timeout))
   {
     std::cout << "waiting..." << std::endl;
     ros::Duration(0.1).sleep();
   }
-  ASSERT_GT(pose_publisher.getNumSubscribers(), 0u);
+  ASSERT_GE(pose_publisher.getNumSubscribers(), 1u);
 
   // Publish a relative pose
   auto pose_msg1 = geometry_msgs::PoseWithCovarianceStamped();

--- a/fuse_optimizers/test/test_fixed_lag_ignition.cpp
+++ b/fuse_optimizers/test/test_fixed_lag_ignition.cpp
@@ -1,0 +1,124 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_models/SetPose.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+
+TEST(FixedLagIgnition, SetInitialState)
+{
+  auto node_handle = ros::NodeHandle();
+  auto pose_publisher = node_handle.advertise<geometry_msgs::PoseWithCovarianceStamped>("/pose", 1);
+
+  // Wait for the optimizer to be ready
+  ASSERT_TRUE(ros::service::waitForService("/fixed_lag/reset", ros::Duration(1.0)));
+  ASSERT_TRUE(ros::service::waitForService("/fixed_lag/set_pose", ros::Duration(1.0)));
+
+  // Set the initial pose to something near zero
+  fuse_models::SetPose::Request req;
+  req.pose.header.frame_id = "map";
+  req.pose.header.stamp = ros::Time(1, 0);
+  req.pose.pose.pose.position.x = 100.1;
+  req.pose.pose.pose.position.y = 100.2;
+  req.pose.pose.pose.position.z = 0.0;
+  req.pose.pose.pose.orientation.x = 0.0;
+  req.pose.pose.pose.orientation.y = 0.0;
+  req.pose.pose.pose.orientation.z = 0.0;
+  req.pose.pose.pose.orientation.w = 1.0;
+  req.pose.pose.covariance[0] = 1.0;
+  req.pose.pose.covariance[7] = 1.0;
+  req.pose.pose.covariance[35] = 1.0;
+  fuse_models::SetPose::Response res;
+  ros::service::call("/fixed_lag/set_pose", req, res);
+
+  // I need to wait for the subscriber to be ready. I don't know of a better way.
+  // There is no ros::topic::waitForSubscriber() method.
+  ros::Duration(0.5).sleep();
+
+  // Publish a relative pose
+  auto pose_msg1 = geometry_msgs::PoseWithCovarianceStamped();
+  pose_msg1.header.stamp = ros::Time(2, 0);
+  pose_msg1.header.frame_id = "base_link";
+  pose_msg1.pose.pose.position.x = 0.0;
+  pose_msg1.pose.pose.position.y = 0.0;
+  pose_msg1.pose.pose.position.z = 0.0;
+  pose_msg1.pose.pose.orientation.x = 0.0;
+  pose_msg1.pose.pose.orientation.y = 0.0;
+  pose_msg1.pose.pose.orientation.z = 0.0;
+  pose_msg1.pose.pose.orientation.w = 0.0;
+  pose_msg1.pose.covariance[0] = 1.0;
+  pose_msg1.pose.covariance[7] = 1.0;
+  pose_msg1.pose.covariance[35] = 1.0;
+  pose_publisher.publish(pose_msg1);
+
+  auto pose_msg2 = geometry_msgs::PoseWithCovarianceStamped();
+  pose_msg2.header.stamp = ros::Time(3, 0);
+  pose_msg2.header.frame_id = "base_link";
+  pose_msg2.pose.pose.position.x = 10.0;
+  pose_msg2.pose.pose.position.y = 20.0;
+  pose_msg2.pose.pose.position.z = 0.0;
+  pose_msg2.pose.pose.orientation.x = 0.0;
+  pose_msg2.pose.pose.orientation.y = 0.0;
+  pose_msg2.pose.pose.orientation.z = 0.5000;
+  pose_msg2.pose.pose.orientation.w = 0.8660;
+  pose_msg2.pose.covariance[0] = 1.0;
+  pose_msg2.pose.covariance[7] = 1.0;
+  pose_msg2.pose.covariance[35] = 1.0;
+  pose_publisher.publish(pose_msg2);
+
+  // Wait for the optimizer to publish the first pose
+  auto odom_msg = ros::topic::waitForMessage<nav_msgs::Odometry>("/odom", ros::Duration(1.0));
+  ASSERT_TRUE(odom_msg);
+
+  // The optimizer is configured for 0 iterations, so it should return the initial variable values
+  // If we did our job correctly, the initial variable values should be the same as the service call state, give or
+  // take the motion model forward prediction.
+  EXPECT_NEAR(100.1, odom_msg->pose.pose.position.x, 0.10);
+  EXPECT_NEAR(100.2, odom_msg->pose.pose.position.y, 0.10);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "fixed_lag_ignition_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}


### PR DESCRIPTION
There is an issue with how variables are initialized in the motion model. This PR creates a unit test that adds an initial constraint to the graph and grabs to the optimized output. Because the test has the optimizer limited to 0 iterations, the "optimized" value is actually just the initial value provided by the motion model.

This issue is fixed by #154.