### PR TITLE
Fix constness to match usage

### DIFF
--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -287,7 +287,7 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
     ignited_ = false;
 
     const auto transaction_rbegin = pending_transactions_.rbegin();
-    const auto& element = *transaction_rbegin;
+    auto& element = *transaction_rbegin;
     if (!std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), element.sensor_name))
     {
       // We just started, but the oldest transaction is not from an ignition sensor. We will still process the


### PR DESCRIPTION
From a usage standpoint, the 'element' variable is getting modified and should not be const. The const was not causing compilation issues before because of some pointer indirection.