### PR TITLE
Keep constraint properties sorted by source

### DIFF
--- a/fuse_viz/include/fuse_viz/serialized_graph_display.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_display.h
@@ -43,6 +43,7 @@
 #include <rviz/message_filter_display.h>
 #endif  // Q_MOC_RUN
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -97,7 +98,7 @@ private:
       std::unordered_map<fuse_core::UUID, std::shared_ptr<RelativePose2DStampedConstraintVisual>,
                          fuse_core::uuid::hash>;
   using ColorBySourceMap = std::unordered_map<std::string, Ogre::ColourValue>;
-  using ConstraintPropertyBySourceMap = std::unordered_map<std::string, RelativePose2DStampedConstraintProperty*>;
+  using ConstraintPropertyBySourceMap = std::map<std::string, RelativePose2DStampedConstraintProperty*>;
   using ConfigBySourceMap = std::unordered_map<std::string, Config>;
 
   void clear();


### PR DESCRIPTION
This keeps the constraint properties sorted by source regardless of the order in which they're discovered and added to the parent property.

This implementation relies on the alphabetical order of the constraint source `std::string`, which is used as the key in an `std::map`.

The sorted properties would look as follows:
![Screenshot from 2020-03-19 20-03-14](https://user-images.githubusercontent.com/382167/77105018-3f7d6600-6a1d-11ea-95bc-233bf3cd1d08.png)
