### PR TITLE
Fix motion model history

### DIFF
--- a/fuse_core/include/fuse_core/message_buffer.h
+++ b/fuse_core/include/fuse_core/message_buffer.h
@@ -162,6 +162,9 @@ protected:
 
   /**
    * @brief Remove any motion model segments that are older than \p buffer_length_
+   *
+   * The span of the buffer will be *at least* the requested buffer length, but it may be longer depending on the
+   * specific stamps of received messages.
    */
   void purgeHistory();
 };

--- a/fuse_core/include/fuse_core/message_buffer_impl.h
+++ b/fuse_core/include/fuse_core/message_buffer_impl.h
@@ -96,7 +96,7 @@ typename MessageBuffer<Message>::message_range MessageBuffer<Message>::query(
   }
   // Find the entry that is strictly greater than the requested beginning stamp. If the extended range flag is true,
   // we will then back up one entry.
-  auto upper_bound_comparison = [](const ros::Time& stamp, const typename Buffer::value_type& element) -> bool
+  auto upper_bound_comparison = [](const auto& stamp, const auto& element) -> bool
   {
     return (element.first > stamp);
   };
@@ -107,7 +107,7 @@ typename MessageBuffer<Message>::message_range MessageBuffer<Message>::query(
   }
   // Find the entry that is greater than or equal to the ending stamp. If the extended range flag is false, we will
   // back up one entry.
-  auto lower_bound_comparison = [](const typename Buffer::value_type& element, const ros::Time& stamp) -> bool
+  auto lower_bound_comparison = [](const auto& element, const auto& stamp) -> bool
   {
     return (element.first < stamp);
   };
@@ -139,21 +139,14 @@ void MessageBuffer<Message>::purgeHistory()
   }
 
   // Compute the expiration time carefully, as ROS can't handle negative times
-  const ros::Time& ending_stamp = buffer_.back().first;
-  ros::Time expiration_time;
-  if (ending_stamp.toSec() < buffer_length_.toSec())
-  {
-    expiration_time = ros::Time(0);
-  }
-  else
-  {
-    expiration_time = ending_stamp - buffer_length_;
-  }
+  const auto& ending_stamp = buffer_.back().first;
+  auto expiration_time =
+      ending_stamp.toSec() > buffer_length_.toSec() ? ending_stamp - buffer_length_ : ros::Time(0, 0);
   // Remove buffer elements before the expiration time.
   // Be careful to ensure that:
   //  - at least two entries remains at all times
   //  - the buffer covers *at least* until the expiration time. Longer is acceptable.
-  auto is_greater = [](const ros::Time& stamp, const typename Buffer::value_type& element) -> bool
+  auto is_greater = [](const auto& stamp, const auto& element) -> bool
   {
     return (element.first > stamp);
   };

--- a/fuse_core/test/test_message_buffer.cpp
+++ b/fuse_core/test/test_message_buffer.cpp
@@ -161,9 +161,9 @@ TEST_F(MessageBufferTestFixture, Purge)
     EXPECT_EQ(ros::Time(40, 0), *stamps_range_iter);
   }
 
-  // Add a new entry that is slightly in the future. Verify the oldest entry is removed.
+  // Add a new entry in the future. Verify the oldest entry is removed.
   {
-    buffer.insert(ros::Time(40, 1), 5);
+    buffer.insert(ros::Time(50, 0), 5);
     auto stamps_range = buffer.stamps();
     ASSERT_EQ(4, std::distance(stamps_range.begin(), stamps_range.end()));
     auto stamps_range_iter = stamps_range.begin();
@@ -173,7 +173,7 @@ TEST_F(MessageBufferTestFixture, Purge)
     ++stamps_range_iter;
     EXPECT_EQ(ros::Time(40, 0), *stamps_range_iter);
     ++stamps_range_iter;
-    EXPECT_EQ(ros::Time(40, 1), *stamps_range_iter);
+    EXPECT_EQ(ros::Time(50, 0), *stamps_range_iter);
   }
 
   // Add a longer entry. This should cause multiple entries to get purged.
@@ -184,7 +184,7 @@ TEST_F(MessageBufferTestFixture, Purge)
     auto stamps_range_iter = stamps_range.begin();
     EXPECT_EQ(ros::Time(40, 0), *stamps_range_iter);
     ++stamps_range_iter;
-    EXPECT_EQ(ros::Time(40, 1), *stamps_range_iter);
+    EXPECT_EQ(ros::Time(50, 0), *stamps_range_iter);
     ++stamps_range_iter;
     EXPECT_EQ(ros::Time(70, 0), *stamps_range_iter);
   }

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -316,12 +316,16 @@ void Unicycle2D::updateStateHistoryEstimates(
     expiration_time = state_history.rbegin()->first - buffer_length;
   }
 
-  auto current_iter = state_history.begin();
-
-  // always keep at least one entry in the buffer
-  while (state_history.size() > 1 && current_iter->first < expiration_time)
+  // Remove state history elements before the expiration time.
+  // Be careful to ensure that:
+  //  - at least one entry remains at all times
+  //  - the history covers *at least* until the expiration time. Longer is acceptable.
+  auto expiration_iter = state_history.upper_bound(expiration_time);
+  if (expiration_iter != state_history.begin())
   {
-    current_iter = state_history.erase(current_iter);
+    // expiration_iter points to the first element > expiration_time.
+    // Back up one entry, to a point that is <= expiration_time
+    state_history.erase(state_history.begin(), std::prev(expiration_iter));
   }
 
   // Update the states in the state history with information from the graph

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -304,17 +304,10 @@ void Unicycle2D::updateStateHistoryEstimates(
     return;
   }
 
-  ros::Time expiration_time;
-
-  // ROS can't handle negative times
-  if (state_history.rbegin()->first.toSec() < buffer_length.toSec())
-  {
-    expiration_time = ros::Time(0);
-  }
-  else
-  {
-    expiration_time = state_history.rbegin()->first - buffer_length;
-  }
+  // Compute the expiration time carefully, as ROS can't handle negative times
+  const auto& ending_stamp = state_history.rbegin()->first;
+  auto expiration_time =
+      ending_stamp.toSec() > buffer_length.toSec() ? ending_stamp - buffer_length : ros::Time(0, 0);
 
   // Remove state history elements before the expiration time.
   // Be careful to ensure that:


### PR DESCRIPTION
The motion model history was being pruned too much. This PR modifies the pruning logic to ensure that entries are available for *at least* the requested history length. This will generally mean that one entry will remain in the buffer that is before the expiration time.

Because the motion model is expected to generate segments for anything inside the history length, it was previously possible for the motion model to be missing the required data. This is particularly likely in situations with large time gaps between requests.

As an example, consider a history buffer with the following time entries:
```
{0s, 1s, 9s, 11s, 12s}
```
If the history length is set to 10s, then the original code would purge the t=0s and t=1s entries, as both are older than the t=2s limit (t=12s - 10s length). However, that would leave just the t=9s, t=11s, and t=12s entries. This is only a 3s history, much shorter history than the requested 10s. In contrast, with this PR in place, only the t=0s entry would be purged; the t=1s entry would remain. Thus, the history will span 11s, which is at least as large as the requested span of 10s.