### PR TITLE
Filter out transactions older than the lag window

### DIFF
--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -122,6 +122,22 @@ public:
   const_stamp_range involvedStamps() const { return involved_stamps_; }
 
   /**
+   * @brief Read-only access to the minimum (oldest), timestamp among the transaction's stamp and all involved
+   * timestamps, if any
+   *
+   * @return The minimum (oldest) timestamp.
+   */
+  const ros::Time& minStamp() const;
+
+  /**
+   * @brief Read-only access to the maximum (newest) timestamp among the transaction's stamp and all involved
+   * timestamps, if any
+   *
+   * @return The maximum (newest) timestamp.
+   */
+  const ros::Time& maxStamp() const;
+
+  /**
    * @brief Read-only access to the added constraints
    *
    * @return  An iterator range containing all added constraints

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -48,6 +48,30 @@
 namespace fuse_core
 {
 
+const ros::Time& Transaction::minStamp() const
+{
+  if (involved_stamps_.empty())
+  {
+    return stamp_;
+  }
+  else
+  {
+    return std::min(*involved_stamps_.begin(), stamp_);
+  }
+}
+
+const ros::Time& Transaction::maxStamp() const
+{
+  if (involved_stamps_.empty())
+  {
+    return stamp_;
+  }
+  else
+  {
+    return std::max(*involved_stamps_.rbegin(), stamp_);
+  }
+}
+
 void Transaction::addInvolvedStamp(const ros::Time& stamp)
 {
   involved_stamps_.insert(stamp);
@@ -211,6 +235,7 @@ void Transaction::merge(const Transaction& other, bool overwrite)
 
 void Transaction::print(std::ostream& stream) const
 {
+  stream << "Stamp: " << stamp_ << "\n";
   stream << "Involved Timestamps:\n";
   for (const auto& involved_stamp : involved_stamps_)
   {

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -189,7 +189,12 @@ protected:
    *
    * @param[in] new_transaction All new, non-marginal-related transactions that *will be* applied to the graph
    */
-  virtual void preprocessMarginalization(const fuse_core::Transaction& new_transaction);
+  void preprocessMarginalization(const fuse_core::Transaction& new_transaction);
+
+  /**
+   * @brief Compute the oldest timestamp that is part of the configured lag window
+   */
+  ros::Time computeLagExpirationTime() const;
 
   /**
    * @brief Compute the set of variables that should be marginalized from the graph
@@ -197,9 +202,10 @@ protected:
    * This will be called after \p preprocessMarginalization() and after the graph has been updated with the any
    * previous marginal transactions and new transactions.
    *
+   * @param[in] lag_expiration The oldest timestamp that should remain in the graph
    * @return A container with the set of variables to marginalize out. Order of the variables is not specified.
    */
-  virtual std::vector<fuse_core::UUID> computeVariablesToMarginalize();
+  std::vector<fuse_core::UUID> computeVariablesToMarginalize(const ros::Time& lag_expiration);
 
   /**
    * @brief Perform any required post-marginalization bookkeeping
@@ -210,7 +216,7 @@ protected:
    * @param[in] marginal_transaction The actual changes to the graph caused my marginalizing out the requested
    *                                 variables.
    */
-  virtual void postprocessMarginalization(const fuse_core::Transaction& marginal_transaction);
+  void postprocessMarginalization(const fuse_core::Transaction& marginal_transaction);
 
   /**
    * @brief Function that optimizes all constraints, designed to be run in a separate thread.
@@ -238,8 +244,9 @@ protected:
    * deleted from the pending queue and a warning will be displayed.
    *
    * @param[out] transaction The transaction object to be augmented with pending motion model and sensor transactions
+   * @param[in]  lag_expiration The oldest timestamp that should remain in the graph
    */
-  void processQueue(fuse_core::Transaction& transaction);
+  void processQueue(fuse_core::Transaction& transaction, const ros::Time& lag_expiration);
 
   /**
    * @brief Service callback that resets the optimizer to its original state

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -136,6 +136,8 @@ protected:
     fuse_core::Transaction::SharedPtr transaction;
 
     const ros::Time& stamp() const { return transaction->stamp(); }
+    const ros::Time& minStamp() const { return transaction->minStamp(); }
+    const ros::Time& maxStamp() const { return transaction->maxStamp(); }
   };
 
   /**

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -150,6 +150,7 @@ protected:
    */
   using TransactionQueue = std::vector<TransactionQueueElement>;
 
+  ros::Time lag_expiration_;  //!< The oldest stamp that is inside the fixed-lag smoother window
   fuse_core::Transaction marginal_transaction_;  //!< The marginals to add during the next optimization cycle
   ros::Time optimization_deadline_;  //!< The deadline for the optimization to complete. Triggers a warning if exceeded.
   std::mutex optimization_mutex_;  //!< Mutex held while the graph is begin optimized

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -261,9 +261,6 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction, const r
     return;
   }
 
-  // Use the most recent transaction time as the current time
-  const auto current_time = pending_transactions_.front().stamp();
-
   // If we just started because an ignition sensor transaction was received, we try to process it individually. This is
   // important because we need to update the graph with the ignition sensor transaction in order to get the motion
   // models notified of the initial state. The motion models will typically maintain a state history in order to create
@@ -335,6 +332,9 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction, const r
     }
   }
 
+  // Use the most recent transaction time as the current time
+  const auto current_time = pending_transactions_.front().stamp();
+
   // Attempt to process each pending transaction
   auto sensor_blacklist = std::vector<std::string>();
   auto transaction_riter = pending_transactions_.rbegin();
@@ -369,7 +369,7 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction, const r
       if (max_stamp + params_.transaction_timeout < current_time)
       {
         // Warn that this transaction has expired, then skip it.
-        ROS_ERROR_STREAM("The queued transaction with timestamp " << element.stamp() << "and maximum "
+        ROS_ERROR_STREAM("The queued transaction with timestamp " << element.stamp() << " and maximum "
                           "involved stamp of " << max_stamp << " from sensor " << element.sensor_name <<
                           " could not be processed after " << (current_time - max_stamp) << " seconds, "
                           "which is greater than the 'transaction_timeout' value of " <<

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -82,11 +82,11 @@ FixedLagSmoother::FixedLagSmoother(
   const ros::NodeHandle& node_handle,
   const ros::NodeHandle& private_node_handle) :
     fuse_optimizers::Optimizer(std::move(graph), node_handle, private_node_handle),
+    start_time_(ros::TIME_MAX),
+    ignited_(false),
     optimization_request_(false),
     optimization_running_(true),
-    start_time_(ros::TIME_MAX),
-    started_(false),
-    ignited_(false)
+    started_(false)
 {
   params_.loadFromROS(private_node_handle);
 

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -143,7 +143,7 @@ ros::Time FixedLagSmoother::computeLagExpirationTime() const
   // Find the most recent variable timestamp
   auto now = timestamp_tracking_.currentStamp();
   // Then carefully subtract the lag duration. ROS Time objects do not handle negative values.
-  return (ros::Time(0, 0) + params_.lag_duration > now) ? ros::Time(0, 0) : now - params_.lag_duration;
+  return (ros::Time(0, 0) + params_.lag_duration < now) ? now - params_.lag_duration : ros::Time(0, 0);
 }
 
 std::vector<fuse_core::UUID> FixedLagSmoother::computeVariablesToMarginalize(const ros::Time& lag_expiration)


### PR DESCRIPTION
There is a bug where old sensor data is getting added to the fixed-lag smoother. This PR fixes that by correctly filtering out old sensor transactions before that are inserted into the graph. For thread synchronization reasons, this is done inside of the optimization thread rather than in the ROS callback thread.