### PR TITLE
Patch Tukey loss for Ceres < 2.0.0

### DIFF
--- a/fuse_core/include/fuse_core/ceres_macros.h
+++ b/fuse_core/include/fuse_core/ceres_macros.h
@@ -1,0 +1,46 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020 Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_CERES_MACROS_H
+#define FUSE_CORE_CERES_MACROS_H
+
+#include <ceres/version.h>
+
+/**
+ * Check for at least Ceres Solver version x.y.z, where: x = major, y = minor and z = revision.
+ */
+#define CERES_VERSION_AT_LEAST(x, y, z) (CERES_VERSION_MAJOR > x || (CERES_VERSION_MAJOR    >= x && \
+                                        (CERES_VERSION_MINOR > y || (CERES_VERSION_MINOR    >= y && \
+                                                                     CERES_VERSION_REVISION >= z))))
+
+#endif  // FUSE_CORE_CERES_MACROS_H

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -34,6 +34,8 @@
 #ifndef FUSE_CORE_CERES_OPTIONS_H
 #define FUSE_CORE_CERES_OPTIONS_H
 
+#include <fuse_core/ceres_macros.h>
+
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
@@ -75,13 +77,6 @@
 #define CERES_OPTION_STRING_DEFINITIONS(Option) \
   CERES_OPTION_TO_STRING_DEFINITION(Option) \
   CERES_OPTION_FROM_STRING_DEFINITION(Option)
-
-/**
- * Check for at least Ceres Solver version x.y.z, where: x = major, y = minor and z = revision.
- */
-#define CERES_VERSION_AT_LEAST(x, y, z) (CERES_VERSION_MAJOR > x || (CERES_VERSION_MAJOR    >= x && \
-                                        (CERES_VERSION_MINOR > y || (CERES_VERSION_MINOR    >= y && \
-                                                                     CERES_VERSION_REVISION >= z))))
 
 #if !CERES_VERSION_AT_LEAST(2, 0, 0)
 /**

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -150,6 +150,30 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Tukey Loss Tests
+  catkin_add_gtest(test_tukey_loss
+    test/test_tukey_loss.cpp
+  )
+  add_dependencies(test_tukey_loss
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_tukey_loss
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_tukey_loss
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+  )
+  set_target_properties(test_tukey_loss
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Qwt Loss Plot Tests
   option(BUILD_WITH_PLOT_TESTS "Build with plot tests. These test might fail to run in headless systems." OFF)
   if(BUILD_WITH_PLOT_TESTS)

--- a/fuse_loss/fuse_plugins.xml
+++ b/fuse_loss/fuse_plugins.xml
@@ -7,7 +7,14 @@
   For this reason loss functions are also known as robustifiers.
 
   In the notation used here, `rho(s)` takes the squared residuals `s` as an input, not the residuals `r`, as in Ceres
-  solver.
+  solver. More precisely, `s` is the squared norm of the residuals:
+
+    s = ||residuals||^2
+
+  but for simplicity we refer to it as the squared residual.
+
+  Similarly, the `rho(s)` equations are multiplied by `2` because the convention in Ceres solver is that the
+  contribution of a term to the cost function is given by `1/2 rho(s)`.
 
   For least squares problems where there are no outliers and standard squared loss is expected, it is not necessary to
   create use a loss function.
@@ -45,15 +52,15 @@
     Loss function that is capped beyond a certain level using the arc-tangent function, with scaling parameter 'a' that
     determines the level where falloff occurs. For costs much smaller than 'a', the loss function is linear and behaves
     like TrivialLoss, and for values much larger than 'a' the value asymptotically approaches the constant value of
-    'a * PI / 2'. It is defined as follows for the residual 's':
+    'a * PI / 2'. It is defined as follows for the squared residual 's':
 
     rho(s) = a * atan2(s, a)
     </description>
   </class>
   <class type="fuse_loss::CauchyLoss" base_class_type="fuse_core::Loss">
     <description>
-    Loss function inspired by the Cauchy distribution, with scaling parameter 'a', defined as follows for the residual
-    's':
+    Loss function inspired by the Cauchy distribution, with scaling parameter 'a', defined as follows for the squared
+    residual 's':
 
     rho(s) = b * log(1 + s * c)
 
@@ -62,7 +69,8 @@
   </class>
   <class type="fuse_loss::DCSLoss" base_class_type="fuse_core::Loss">
     <description>
-    DCS (Dynamic Covariance Scaling) loss function with scaling parameter 'a', defined as follows for the residual 's':
+    DCS (Dynamic Covariance Scaling) loss function with scaling parameter 'a', defined as follows for the squared
+    residual 's':
 
     rho(s) = a * (3 * s - a) / (a + s)  if s > a   // outlier region
            = s                          otherwise  // inlier region
@@ -82,7 +90,7 @@
   </class>
   <class type="fuse_loss::FairLoss" base_class_type="fuse_core::Loss">
     <description>
-    Fair loss function with scaling parameter 'a', defined as follows for the residual 's':
+    Fair loss function with scaling parameter 'a', defined as follows for the squared residual 's':
 
     rho(s) = 2 * b * (r/a - log(1 + r/a))
 
@@ -91,7 +99,7 @@
   </class>
   <class type="fuse_loss::GemanMcClureLoss" base_class_type="fuse_core::Loss">
     <description>
-    Geman-McClure loss function with scaling parameter 'a', defined as follows for the residual 's':
+    Geman-McClure loss function with scaling parameter 'a', defined as follows for the squared residual 's':
 
     rho(s) = s * b / (b + s)
 
@@ -100,7 +108,7 @@
   </class>
   <class type="fuse_loss::HuberLoss" base_class_type="fuse_core::Loss">
     <description>
-    Huber loss function with scaling parameter 'a', defined as follows for the residual 's':
+    Huber loss function with scaling parameter 'a', defined as follows for the squared residual 's':
 
     rho(s) = 2 * a * sqrt(s) - b  if s > b   // outlier region
            = s                    otherwise  // inlier region
@@ -125,7 +133,7 @@
   <class type="fuse_loss::SoftLOneLoss" base_class_type="fuse_core::Loss">
     <description>
     Soft L1 loss function with scaling parameter 'a', that is similar to Huber but smooth, defined as follows for the
-    residual 's':
+    squared residual 's':
 
     rho(s) = 2 * b * (sqrt(1 + s * c) - 1)
 
@@ -140,7 +148,7 @@
     (quadratic in cost) beyond this range. The tolerance parameter 'a' sets the nominal point at which the transition
     occurs, and the transition size parameter 'b' sets the nominal distance over which most of the transition occurs.
     Both 'a' and 'b' must be greater than zero, and typically 'b' will be set to a fraction of 'a'. It is defined as
-    follows for the residual 's':
+    follows for the squared residual 's':
 
     rho(s) = b * log(1 + exp((s - a) / b)) - c0
 
@@ -158,7 +166,7 @@
   <class type="fuse_loss::TukeyLoss" base_class_type="fuse_core::Loss">
     <description>
     Tukey biweight loss function which aggressively attempts to suppress large errors, with scaling parameter 'a',
-    defined as follows for the residual 's':
+    defined as follows for the squared residual 's':
 
     rho(s) = a^2 / 6                          if s > a^2  // inlier region
            = a^2 / 6 * (1 - (1 - s / a^2)^3)  otherwise   // outlier region
@@ -166,7 +174,7 @@
   </class>
   <class type="fuse_loss::WelschLoss" base_class_type="fuse_core::Loss">
     <description>
-    Welsch loss function with scaling parameter 'a', defined as follows for the residual 's':
+    Welsch loss function with scaling parameter 'a', defined as follows for the squared residual 's':
 
     rho(s) = b * (1 - exp(-s/b))
 

--- a/fuse_loss/include/fuse_loss/loss_function.h
+++ b/fuse_loss/include/fuse_loss/loss_function.h
@@ -57,17 +57,6 @@
 // without loss:
 // * cost w/o loss: https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/residual_block.cc#L159
 // * cost w/  loss: https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/residual_block.cc#L165
-//
-// Note that according to this, it looks like the Tukey loss function is incorrectly implemented in Ceres because it
-// must be multiplied by 2, so instead of dividing by 6 it should divide by 3. See:
-//
-//   https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/loss_function.h#L281-L282
-//
-// There is an easy workaround for this: combine TukeyLoss with ScaledLoss, using a scaled factor of 2.
-//
-// There is also a PR with a patch already sent to Ceres:
-//
-//   https://ceres-solver-review.googlesource.com/c/ceres-solver/+/16700
 namespace ceres
 {
 

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/tukey_loss.h>
 
-#include <fuse_core/ceres_options.h>
+#include <fuse_core/ceres_macros.h>
 
 #include <pluginlib/class_list_macros.h>
 #include <ros/node_handle.h>

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -33,6 +33,8 @@
  */
 #include <fuse_loss/tukey_loss.h>
 
+#include <fuse_core/ceres_options.h>
+
 #include <pluginlib/class_list_macros.h>
 #include <ros/node_handle.h>
 
@@ -64,7 +66,25 @@ void TukeyLoss::print(std::ostream& stream) const
 
 ceres::LossFunction* TukeyLoss::lossFunction() const
 {
+#if CERES_VERSION_AT_LEAST(2, 0, 0)
   return new ceres::TukeyLoss(a_);
+#else
+  // The Tukey loss function is incorrectly implemented in Ceres before the 2.* version because it must be multiplied by
+  // 2, so instead of dividing by 6 it should have divided by 3 in:
+  //
+  //   https://github.com/ceres-solver/ceres-solver/blob/4362a2169966e0839425209/include/ceres/loss_function.h#L281-L282
+  //
+  // This was fix with the patch already sent and merged into Ceres in this PR:
+  //
+  //   https://ceres-solver-review.googlesource.com/c/ceres-solver/+/16700
+  //
+  // See:
+  //
+  //   https://github.com/ceres-solver/ceres-solver/commit/6da364713f5b78#diff-7f75c0abfe2c5756f744aa61097ca1c2L281-R283
+  //
+  // There is an easy workaround for this. We combine TukeyLoss with ScaledLoss, using a scaled factor of 2.
+  return new ceres::ScaledLoss(new ceres::TukeyLoss(a_), 2.0, Ownership);
+#endif
 }
 
 }  // namespace fuse_loss

--- a/fuse_loss/test/test_loss_function.cpp
+++ b/fuse_loss/test/test_loss_function.cpp
@@ -35,6 +35,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 // The following function has been copied and adapted from:
 //
 // https://github.com/ceres-solver/ceres-solver/blob/master/internal/ceres/loss_function_test.cc
@@ -111,6 +113,12 @@ TEST(LossFunction, DCSLoss)
   AssertLossFunctionIsValid(ceres::DCSLoss(0.7), 1.792);
   AssertLossFunctionIsValid(ceres::DCSLoss(1.3), 0.357);
   AssertLossFunctionIsValid(ceres::DCSLoss(1.3), 1.792);
+  // Check that at s = 0: rho = [0, 1, 0].
+  double rho[3];
+  ceres::DCSLoss(0.7).Evaluate(0.0, rho);
+  ASSERT_NEAR(rho[0], 0.0, 1e-6);
+  ASSERT_NEAR(rho[1], 1.0, 1e-6);
+  ASSERT_NEAR(rho[2], 0.0, 1e-6);
 }
 
 TEST(LossFunction, FairLoss)
@@ -119,6 +127,12 @@ TEST(LossFunction, FairLoss)
   AssertLossFunctionIsValid(ceres::FairLoss(0.7), 1.792);
   AssertLossFunctionIsValid(ceres::FairLoss(1.3), 0.357);
   AssertLossFunctionIsValid(ceres::FairLoss(1.3), 1.792);
+  // Check that at s = 0: rho = [0, 1, -Inf].
+  double rho[3];
+  ceres::FairLoss(0.7).Evaluate(0.0, rho);
+  ASSERT_NEAR(rho[0], 0.0, 1e-6);
+  ASSERT_NEAR(rho[1], 1.0, 1e-6);
+  ASSERT_LT(rho[2], -std::numeric_limits<double>::lowest());
 }
 
 TEST(LossFunction, GemanMcClureLoss)
@@ -127,6 +141,14 @@ TEST(LossFunction, GemanMcClureLoss)
   AssertLossFunctionIsValid(ceres::GemanMcClureLoss(0.7), 1.792);
   AssertLossFunctionIsValid(ceres::GemanMcClureLoss(1.3), 0.357);
   AssertLossFunctionIsValid(ceres::GemanMcClureLoss(1.3), 1.792);
+  // Check that at s = 0: rho = [0, 1, -2/b].
+  const double a = 0.7;
+
+  double rho[3];
+  ceres::GemanMcClureLoss(a).Evaluate(0.0, rho);
+  ASSERT_NEAR(rho[0], 0.0, 1e-6);
+  ASSERT_NEAR(rho[1], 1.0, 1e-6);
+  ASSERT_NEAR(rho[2], -2.0 / (a * a), 1e-6);
 }
 
 TEST(LossFunction, WelschLoss)
@@ -135,6 +157,14 @@ TEST(LossFunction, WelschLoss)
   AssertLossFunctionIsValid(ceres::WelschLoss(0.7), 1.792);
   AssertLossFunctionIsValid(ceres::WelschLoss(1.3), 0.357);
   AssertLossFunctionIsValid(ceres::WelschLoss(1.3), 1.792);
+  // Check that at s = 0: rho = [0, 1, -1/b].
+  const double a = 0.7;
+
+  double rho[3];
+  ceres::WelschLoss(a).Evaluate(0.0, rho);
+  ASSERT_NEAR(rho[0], 0.0, 1e-6);
+  ASSERT_NEAR(rho[1], 1.0, 1e-6);
+  ASSERT_NEAR(rho[2], -1 / (a * a), 1e-6);
 }
 
 int main(int argc, char** argv)

--- a/fuse_loss/test/test_tukey_loss.cpp
+++ b/fuse_loss/test/test_tukey_loss.cpp
@@ -1,0 +1,210 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/serialization.h>
+#include <fuse_loss/tukey_loss.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
+#include <gtest/gtest.h>
+
+TEST(TukeyLoss, Constructor)
+{
+  // Create a default loss
+  {
+    fuse_loss::TukeyLoss loss;
+    ASSERT_EQ(1.0, loss.a());
+  }
+
+  // Create a loss with a parameter
+  {
+    const double a{ 0.3 };
+    fuse_loss::TukeyLoss loss(a);
+    ASSERT_EQ(a, loss.a());
+  }
+}
+
+TEST(TukeyLoss, Evaluate)
+{
+  // Check that at s = 0: rho = [0, 1, -2 / a^2].
+  fuse_loss::TukeyLoss loss(0.7);
+  const std::unique_ptr<ceres::LossFunction> loss_function(loss.lossFunction());
+
+  double rho[3];
+  loss_function->Evaluate(0.0, rho);
+  ASSERT_NEAR(rho[0], 0.0, 1e-6);
+  ASSERT_NEAR(rho[1], 1.0, 1e-6);
+  ASSERT_NEAR(rho[2], -2.0 / (0.7 * 0.7), 1e-6);
+}
+
+struct CostFunctor
+{
+  explicit CostFunctor(const double data)
+    : data(data)
+  {}
+
+  template <typename T> bool operator()(const T* const x, T* residual) const
+  {
+    residual[0] = x[0] - T(data);
+    return true;
+  }
+
+  double data{ 0.0 };
+};
+
+TEST(TukeyLoss, Optimization)
+{
+  // Create a simple parameter
+  double x{ 5.0 };
+
+  // Create a simple inlier constraint
+  const double inlier{ 1.0 };
+
+  // Create a simple outlier constraint
+  const double outlier{ 10.0 };
+  ceres::CostFunction* cost_function_outlier =
+      new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(new CostFunctor(outlier));
+
+  // Create loss with a = x, so the initial value of x is not handled in the outlier region, in which case the
+  // optimization does not convergence and the initial solution does not change
+  fuse_loss::TukeyLoss loss(x);
+
+  // Build the problem.
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+
+  ceres::Problem problem(problem_options);
+
+  const size_t num_inliers{ 1000 };
+  for (size_t i = 0; i < num_inliers; ++i)
+  {
+    problem.AddResidualBlock(
+      new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(new CostFunctor(inlier)),
+      loss.lossFunction(),  // A nullptr here would produce a slightly better solution
+      &x);
+  }
+
+  // Add outlier constraints
+  const size_t num_outliers{ 9 };
+  for (size_t i = 0; i < num_outliers; ++i)
+  {
+    problem.AddResidualBlock(
+      cost_function_outlier,
+      loss.lossFunction(),
+      &x);
+  }
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+
+  // Check
+  EXPECT_NEAR(inlier, x, 1.0e-3);
+
+  // Evaluate problem cost
+  double cost = 0.0;
+  problem.Evaluate(ceres::Problem::EvaluateOptions(), &cost, nullptr, nullptr, nullptr);
+
+  // Evaluate problem without applying the loss
+  ceres::Problem::EvaluateOptions evaluate_options;
+  evaluate_options.apply_loss_function = false;
+
+  double raw_cost = 0.0;
+  problem.Evaluate(evaluate_options, &raw_cost, nullptr, nullptr, nullptr);
+
+  // Check the cost with loss is lower
+  EXPECT_LT(cost, raw_cost);
+}
+
+TEST(TukeyLoss, Serialization)
+{
+  // Construct a loss
+  const double a{ 0.3 };
+  fuse_loss::TukeyLoss expected(a);
+
+  // Serialize the loss into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new loss from that same stream
+  fuse_loss::TukeyLoss actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.a(), actual.a());
+  EXPECT_NE(nullptr, actual.lossFunction());
+
+  // Test inlier (s <= a*a)
+  const double s = 0.95 * a * a;
+  double rho[3] = {0.0};
+  actual.lossFunction()->Evaluate(s, rho);
+
+  EXPECT_GT(a * a / 3.0, rho[0]);
+  EXPECT_GT(1.0, rho[1]);
+  EXPECT_GT(0.0, rho[2]);
+
+  // Test outlier
+  const double s_outlier = 1.05 * a * a;
+  actual.lossFunction()->Evaluate(s_outlier, rho);
+
+  // In the outlier region rho() satisfies:
+  //
+  //   rho(s) < s
+  //   rho'(s) < 1
+  //   rho''(s) < 0
+  //
+  // For the particular case of the Tukey loss we also have:
+  //
+  //   rho(s) = a^2 / 3
+  //   rho'(s) = 0
+  //   rho''(s) = 0
+  //
+  // where rho(s) is rho[0], rho'(s) is rho[1] and rho''(s) is rho[2]
+  EXPECT_NEAR(a * a / 3.0, rho[0], 1e-6);
+  EXPECT_NEAR(0.0, rho[1], 1e-6);
+  EXPECT_NEAR(0.0, rho[2], 1e-6);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
https://ceres-solver-review.googlesource.com/c/ceres-solver/+/16700 has been merged (see https://github.com/ceres-solver/ceres-solver/commit/6da364713f5b78ddf15b0e0ad92c76362c7c7683), so now the `TukeyLoss` won't need any workaround once Ceres 2.0.0 is release. You could also try building it from source and installing it in your system, as I've done.

This PR adds a workaround for `TukeyLoss` if Ceres < 2.0.0, updates the comments and unit tests.