### PR TITLE
Throttle

### DIFF
--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -66,7 +66,7 @@ void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& valu
 }
 
 /**
- * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
+ * @brief Helper function that loads positive integral or floating point values from the parameter server
  *
  * @param[in] node_handle - The node handle used to load the parameter
  * @param[in] parameter_name - The parameter name to load

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -226,6 +226,21 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  add_rostest_gtest(
+    test_throttled_callback
+    test/throttled_callback.test
+    test/test_throttled_callback.cpp
+  )
+  target_link_libraries(test_throttled_callback
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_throttled_callback
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Benchmarks
   find_package(benchmark QUIET)
 

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -35,6 +35,7 @@
 #define FUSE_MODELS_ACCELERATION_2D_H
 
 #include <fuse_models/parameters/acceleration_2d_params.h>
+#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -115,6 +116,9 @@ protected:
   tf2_ros::TransformListener tf_listener_;
 
   ros::Subscriber subscriber_;
+
+  using AccelerationThrottledCallback = common::ThrottledCallback<geometry_msgs::AccelWithCovarianceStamped>;
+  AccelerationThrottledCallback throttled_callback_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -67,7 +67,8 @@ public:
    *                            nullptr
    * @param[in] throttle_period The throttling period duration in seconds. Defaults to 0.0, i.e. no throttling
    */
-  ThrottledCallback(Callback keep_callback = nullptr, Callback drop_callback = nullptr,
+  ThrottledCallback(Callback&& keep_callback = nullptr,  // NOLINT(whitespace/operators)
+                    Callback&& drop_callback = nullptr,  // NOLINT(whitespace/operators)
                     const ros::Duration& throttle_period = ros::Duration(0.0))
     : keep_callback_(keep_callback), drop_callback_(drop_callback), throttle_period_(throttle_period)
   {

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -135,7 +135,11 @@ public:
     const auto now = ros::Time::now();
     if (!last_called_time_.isValid() || now - last_called_time_ > throttle_period_)
     {
-      keep_callback_(message);
+      if (keep_callback_)
+      {
+        keep_callback_(message);
+      }
+
       last_called_time_ = now;
     }
     else if (drop_callback_)

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -66,11 +66,15 @@ public:
    * @param[in] drop_callback   The callback to call when the message is dropped because of the throttling. Defaults to
    *                            nullptr
    * @param[in] throttle_period The throttling period duration in seconds. Defaults to 0.0, i.e. no throttling
+   * @param[in] use_wall_time   Whether to use ros::WallTime or not. Defaults to false
    */
   ThrottledCallback(Callback&& keep_callback = nullptr,  // NOLINT(whitespace/operators)
                     Callback&& drop_callback = nullptr,  // NOLINT(whitespace/operators)
-                    const ros::Duration& throttle_period = ros::Duration(0.0))
-    : keep_callback_(keep_callback), drop_callback_(drop_callback), throttle_period_(throttle_period)
+                    const ros::Duration& throttle_period = ros::Duration(0.0), const bool use_wall_time = false)
+    : keep_callback_(keep_callback)
+    , drop_callback_(drop_callback)
+    , throttle_period_(throttle_period)
+    , use_wall_time_(use_wall_time)
   {
   }
 
@@ -85,6 +89,16 @@ public:
   }
 
   /**
+   * @brief Use wall time flag getter
+   *
+   * @return True if using ros::WallTime, false otherwise
+   */
+  bool getUseWallTime() const
+  {
+    return use_wall_time_;
+  }
+
+  /**
    * @brief Throttle period setter
    *
    * @param[in] throttle_period The new throttle period duration in seconds to use
@@ -92,6 +106,16 @@ public:
   void setThrottlePeriod(const ros::Duration& throttle_period)
   {
     throttle_period_ = throttle_period;
+  }
+
+  /**
+   * @brief Use wall time flag setter
+   *
+   * @param[in] use_wall_time Whether to use ros::WallTime or not
+   */
+  void setUseWallTime(const bool use_wall_time)
+  {
+    use_wall_time_ = use_wall_time;
   }
 
   /**
@@ -132,7 +156,7 @@ public:
    */
   void callback(const MessageConstPtr& message)
   {
-    const auto now = ros::Time::now();
+    const ros::Time now = use_wall_time_ ? ros::Time(ros::WallTime::now().toSec()) : ros::Time::now();
     if (!last_called_time_.isValid() || now - last_called_time_ > throttle_period_)
     {
       if (keep_callback_)
@@ -152,6 +176,7 @@ private:
   Callback keep_callback_;         //!< The callback to call when the message is kept, i.e. not dropped
   Callback drop_callback_;         //!< The callback to call when the message is dropped because of throttling
   ros::Duration throttle_period_;  //!< The throttling period duration in seconds
+  bool use_wall_time_;             //<! The flag to indicate whether to use ros::WallTime or not
 
   ros::Time last_called_time_;  //!< The last time the keep callback was called
 };

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -1,0 +1,158 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
+#define FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
+
+#include <ros/subscriber.h>
+
+#include <functional>
+
+
+namespace fuse_models
+{
+
+namespace common
+{
+
+/**
+ * @brief A throttled callback that encapsulates the logic to throttle a message callback so it is only called after a
+ * given period in seconds (or more). The dropped messages can optionally be received in a dropped callback, that could
+ * be used to count the number of messages dropped.
+ *
+ * @tparam M The message the callback receives
+ */
+template <class M>
+class ThrottledCallback
+{
+public:
+  using MessageConstPtr = typename M::ConstPtr;
+  using Callback = std::function<void(const MessageConstPtr&)>;
+
+  /**
+   * @brief Constructor
+   *
+   * @param[in] keep_callback   The callback to call when the message is kept, i.e. not dropped. Defaults to nullptr
+   * @param[in] drop_callback   The callback to call when the message is dropped because of the throttling. Defaults to
+   *                            nullptr
+   * @param[in] throttle_period The throttling period duration in seconds. Defaults to 0.0, i.e. no throttling
+   */
+  ThrottledCallback(Callback keep_callback = nullptr, Callback drop_callback = nullptr,
+                    const ros::Duration& throttle_period = ros::Duration(0.0))
+    : keep_callback_(keep_callback), drop_callback_(drop_callback), throttle_period_(throttle_period)
+  {
+  }
+
+  /**
+   * @brief Throttle period getter
+   *
+   * @return The current throttle period duration in seconds being used
+   */
+  const ros::Duration& getThrottlePeriod() const
+  {
+    return throttle_period_;
+  }
+
+  /**
+   * @brief Throttle period setter
+   *
+   * @param[in] throttle_period The new throttle period duration in seconds to use
+   */
+  void setThrottlePeriod(const ros::Duration& throttle_period)
+  {
+    throttle_period_ = throttle_period;
+  }
+
+  /**
+   * @brief Keep callback setter
+   *
+   * @param[in] keep_callback The new keep callback to use
+   */
+  void setKeepCallback(const Callback& keep_callback)
+  {
+    keep_callback_ = keep_callback;
+  }
+
+  /**
+   * @brief Drop callback setter
+   *
+   * @param[in] drop_callback The new drop callback to use
+   */
+  void setDropCallback(const Callback& drop_callback)
+  {
+    drop_callback_ = drop_callback;
+  }
+
+  /**
+   * @brief Last called time
+   *
+   * @return The last time the keep callback was called
+   */
+  const ros::Time& getLastCalledTime() const
+  {
+    return last_called_time_;
+  }
+
+  /**
+   * @brief Message callback that throttles the calls to the keep callback provided. When the message is dropped because
+   * of throttling, the drop callback is called instead.
+   *
+   * @param[in] message The input message
+   */
+  void callback(const MessageConstPtr& message)
+  {
+    const auto now = ros::Time::now();
+    if (!last_called_time_.isValid() || now - last_called_time_ > throttle_period_)
+    {
+      keep_callback_(message);
+      last_called_time_ = now;
+    }
+    else if (drop_callback_)
+    {
+      drop_callback_(message);
+    }
+  }
+
+private:
+  Callback keep_callback_;         //!< The callback to call when the message is kept, i.e. not dropped
+  Callback drop_callback_;         //!< The callback to call when the message is dropped because of throttling
+  ros::Duration throttle_period_;  //!< The throttling period duration in seconds
+
+  ros::Time last_called_time_;  //!< The last time the keep callback was called
+};
+
+}  // namespace common
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -156,8 +156,13 @@ public:
    */
   void callback(const MessageConstPtr& message)
   {
+    // Keep the callback if:
+    //
+    // (a) This is the first call, i.e. the last called time is still invalid because it has not been set yet
+    // (b) The throttle period is zero, so we should always keep the callbacks
+    // (c) The elpased time between now and the last called time is greater than the throttle period
     const ros::Time now = use_wall_time_ ? ros::Time(ros::WallTime::now().toSec()) : ros::Time::now();
-    if (!last_called_time_.isValid() || now - last_called_time_ > throttle_period_)
+    if (!last_called_time_.isValid() || throttle_period_.isZero() || now - last_called_time_ > throttle_period_)
     {
       if (keep_callback_)
       {

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -35,6 +35,7 @@
 #define FUSE_MODELS_IMU_2D_H
 
 #include <fuse_models/parameters/imu_2d_params.h>
+#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -135,6 +136,9 @@ protected:
   tf2_ros::TransformListener tf_listener_;
 
   ros::Subscriber subscriber_;
+
+  using ImuThrottledCallback = common::ThrottledCallback<sensor_msgs::Imu>;
+  ImuThrottledCallback throttled_callback_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -35,6 +35,7 @@
 #define FUSE_MODELS_ODOMETRY_2D_H
 
 #include <fuse_models/parameters/odometry_2d_params.h>
+#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -129,6 +130,9 @@ protected:
   tf2_ros::TransformListener tf_listener_;
 
   ros::Subscriber subscriber_;
+
+  using OdometryThrottledCallback = common::ThrottledCallback<nav_msgs::Odometry>;
+  OdometryThrottledCallback throttled_callback_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -70,7 +70,7 @@ struct Acceleration2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
 
       double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -68,6 +68,11 @@ struct Acceleration2DParams : public ParameterBase
 
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+
+      double throttle_period_double = throttle_period.toSec();
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      throttle_period.fromSec(throttle_period_double);
+
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
@@ -76,6 +81,7 @@ struct Acceleration2DParams : public ParameterBase
 
     bool disable_checks { false };
     int queue_size { 10 };
+    ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> indices;

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -72,6 +72,7 @@ struct Acceleration2DParams : public ParameterBase
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
+      nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
@@ -82,6 +83,7 @@ struct Acceleration2DParams : public ParameterBase
     bool disable_checks { false };
     int queue_size { 10 };
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
+    bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> indices;

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -75,6 +75,11 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+
+      double throttle_period_double = throttle_period.toSec();
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      throttle_period.fromSec(throttle_period_double);
+
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);
       fuse_core::getParamRequired(nh, "topic", topic);
@@ -116,6 +121,7 @@ struct Imu2DParams : public ParameterBase
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
+    ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     double gravitational_acceleration { 9.80665 };
     std::string acceleration_target_frame {};
     std::string orientation_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -77,7 +77,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
 
       double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
 
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -79,6 +79,7 @@ struct Imu2DParams : public ParameterBase
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
+      nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);
@@ -122,6 +123,7 @@ struct Imu2DParams : public ParameterBase
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
+    bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     double gravitational_acceleration { 9.80665 };
     std::string acceleration_target_frame {};
     std::string orientation_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -77,6 +77,11 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+
+      double throttle_period_double = throttle_period.toSec();
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      throttle_period.fromSec(throttle_period_double);
+
       fuse_core::getParamRequired(nh, "topic", topic);
 
       if (!linear_velocity_indices.empty() || !angular_velocity_indices.empty())
@@ -108,6 +113,7 @@ struct Odometry2DParams : public ParameterBase
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
+    ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     std::string topic {};
     std::string pose_target_frame {};
     std::string twist_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -79,7 +79,7 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
 
       double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -81,6 +81,7 @@ struct Odometry2DParams : public ParameterBase
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
+      nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);
 
@@ -114,6 +115,7 @@ struct Odometry2DParams : public ParameterBase
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
+    bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};
     std::string pose_target_frame {};
     std::string twist_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -71,6 +71,11 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+
+      double throttle_period_double = throttle_period.toSec();
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      throttle_period.fromSec(throttle_period_double);
+
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
@@ -93,6 +98,7 @@ struct Pose2DParams : public ParameterBase
     bool independent { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
+    ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> position_indices;

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -73,7 +73,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
 
       double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -75,6 +75,7 @@ struct Pose2DParams : public ParameterBase
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
+      nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
@@ -99,6 +100,7 @@ struct Pose2DParams : public ParameterBase
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
+    bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> position_indices;

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -74,6 +74,7 @@ struct Twist2DParams : public ParameterBase
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
+      nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
@@ -85,6 +86,7 @@ struct Twist2DParams : public ParameterBase
     bool disable_checks { false };
     int queue_size { 10 };
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
+    bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> linear_indices;

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -70,6 +70,11 @@ struct Twist2DParams : public ParameterBase
 
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+
+      double throttle_period_double = throttle_period.toSec();
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      throttle_period.fromSec(throttle_period_double);
+
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
@@ -79,6 +84,7 @@ struct Twist2DParams : public ParameterBase
 
     bool disable_checks { false };
     int queue_size { 10 };
+    ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> linear_indices;

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -72,7 +72,7 @@ struct Twist2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
 
       double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
       throttle_period.fromSec(throttle_period_double);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -35,6 +35,7 @@
 #define FUSE_MODELS_POSE_2D_H
 
 #include <fuse_models/parameters/pose_2d_params.h>
+#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -120,6 +121,9 @@ protected:
   tf2_ros::TransformListener tf_listener_;
 
   ros::Subscriber subscriber_;
+
+  using PoseThrottledCallback = common::ThrottledCallback<geometry_msgs::PoseWithCovarianceStamped>;
+  PoseThrottledCallback throttled_callback_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -35,6 +35,7 @@
 #define FUSE_MODELS_TWIST_2D_H
 
 #include <fuse_models/parameters/twist_2d_params.h>
+#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -109,6 +110,9 @@ protected:
   tf2_ros::TransformListener tf_listener_;
 
   ros::Subscriber subscriber_;
+
+  using TwistThrottledCallback = common::ThrottledCallback<geometry_msgs::TwistWithCovarianceStamped>;
+  TwistThrottledCallback throttled_callback_;
 };
 
 }  // namespace fuse_models

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -52,7 +52,7 @@ Acceleration2D::Acceleration2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
   tf_listener_(tf_buffer_),
-  throttled_callback_(std::move(std::bind(&Acceleration2D::process, this, std::placeholders::_1)))
+  throttled_callback_(std::bind(&Acceleration2D::process, this, std::placeholders::_1))
 {
 }
 

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -64,6 +64,7 @@ void Acceleration2D::onInit()
   params_.loadFromROS(private_node_handle_);
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
+  throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
 
   if (params_.indices.empty())
   {

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -51,7 +51,8 @@ namespace fuse_models
 Acceleration2D::Acceleration2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_)
+  tf_listener_(tf_buffer_),
+  throttled_callback_(std::move(std::bind(&Acceleration2D::process, this, std::placeholders::_1)))
 {
 }
 
@@ -61,6 +62,8 @@ void Acceleration2D::onInit()
   device_id_ = fuse_variables::loadDeviceId(private_node_handle_);
 
   params_.loadFromROS(private_node_handle_);
+
+  throttled_callback_.setThrottlePeriod(params_.throttle_period);
 
   if (params_.indices.empty())
   {
@@ -73,8 +76,8 @@ void Acceleration2D::onStart()
 {
   if (!params_.indices.empty())
   {
-    subscriber_ =
-      node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Acceleration2D::process, this);
+    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
+                                         &AccelerationThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -56,7 +56,8 @@ namespace fuse_models
 Imu2D::Imu2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_)
+  tf_listener_(tf_buffer_),
+  throttled_callback_(std::move(std::bind(&Imu2D::process, this, std::placeholders::_1)))
 {
 }
 
@@ -66,6 +67,8 @@ void Imu2D::onInit()
   device_id_ = fuse_variables::loadDeviceId(private_node_handle_);
 
   params_.loadFromROS(private_node_handle_);
+
+  throttled_callback_.setThrottlePeriod(params_.throttle_period);
 
   if (params_.orientation_indices.empty() &&
       params_.linear_acceleration_indices.empty() &&
@@ -83,7 +86,8 @@ void Imu2D::onStart()
       !params_.angular_velocity_indices.empty())
   {
     previous_pose_.reset();
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Imu2D::process, this);
+    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
+                                         &ImuThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -57,7 +57,7 @@ Imu2D::Imu2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
   tf_listener_(tf_buffer_),
-  throttled_callback_(std::move(std::bind(&Imu2D::process, this, std::placeholders::_1)))
+  throttled_callback_(std::bind(&Imu2D::process, this, std::placeholders::_1))
 {
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -69,6 +69,7 @@ void Imu2D::onInit()
   params_.loadFromROS(private_node_handle_);
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
+  throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
 
   if (params_.orientation_indices.empty() &&
       params_.linear_acceleration_indices.empty() &&

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -66,6 +66,7 @@ void Odometry2D::onInit()
   params_.loadFromROS(private_node_handle_);
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
+  throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
 
   if (params_.position_indices.empty() &&
       params_.orientation_indices.empty() &&

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -54,7 +54,7 @@ Odometry2D::Odometry2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
   tf_listener_(tf_buffer_),
-  throttled_callback_(std::move(std::bind(&Odometry2D::process, this, std::placeholders::_1)))
+  throttled_callback_(std::bind(&Odometry2D::process, this, std::placeholders::_1))
 {
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -52,7 +52,7 @@ Pose2D::Pose2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
   tf_listener_(tf_buffer_),
-  throttled_callback_(std::move(std::bind(&Pose2D::process, this, std::placeholders::_1)))
+  throttled_callback_(std::bind(&Pose2D::process, this, std::placeholders::_1))
 {
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -64,6 +64,7 @@ void Pose2D::onInit()
   params_.loadFromROS(private_node_handle_);
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
+  throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
 
   if (params_.position_indices.empty() &&
       params_.orientation_indices.empty())

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -64,6 +64,7 @@ void Twist2D::onInit()
   params_.loadFromROS(private_node_handle_);
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
+  throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
 
   if (params_.linear_indices.empty() &&
       params_.angular_indices.empty())

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -51,7 +51,8 @@ namespace fuse_models
 Twist2D::Twist2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_)
+  tf_listener_(tf_buffer_),
+  throttled_callback_(std::move(std::bind(&Twist2D::process, this, std::placeholders::_1)))
 {
 }
 
@@ -61,6 +62,8 @@ void Twist2D::onInit()
   device_id_ = fuse_variables::loadDeviceId(private_node_handle_);
 
   params_.loadFromROS(private_node_handle_);
+
+  throttled_callback_.setThrottlePeriod(params_.throttle_period);
 
   if (params_.linear_indices.empty() &&
       params_.angular_indices.empty())
@@ -75,8 +78,8 @@ void Twist2D::onStart()
   if (!params_.linear_indices.empty() ||
       !params_.angular_indices.empty())
   {
-    subscriber_ =
-      node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Twist2D::process, this);
+    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
+                                         &TwistThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -52,7 +52,7 @@ Twist2D::Twist2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
   tf_listener_(tf_buffer_),
-  throttled_callback_(std::move(std::bind(&Twist2D::process, this, std::placeholders::_1)))
+  throttled_callback_(std::bind(&Twist2D::process, this, std::placeholders::_1))
 {
 }
 

--- a/fuse_models/test/test_throttled_callback.cpp
+++ b/fuse_models/test/test_throttled_callback.cpp
@@ -1,0 +1,268 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_models/common/throttled_callback.h>
+#include <geometry_msgs/Point.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+
+/**
+ * @brief A helper class to publish a given number geometry_msgs::Point messages at a given frequency.
+ *
+ * The messages published are geometry_msgs::Point because it is simple. The 'x' field is set to the number of messages
+ * published so far, starting at 0.
+ */
+class PointPublisher
+{
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param[in] frequency The publishing frequency in Hz
+   */
+  explicit PointPublisher(const double frequency)
+    : frequency_(frequency)
+  {
+    publisher_ = node_handle_.advertise<geometry_msgs::Point>("point", 1);
+  }
+
+  /**
+   * @brief Publish the given number of messages
+   *
+   * @param[in] num_messages The number of messages to publish
+   */
+  void publish(const size_t num_messages)
+  {
+    // Wait for the subscribers to be ready before sending them data:
+    ros::WallTime subscriber_timeout = ros::WallTime::now() + ros::WallDuration(1.0);
+    while (publisher_.getNumSubscribers() < 1u && ros::WallTime::now() < subscriber_timeout)
+    {
+      ros::WallDuration(0.01).sleep();
+    }
+
+    ASSERT_GE(publisher_.getNumSubscribers(), 1u);
+
+    // Send data:
+    ros::Rate rate(frequency_);
+    for (size_t i = 0; i < num_messages; ++i)
+    {
+      geometry_msgs::Point point_message;
+      point_message.x = i;
+
+      publisher_.publish(point_message);
+
+      rate.sleep();
+    }
+  }
+
+private:
+  ros::NodeHandle node_handle_;  //!< The node handle
+  ros::Publisher publisher_;     //!< The publisher
+  double frequency_{ 10.0 };     //!< The publish rate frequency
+};
+
+/**
+ * @brief A dummy point sensor model that uses a fuse_models::common::ThrottledCallback<geometry_msgs::Point> with a
+ * keep and drop callback.
+ *
+ * The callbacks simply count the number of times they are called, for testing purposes. The keep callback also caches
+ * the last message received, also for testing purposes.
+ */
+class PointSensorModel
+{
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param[in] throttle_period The throttle period duration in seconds
+   */
+  explicit PointSensorModel(const ros::Duration& throttle_period)
+    : throttled_callback_(std::bind(&PointSensorModel::keepCallback, this, std::placeholders::_1),
+                          std::bind(&PointSensorModel::dropCallback, this, std::placeholders::_1), throttle_period)
+  {
+    subscriber_ = node_handle_.subscribe("point", 10, &PointThrottledCallback::callback, &throttled_callback_);
+  }
+
+  /**
+   * @brief The kept messages counter getter
+   *
+   * @return The number of messages kept
+   */
+  size_t getKeptMessages() const
+  {
+    return kept_messages_;
+  }
+
+  /**
+   * @brief The dropped messages counter getter
+   *
+   * @return The number of messages dropped
+   */
+  size_t getDroppedMessages() const
+  {
+    return dropped_messages_;
+  }
+
+  /**
+   * @brief The last message kept getter
+   *
+   * @return The last message kept. It would be nullptr if no message has been kept so far
+   */
+  const geometry_msgs::Point::ConstPtr getLastKeptMessage() const
+  {
+    return last_kept_message_;
+  }
+
+private:
+  /**
+   * @brief Keep callback, that counts the number of times it has been called and caches the last message received
+   *
+   * @param[in] msg A geometry_msgs::Point message
+   */
+  void keepCallback(const geometry_msgs::Point::ConstPtr& msg)
+  {
+    ++kept_messages_;
+    last_kept_message_ = msg;
+  }
+
+  /**
+   * @brief Drop callback, that counts the number of times it has been called
+   *
+   * @param[in] msg A geometry_msgs::Point message (not used)
+   */
+  void dropCallback(const geometry_msgs::Point::ConstPtr& /*msg*/)
+  {
+    ++dropped_messages_;
+  }
+
+  ros::NodeHandle node_handle_;  //!< The node handle
+  ros::Subscriber subscriber_;   //!< The subscriber
+
+  using PointThrottledCallback = fuse_models::common::ThrottledCallback<geometry_msgs::Point>;
+  PointThrottledCallback throttled_callback_;  //!< The throttled callback
+
+  size_t kept_messages_{ 0 };                         //!< Messages kept
+  size_t dropped_messages_{ 0 };                      //!< Messages dropped
+  geometry_msgs::Point::ConstPtr last_kept_message_;  //!< The last message kept
+};
+
+
+TEST(ThrottledCallback, NoDroppedMessagesIfThrottlePeriodIsZero)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(0.0);
+  PointSensorModel sensor_model(throttled_period);
+
+  // Publish some messages:
+  const size_t num_messages = 10;
+  const double frequency = 10.0;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check all messages are kept and none are dropped, because when the throttle period is zero, throttling is disabled:
+  EXPECT_EQ(num_messages, sensor_model.getKeptMessages());
+  EXPECT_EQ(0u, sensor_model.getDroppedMessages());
+}
+
+TEST(ThrottledCallback, DropMessagesIfThrottlePeriodIsGreaterThanPublishPeriod)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(0.2);
+  PointSensorModel sensor_model(throttled_period);
+
+  // Publish some messages at half the throttled period:
+  const size_t num_messages = 10;
+  const double period_factor = 0.25;
+  const double period = period_factor * throttled_period.toSec();
+  const double frequency = 1.0 / period;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check the number of kept and dropped callbacks:
+  const auto expected_kept_messages = period_factor * num_messages;
+  const auto expected_dropped_messages = num_messages - expected_kept_messages;
+
+  EXPECT_NEAR(expected_kept_messages, sensor_model.getKeptMessages(), 1.0);
+  EXPECT_NEAR(expected_dropped_messages, sensor_model.getDroppedMessages(), 1.0);
+}
+
+TEST(ThrottledCallback, AlwaysKeepFirstMessageEvenIfThrottlePeriodIsTooLarge)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(10.0);
+  PointSensorModel sensor_model(throttled_period);
+
+  ASSERT_EQ(nullptr, sensor_model.getLastKeptMessage());
+
+  // Publish some messages:
+  const size_t num_messages = 10;
+  const double period = 0.1 * num_messages / throttled_period.toSec();
+  const double frequency = 1.0 / period;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check that regardless of the large throttled period, at least one message is ketpt:
+  EXPECT_EQ(1u, sensor_model.getKeptMessages());
+  EXPECT_EQ(num_messages - 1u, sensor_model.getDroppedMessages());
+
+  // Check the message kept was the first message:
+  const auto last_kept_message = sensor_model.getLastKeptMessage();
+  ASSERT_NE(nullptr, last_kept_message);
+  EXPECT_EQ(0.0, last_kept_message->x);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "throttled_callback_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/fuse_models/test/throttled_callback.test
+++ b/fuse_models/test/throttled_callback.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>	
+  <test test-name="throttled_callback_test" pkg="fuse_models" type="test_throttled_callback" />
+</launch>


### PR DESCRIPTION
# Contribution

This adds a `ThrottledCallback` class and uses it in all sensor models, so they can throttle the input messages at the user given `throttle_period`, which is a new ROS param added to all of them. This param defaults to `0.0`, so no throttling happens by default, which is the previous behaviour.

# Motivation

This makes things cleaner from outside, because even though we could use `rosrun topic_tools throttle messages`, that requires changes in the `launch` files and it doesn't scale well if we have to maintain multiple robots with different sensor suites and topic names. With this change we only need to set the `throttled_period` param in a `yaml` file, and we can even pass its value from a `launch` file with  `subst_value="true"` if we want to.