### PR TITLE
Get positive param API change

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -402,9 +402,33 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Parameter tests
+  add_rostest_gtest(test_parameter
+    test/parameter.test
+    test/test_parameter.cpp
+  )
+  add_dependencies(test_parameter
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_parameter
+    PRIVATE
+      include
+      ${Boost_INCLUDE_DIRS}
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${EIGEN3_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_parameter
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_parameter
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Util tests
-  add_rostest_gtest(test_util
-    test/util.test
+  catkin_add_gtest(test_util
     test/test_util.cpp
   )
   add_dependencies(test_util

--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -34,13 +34,14 @@
 #ifndef FUSE_CORE_PARAMETER_H
 #define FUSE_CORE_PARAMETER_H
 
+#include <fuse_core/eigen.h>
 #include <fuse_core/loss_loader.h>
 
 #include <ros/node_handle.h>
 
 #include <stdexcept>
 #include <string>
-
+#include <vector>
 
 namespace fuse_core
 {
@@ -62,6 +63,72 @@ void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& valu
     ROS_FATAL_STREAM(error);
     throw std::runtime_error(error);
   }
+}
+
+/**
+ * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in, out] default_value - A default value to use if the provided parameter name does not exist. As output it
+ *                                 has the loaded (or default) value
+ * @param[in] strict - Whether to check the loaded value is strictly positive or not, i.e. whether 0 is accepted or not
+ */
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type* = nullptr>
+void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T& default_value,
+                      const bool strict = true)
+{
+  T value;
+  node_handle.param(parameter_name, value, default_value);
+  if (value < 0 || (strict && value == 0))
+  {
+    ROS_WARN_STREAM("The requested " << parameter_name << " is <" << (strict ? "=" : "") <<
+                    " 0. Using the default value (" << default_value << ") instead.");
+  }
+  else
+  {
+    default_value = value;
+  }
+}
+
+/**
+ * @brief Helper function that loads a covariance matrix diagonal vector from the parameter server and checks the size
+ * and the values are invalid, i.e. they are positive.
+ *
+ * @tparam Scalar - A scalar type, defaults to double
+ * @tparam Size - An int size that specifies the expected size of the covariance matrix (rows and columns)
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in] default_value - A default value to use for all the diagonal elements if the provided parameter name does
+ *                            not exist
+ * @return The loaded (or default) covariance matrix, generated from the diagonal vector
+ */
+template <int Size, typename Scalar = double>
+fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::NodeHandle& node_handle,
+                                                                 const std::string& parameter_name,
+                                                                 Scalar default_value)
+{
+  using Vector = typename Eigen::Matrix<Scalar, Size, 1>;
+
+  std::vector<Scalar> diagonal(Size, default_value);
+  node_handle.param(parameter_name, diagonal, diagonal);
+
+  const auto diagonal_size = diagonal.size();
+  if (diagonal_size != Size)
+  {
+    throw std::invalid_argument("Invalid size of " + std::to_string(diagonal_size) + ", expected " +
+                                std::to_string(Size));
+  }
+
+  if (std::any_of(diagonal.begin(), diagonal.end(),
+                  [](const auto& value) { return value < Scalar(0); }))  // NOLINT(whitespace/braces)
+  {
+    throw std::invalid_argument("Invalid negative diagonal values in " + fuse_core::to_string(Vector(diagonal.data())));
+  }
+
+  return Vector(diagonal.data()).asDiagonal();
 }
 
 /**

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -37,14 +37,10 @@
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
-#include <fuse_core/eigen.h>
-
 #include <ceres/jet.h>
 #include <Eigen/Core>
 
 #include <cmath>
-#include <string>
-#include <vector>
 
 
 namespace fuse_core
@@ -155,69 +151,6 @@ Eigen::Matrix<T, 2, 2, Eigen::RowMajor> rotationMatrix2D(const T angle)
   Eigen::Matrix<T, 2, 2, Eigen::RowMajor> rotation;
   rotation << cos_angle, -sin_angle, sin_angle, cos_angle;
   return rotation;
-}
-
-
-/**
- * @brief Helper function that loads strictly positive integral or floating point values from the parameter server
- *
- * @param[in] node_handle - The node handle used to load the parameter
- * @param[in] parameter_name - The parameter name to load
- * @param[in] default_value - A default value to use if the provided parameter name does not exist
- * @return The loaded (or default) value
- */
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type* = nullptr>
-T getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T default_value)
-{
-  T value;
-  node_handle.param(parameter_name, value, default_value);
-  if (value <= 0)
-  {
-    ROS_WARN_STREAM("The requested " << parameter_name << " is <= 0. Using the default value (" <<
-                    default_value << ") instead.");
-    value = default_value;
-  }
-  return value;
-}
-
-/**
- * @brief Helper function that loads a covariance matrix diagonal vector from the parameter server and checks the size
- * and the values are invalid, i.e. they are positive.
- *
- * @tparam Scalar - A scalar type, defaults to double
- * @tparam Size - An int size that specifies the expected size of the covariance matrix (rows and columns)
- *
- * @param[in] node_handle - The node handle used to load the parameter
- * @param[in] parameter_name - The parameter name to load
- * @param[in] default_value - A default value to use for all the diagonal elements if the provided parameter name does
- *                            not exist
- * @return The loaded (or default) covariance matrix, generated from the diagonal vector
- */
-template <int Size, typename Scalar = double>
-fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::NodeHandle& node_handle,
-                                                                 const std::string& parameter_name,
-                                                                 Scalar default_value)
-{
-  using Vector = typename Eigen::Matrix<Scalar, Size, 1>;
-
-  std::vector<Scalar> diagonal(Size, default_value);
-  node_handle.param(parameter_name, diagonal, diagonal);
-
-  const auto diagonal_size = diagonal.size();
-  if (diagonal_size != Size)
-  {
-    throw std::invalid_argument("Invalid size of " + std::to_string(diagonal_size) + ", expected " +
-                                std::to_string(Size));
-  }
-
-  if (std::any_of(diagonal.begin(), diagonal.end(),
-                  [](const auto& value) { return value < Scalar(0); }))  // NOLINT(whitespace/braces)
-  {
-    throw std::invalid_argument("Invalid negative diagonal values in " + fuse_core::to_string(Vector(diagonal.data())));
-  }
-
-  return Vector(diagonal.data()).asDiagonal();
 }
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -108,9 +108,9 @@ static inline T getYaw(const T w, const T x, const T y, const T z)
 }
 
 /**
- * @brief Wrap a 2D angle to the standard (-Pi, +Pi] range.
+ * @brief Wrap a 2D angle to the standard [-Pi, +Pi) range.
  *
- * @param[in/out] angle Input angle to be wrapped to the (-Pi, +Pi] range. Angle is updated by this function.
+ * @param[in/out] angle Input angle to be wrapped to the [-Pi, +Pi) range. Angle is updated by this function.
  */
 template <typename T>
 void wrapAngle2D(T& angle)

--- a/fuse_core/test/parameter.test
+++ b/fuse_core/test/parameter.test
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <rosparam file="$(find fuse_core)/test/parameter.yaml" command="load"/>
+
+  <test test-name="Parameter" pkg="fuse_core" type="test_parameter" />
+</launch>

--- a/fuse_core/test/parameter.yaml
+++ b/fuse_core/test/parameter.yaml
@@ -15,3 +15,12 @@ covariance_diagonal_with_strings: ["NaN", "NaN", "NaN"]
 
 # Covariance diagonal with invalid type:
 covariance_diagonal_with_string: "NaN"
+
+# Positive parameter:
+positive_parameter: 3.0
+
+# Negative parameter:
+negative_parameter: -3.0
+
+# Zero parameter:
+zero_parameter: 0.0

--- a/fuse_core/test/test_parameter.cpp
+++ b/fuse_core/test/test_parameter.cpp
@@ -1,0 +1,234 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/parameter.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <string>
+
+TEST(Parameter, GetPositiveParam)
+{
+  // Load parameters enforcing they are positive:
+  const double default_value{ 1.0 };
+
+  ros::NodeHandle node_handle;
+
+  // Load a positive parameter:
+  {
+    double parameter{ default_value };
+    fuse_core::getPositiveParam(node_handle, "positive_parameter", parameter);
+    EXPECT_EQ(3.0, parameter);
+  }
+
+  // Load a negative parameter:
+  {
+    double parameter{ default_value };
+    fuse_core::getPositiveParam(node_handle, "negative_parameter", parameter);
+    EXPECT_EQ(default_value, parameter);
+  }
+
+  // Load a zero parameter:
+  {
+    double parameter{ default_value };
+    fuse_core::getPositiveParam(node_handle, "zero_parameter", parameter);
+    EXPECT_EQ(default_value, parameter);
+  }
+
+  // Load a zero parameter allowing zero (not strict):
+  {
+    double parameter{ default_value };
+    fuse_core::getPositiveParam(node_handle, "zero_parameter", parameter, false);
+    EXPECT_EQ(0.0, parameter);
+  }
+}
+
+TEST(Parameter, GetCovarianceDiagonalParam)
+{
+  // Build expected covariance matrix:
+  constexpr int Size = 3;
+  constexpr double variance = 1.0e-3;
+  constexpr double default_variance = 0.0;
+
+  fuse_core::Matrix3d expected_covariance = fuse_core::Matrix3d::Identity();
+  expected_covariance *= variance;
+
+  fuse_core::Matrix3d default_covariance = fuse_core::Matrix3d::Identity();
+  default_covariance *= default_variance;
+
+  // Load covariance matrix diagonal from the parameter server:
+  ros::NodeHandle node_handle;
+
+  // A covariance diagonal with the expected size and valid should be the same as the expected one:
+  {
+    const std::string parameter_name{ "covariance_diagonal" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(expected_covariance.rows() * expected_covariance.cols(),
+                expected_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << expected_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // If the parameter does not exist we should get the default covariance:
+  {
+    const std::string parameter_name{ "non_existent_parameter" };
+
+    ASSERT_FALSE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // A covariance diagonal with negative values should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_negative_values" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with size 2, smaller than expected, should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_size_2" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with size 4, larger than expected, should throw std::invalid_argument:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_size_4" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
+                 std::invalid_argument);
+  }
+
+  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
+  // default covariance:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_strings" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+
+  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
+  // default covariance:
+  {
+    const std::string parameter_name{ "covariance_diagonal_with_string" };
+
+    ASSERT_TRUE(node_handle.hasParam(parameter_name));
+
+    try
+    {
+      const auto covariance =
+          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
+
+      EXPECT_EQ(Size, covariance.rows());
+      EXPECT_EQ(Size, covariance.cols());
+
+      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
+                default_covariance.cwiseEqual(covariance).count())
+          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
+    }
+    catch (const std::exception& ex)
+    {
+      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "parameter_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/fuse_core/test/test_util.cpp
+++ b/fuse_core/test/test_util.cpp
@@ -41,7 +41,7 @@
 
 TEST(Util, wrapAngle2D)
 {
-  // Wrap angle already in (-Pi, +Pi] range
+  // Wrap angle already in [-Pi, +Pi) range
   {
     const double angle = 0.5;
     EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle));
@@ -50,7 +50,7 @@ TEST(Util, wrapAngle2D)
   // Wrap angle equal to +Pi
   {
     const double angle = M_PI;
-    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle));
+    EXPECT_EQ(-angle, fuse_core::wrapAngle2D(angle));
   }
 
   // Wrap angle equal to -Pi

--- a/fuse_core/test/test_util.cpp
+++ b/fuse_core/test/test_util.cpp
@@ -39,160 +39,41 @@
 #include <numeric>
 #include <string>
 
-TEST(Util, GetCovarianceDiagonalParam)
+TEST(Util, wrapAngle2D)
 {
-  // Build expected covariance matrix:
-  constexpr int Size = 3;
-  constexpr double variance = 1.0e-3;
-  constexpr double default_variance = 0.0;
-
-  fuse_core::Matrix3d expected_covariance = fuse_core::Matrix3d::Identity();
-  expected_covariance *= variance;
-
-  fuse_core::Matrix3d default_covariance = fuse_core::Matrix3d::Identity();
-  default_covariance *= default_variance;
-
-  // Load covariance matrix diagonal from the parameter server:
-  ros::NodeHandle node_handle;
-
-  // A covariance diagonal with the expected size and valid should be the same as the expected one:
+  // Wrap angle already in (-Pi, +Pi] range
   {
-    const std::string parameter_name{ "covariance_diagonal" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    try
-    {
-      const auto covariance =
-          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
-
-      EXPECT_EQ(Size, covariance.rows());
-      EXPECT_EQ(Size, covariance.cols());
-
-      EXPECT_EQ(expected_covariance.rows() * expected_covariance.cols(),
-                expected_covariance.cwiseEqual(covariance).count())
-          << "Expected\n" << expected_covariance << "\nActual\n" << covariance;
-    }
-    catch (const std::exception& ex)
-    {
-      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
-    }
+    const double angle = 0.5;
+    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle));
   }
 
-  // If the parameter does not exist we should get the default covariance:
+  // Wrap angle equal to +Pi
   {
-    const std::string parameter_name{ "non_existent_parameter" };
-
-    ASSERT_FALSE(node_handle.hasParam(parameter_name));
-
-    try
-    {
-      const auto covariance =
-          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
-
-      EXPECT_EQ(Size, covariance.rows());
-      EXPECT_EQ(Size, covariance.cols());
-
-      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
-                default_covariance.cwiseEqual(covariance).count())
-          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
-    }
-    catch (const std::exception& ex)
-    {
-      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
-    }
+    const double angle = M_PI;
+    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle));
   }
 
-  // A covariance diagonal with negative values should throw std::invalid_argument:
+  // Wrap angle equal to -Pi
   {
-    const std::string parameter_name{ "covariance_diagonal_with_negative_values" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
-                 std::invalid_argument);
+    const double angle = -M_PI;
+    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle));
   }
 
-  // A covariance diagonal with size 2, smaller than expected, should throw std::invalid_argument:
+  // Wrap angle greater than +Pi
   {
-    const std::string parameter_name{ "covariance_diagonal_with_size_2" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
-                 std::invalid_argument);
+    const double angle = 0.5;
+    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle + 3.0 * 2.0 * M_PI));
   }
 
-  // A covariance diagonal with size 4, larger than expected, should throw std::invalid_argument:
+  // Wrap angle smaller than -Pi
   {
-    const std::string parameter_name{ "covariance_diagonal_with_size_4" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    EXPECT_THROW(fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance),
-                 std::invalid_argument);
-  }
-
-  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
-  // default covariance:
-  {
-    const std::string parameter_name{ "covariance_diagonal_with_strings" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    try
-    {
-      const auto covariance =
-          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
-
-      EXPECT_EQ(Size, covariance.rows());
-      EXPECT_EQ(Size, covariance.cols());
-
-      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
-                default_covariance.cwiseEqual(covariance).count())
-          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
-    }
-    catch (const std::exception& ex)
-    {
-      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
-    }
-  }
-
-  // A covariance diagonal with invalid element type does not throw, but nothing it is loaded, so we should get the
-  // default covariance:
-  {
-    const std::string parameter_name{ "covariance_diagonal_with_string" };
-
-    ASSERT_TRUE(node_handle.hasParam(parameter_name));
-
-    try
-    {
-      const auto covariance =
-          fuse_core::getCovarianceDiagonalParam<Size>(node_handle, parameter_name, default_variance);
-
-      EXPECT_EQ(Size, covariance.rows());
-      EXPECT_EQ(Size, covariance.cols());
-
-      EXPECT_EQ(default_covariance.rows() * default_covariance.cols(),
-                default_covariance.cwiseEqual(covariance).count())
-          << "Expected\n" << default_covariance << "\nActual\n" << covariance;
-    }
-    catch (const std::exception& ex)
-    {
-      FAIL() << "Failed to get " << node_handle.resolveName(parameter_name) << ": " << ex.what();
-    }
+    const double angle = 0.5;
+    EXPECT_EQ(angle, fuse_core::wrapAngle2D(angle - 3.0 * 2.0 * M_PI));
   }
 }
 
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "util_test");
-
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
-  int ret = RUN_ALL_TESTS();
-  spinner.stop();
-  ros::shutdown();
-  return ret;
+  return RUN_ALL_TESTS();
 }

--- a/fuse_core/test/util.test
+++ b/fuse_core/test/util.test
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<launch>
-  <rosparam file="$(find fuse_core)/test/util.yaml" command="load"/>
-
-  <test test-name="Util" pkg="fuse_core" type="test_util" />
-</launch>

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -38,7 +38,6 @@
 
 #include <fuse_core/loss.h>
 #include <fuse_core/parameter.h>
-#include <fuse_core/util.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -38,7 +38,6 @@
 
 #include <fuse_core/loss.h>
 #include <fuse_core/parameter.h>
-#include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -38,7 +38,7 @@
 
 #include <fuse_core/ceres_options.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/util.h>
+#include <fuse_core/parameter.h>
 
 #include <ros/console.h>
 #include <ros/node_handle.h>

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -38,7 +38,6 @@
 
 #include <fuse_core/loss.h>
 #include <fuse_core/parameter.h>
-#include <fuse_core/util.h>
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <fuse_variables/position_2d_stamped.h>
 #include <ros/node_handle.h>

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -35,7 +35,7 @@
 #define FUSE_OPTIMIZERS_BATCH_OPTIMIZER_PARAMS_H
 
 #include <fuse_core/ceres_options.h>
-#include <fuse_core/util.h>
+#include <fuse_core/parameter.h>
 #include <ros/duration.h>
 #include <ros/node_handle.h>
 
@@ -97,19 +97,19 @@ public:
 
     if (nh.hasParam("optimization_frequency"))
     {
-      auto optimization_frequency =
-        fuse_core::getPositiveParam(nh, "optimization_frequency", 1.0 / optimization_period.toSec());
+      double optimization_frequency{ 1.0 / optimization_period.toSec() };
+      fuse_core::getPositiveParam(nh, "optimization_frequency", optimization_frequency);
       optimization_period.fromSec(1.0 / optimization_frequency);
     }
     else
     {
-      auto optimization_period_sec =
-        fuse_core::getPositiveParam(nh, "optimization_period", optimization_period.toSec());
+      double optimization_period_sec{ optimization_period.toSec() };
+      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period_sec);
       optimization_period.fromSec(optimization_period_sec);
     }
 
-    auto transaction_timeout_sec =
-      fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
+    double transaction_timeout_sec{ transaction_timeout.toSec() };
+    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout_sec);
     transaction_timeout.fromSec(transaction_timeout_sec);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -35,7 +35,7 @@
 #define FUSE_OPTIMIZERS_FIXED_LAG_SMOOTHER_PARAMS_H
 
 #include <fuse_core/ceres_options.h>
-#include <fuse_core/util.h>
+#include <fuse_core/parameter.h>
 #include <ros/duration.h>
 #include <ros/node_handle.h>
 
@@ -105,26 +105,27 @@ public:
     nh.getParam("ignition_sensors", ignition_sensors);
     std::sort(ignition_sensors.begin(), ignition_sensors.end());
 
-    auto lag_duration_sec = fuse_core::getPositiveParam(nh, "lag_duration", lag_duration.toSec());
+    double lag_duration_sec{ lag_duration.toSec() };
+    fuse_core::getPositiveParam(nh, "lag_duration", lag_duration_sec);
     lag_duration.fromSec(lag_duration_sec);
 
     if (nh.hasParam("optimization_frequency"))
     {
-      auto optimization_frequency =
-        fuse_core::getPositiveParam(nh, "optimization_frequency", 1.0 / optimization_period.toSec());
+      double optimization_frequency{ 1.0 / optimization_period.toSec() };
+      fuse_core::getPositiveParam(nh, "optimization_frequency", optimization_frequency);
       optimization_period.fromSec(1.0 / optimization_frequency);
     }
     else
     {
-      auto optimization_period_sec =
-        fuse_core::getPositiveParam(nh, "optimization_period", optimization_period.toSec());
+      double optimization_period_sec{ optimization_period.toSec() };
+      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period_sec);
       optimization_period.fromSec(optimization_period_sec);
     }
 
     nh.getParam("reset_service", reset_service);
 
-    auto transaction_timeout_sec =
-      fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout.toSec());
+    double transaction_timeout_sec{ transaction_timeout.toSec() };
+    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout_sec);
     transaction_timeout.fromSec(transaction_timeout_sec);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);


### PR DESCRIPTION
This changes the `fuse_core::getPositiveParam` API so it matches the `getParam` and `getRequiredParam` ones. That is, the loaded value is not `return`ed, but set in the input/output argument that holds the default value.

This also moves all the helper functions related with ROS parameters into the `parameter.h` header, and updates the ros and unit test accordingly. Some of these functions where in the more generic header `util.h`.

In order to keep the tests for the `util.h` header, this adds a test for `fuse_core::wrapAngle2D`. There's another commit that updates the expected range from `(-Pi, +Pi]` to `[-Pi, +Pi)`, since that seems to be the actual behaviour. This is likely indifferent. Otherwise, the implementation should be changed.