### PR TITLE
Delay throttle no valid state message

### DIFF
--- a/fuse_core/include/fuse_core/console.h
+++ b/fuse_core/include/fuse_core/console.h
@@ -1,0 +1,108 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_CONSOLE_H
+#define FUSE_CORE_CONSOLE_H
+
+#include <ros/console.h>
+#include <ros/time.h>
+
+// Define the helper macro ROSCONSOLE_THROTTLE_CHECK if it is not defined in the ros/console.h version available.
+// This macro was introduced in https://github.com/ros/rosconsole/pull/12 and released in rosconsole version 1.13.8.
+#ifndef ROSCONSOLE_THROTTLE_CHECK
+#define ROSCONSOLE_THROTTLE_CHECK(now, last, period) (ROS_UNLIKELY(last + period <= now) || ROS_UNLIKELY(now < last))
+#endif
+
+namespace fuse_core
+{
+
+/**
+ * @brief ROS console filter that prints messages with ROS_*_DELAYED_THROTTLE and allows to reset the last time the
+ * message was print, so the delayed and throttle conditions are computed from the initial state again.
+ */
+class DelayedThrottleFilter : public ros::console::FilterBase
+{
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param[in] The throttle period in seconds
+   */
+  explicit DelayedThrottleFilter(const double period) : period_(period)
+  {
+  }
+
+  /**
+   * @brief Returns whether or not the log statement should be printed. Called before the log arguments are evaluated
+   * and the message is formatted.
+   *
+   * This works as ROS_*_DELAYED_THROTTLE but the last time the filter condition was hit is handled by this filter, so
+   * it can be reset.
+   *
+   * @return True if the filter condition is hit, false otherwise
+   */
+  bool isEnabled() override
+  {
+    const auto now = ros::Time::now().toSec();
+
+    if (last_hit_ < 0.0)
+    {
+      last_hit_ = now;
+    }
+
+    if (ROSCONSOLE_THROTTLE_CHECK(now, last_hit_, period_))
+    {
+      last_hit_ = now;
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * @brief Rests the last time the filter condition was hit
+   */
+  void reset()
+  {
+    last_hit_ = -1.0;
+  }
+
+private:
+  double period_{ 0.0 };     //!< The throttle period in seconds
+  double last_hit_{ -1.0 };  //!< The last time in seconds the filter condition was hit, and the message was printed. A
+                             //!< negative value means it has never been hit
+};
+
+}  // namespace fuse_core
+
+#endif  // FUSE_CORE_CONSOLE_H

--- a/fuse_core/include/fuse_core/console.h
+++ b/fuse_core/include/fuse_core/console.h
@@ -37,11 +37,6 @@
 #include <ros/console.h>
 #include <ros/time.h>
 
-// Define the helper macro ROSCONSOLE_THROTTLE_CHECK if it is not defined in the ros/console.h version available.
-// This macro was introduced in https://github.com/ros/rosconsole/pull/12 and released in rosconsole version 1.13.8.
-#ifndef ROSCONSOLE_THROTTLE_CHECK
-#define ROSCONSOLE_THROTTLE_CHECK(now, last, period) (ROS_UNLIKELY(last + period <= now) || ROS_UNLIKELY(now < last))
-#endif
 
 namespace fuse_core
 {

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -17,6 +17,7 @@
   <depend>fuse_msgs</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
+  <depend version_gte="1.13.8">rosconsole</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 </package>

--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -37,6 +37,7 @@
 #include <fuse_models/parameters/odometry_2d_publisher_params.h>
 
 #include <fuse_core/async_publisher.h>
+#include <fuse_core/console.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
@@ -198,6 +199,9 @@ protected:
   tf2_ros::TransformBroadcaster tf_broadcaster_;
 
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  fuse_core::DelayedThrottleFilter delayed_throttle_filter_{ 10.0 };  //!< A ros::console filter to print delayed
+                                                                      //!< throttle messages, that can be reset on start
 
   ros::Timer publish_timer_;
 };

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -195,6 +195,7 @@ void Odometry2DPublisher::onStart()
   odom_output_ = nav_msgs::Odometry();
   acceleration_output_ = geometry_msgs::AccelWithCovarianceStamped();
   publish_timer_.start();
+  delayed_throttle_filter_.reset();
 }
 
 void Odometry2DPublisher::onStop()
@@ -272,7 +273,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 {
   if (latest_stamp_ == Synchronizer::TIME_ZERO)
   {
-    ROS_WARN_STREAM_THROTTLE(10.0, "No valid state data yet. Delaying tf broadcast.");
+    ROS_WARN_STREAM_FILTER(&delayed_throttle_filter_, "No valid state data yet. Delaying tf broadcast.");
     return;
   }
 


### PR DESCRIPTION
This makes the `No valid state data yet. Delaying tf broadcast.` **WARN** message from the `Odometry2DPublisher` delayed, i.e. only printed after the throttle period, not immediately.

It also adds a `ros::console::FilterBase` child class that implements the equivalent to `ROS_*_DELAYED_THROTTLE` (see http://wiki.ros.org/roscpp/Overview/Logging and http://docs.ros.org/api/rosconsole/html/console_8h_source.html) and allows to reset it, so when `onStart` is called, it's delayed again.

The motivation is to avoid the first **WARN** message that always gets printed on startup or after a setting a pose.

You can `rosservice call` the `reset` service to force it print after the throttle period expires.