### PR TITLE
Don't require frame if empty indices

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -859,7 +859,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
     }
   }
 
-  // Create a relative pose constraint. We assume the pose measurements are independent.
+  // Create a relative pose constraint.
   auto constraint = fuse_constraints::RelativePose2DStampedConstraint::make_shared(
     source,
     *position1,

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -79,9 +79,13 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       fuse_core::getParamRequired(nh, "topic", topic);
-      fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
 
-      if (!differential)
+      if (!linear_velocity_indices.empty() || !angular_velocity_indices.empty())
+      {
+        fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
+      }
+
+      if (!differential && (!position_indices.empty() || !orientation_indices.empty()))
       {
         fuse_core::getParamRequired(nh, "pose_target_frame", pose_target_frame);
       }


### PR DESCRIPTION
This simply makes the:
* `twist_target_frame` not required if there's no linear or angular velocity indices set
* `pose_target_frame` not required if there's no position or orientation indices set

And old comment is also updated.