### PR TITLE
Fix thread issue with UUID generation

### DIFF
--- a/fuse_core/src/uuid.cpp
+++ b/fuse_core/src/uuid.cpp
@@ -91,12 +91,17 @@ UUID generate()
   static std::uniform_int_distribution<uint64_t> distibution;
   static std::mutex distribution_mutex;
 
-  UUID u;
+  uint64_t random1;
+  uint64_t random2;
   {
     std::lock_guard<std::mutex> lock(distribution_mutex);
-    *reinterpret_cast<uint64_t*>(u.data) = generator();
-    *reinterpret_cast<uint64_t*>(u.data + 4) = generator();
+    random1 = generator();
+    random2 = generator();
   }
+
+  UUID u;
+  std::memcpy(u.data, &random1, 8);
+  std::memcpy(u.data + 8, &random2, 8);
 
   // set variant
   // must be 0b10xxxxxx


### PR DESCRIPTION
The original Boost random UUID generator is thread-safe, but it was very slow. Some time ago, I replaced the generator code with equivalent logic using the STL random library to improve performance. But had the downside of not being thread-safe. This manifests itself occasionally with different constraints having the same UUID.

This PR includes:
* A mutex lock on the random number generator to handle calls from multiple threads correctly.
* A slight refactor of how the random bits are copied into the UUID bytes in an attempt to minimize the lock time.