### PR TITLE
Add latch param to serialized publisher

### DIFF
--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -61,9 +61,12 @@ void SerializedPublisher::onInit()
   // Configure the publisher
   private_node_handle_.getParam("frame_id", frame_id_);
 
+  bool latch = true;
+  private_node_handle_.getParam("latch", latch);
+
   // Advertise the topics
-  graph_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1);
-  transaction_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1);
+  graph_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedGraph>("graph", 1, latch);
+  transaction_publisher_ = private_node_handle_.advertise<fuse_msgs::SerializedTransaction>("transaction", 1, latch);
 }
 
 void SerializedPublisher::notifyCallback(


### PR DESCRIPTION
Add `latch` ROS param to the `fuse_publishers::SerializedPublisher` (defaults to `true`) to allow making the `graph` and `transaction` output topics latch.

This is important if we want to record the `graph` topic and play back only the first message to initialize/ignite the optimizer.