### PR TITLE
Sort transactions by minimum timestamp and purge wrt the maximum timestamp of all pending transactions

### DIFF
--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -122,6 +122,22 @@ public:
   const_stamp_range involvedStamps() const { return involved_stamps_; }
 
   /**
+   * @brief Read-only access to the minimum (oldest), timestamp among the transaction's stamp and all involved
+   * timestamps, if any
+   *
+   * @return The minimum (oldest) timestamp.
+   */
+  const ros::Time& minStamp() const;
+
+  /**
+   * @brief Read-only access to the maximum (newest) timestamp among the transaction's stamp and all involved
+   * timestamps, if any
+   *
+   * @return The maximum (newest) timestamp.
+   */
+  const ros::Time& maxStamp() const;
+
+  /**
    * @brief Read-only access to the added constraints
    *
    * @return  An iterator range containing all added constraints

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -211,6 +211,7 @@ void Transaction::merge(const Transaction& other, bool overwrite)
 
 void Transaction::print(std::ostream& stream) const
 {
+  stream << "Stamp: " << stamp_ << "\n";
   stream << "Involved Timestamps:\n";
   for (const auto& involved_stamp : involved_stamps_)
   {

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -48,6 +48,30 @@
 namespace fuse_core
 {
 
+const ros::Time& Transaction::minStamp() const
+{
+  if (involved_stamps_.empty())
+  {
+    return stamp_;
+  }
+  else
+  {
+    return std::min(*involved_stamps_.begin(), stamp_);
+  }
+}
+
+const ros::Time& Transaction::maxStamp() const
+{
+  if (involved_stamps_.empty())
+  {
+    return stamp_;
+  }
+  else
+  {
+    return std::max(*involved_stamps_.rbegin(), stamp_);
+  }
+}
+
 void Transaction::addInvolvedStamp(const ros::Time& stamp)
 {
   involved_stamps_.insert(stamp);

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -189,7 +189,12 @@ protected:
    *
    * @param[in] new_transaction All new, non-marginal-related transactions that *will be* applied to the graph
    */
-  virtual void preprocessMarginalization(const fuse_core::Transaction& new_transaction);
+  void preprocessMarginalization(const fuse_core::Transaction& new_transaction);
+
+  /**
+   * @brief Compute the oldest timestamp that is part of the configured lag window
+   */
+  ros::Time computeLagExpirationTime() const;
 
   /**
    * @brief Compute the set of variables that should be marginalized from the graph
@@ -197,9 +202,10 @@ protected:
    * This will be called after \p preprocessMarginalization() and after the graph has been updated with the any
    * previous marginal transactions and new transactions.
    *
+   * @param[in] lag_expiration The oldest timestamp that should remain in the graph
    * @return A container with the set of variables to marginalize out. Order of the variables is not specified.
    */
-  virtual std::vector<fuse_core::UUID> computeVariablesToMarginalize();
+  std::vector<fuse_core::UUID> computeVariablesToMarginalize(const ros::Time& lag_expiration);
 
   /**
    * @brief Perform any required post-marginalization bookkeeping
@@ -210,7 +216,7 @@ protected:
    * @param[in] marginal_transaction The actual changes to the graph caused my marginalizing out the requested
    *                                 variables.
    */
-  virtual void postprocessMarginalization(const fuse_core::Transaction& marginal_transaction);
+  void postprocessMarginalization(const fuse_core::Transaction& marginal_transaction);
 
   /**
    * @brief Function that optimizes all constraints, designed to be run in a separate thread.
@@ -238,8 +244,9 @@ protected:
    * deleted from the pending queue and a warning will be displayed.
    *
    * @param[out] transaction The transaction object to be augmented with pending motion model and sensor transactions
+   * @param[in]  lag_expiration The oldest timestamp that should remain in the graph
    */
-  void processQueue(fuse_core::Transaction& transaction);
+  void processQueue(fuse_core::Transaction& transaction, const ros::Time& lag_expiration);
 
   /**
    * @brief Service callback that resets the optimizer to its original state

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -136,6 +136,8 @@ protected:
     fuse_core::Transaction::SharedPtr transaction;
 
     const ros::Time& stamp() const { return transaction->stamp(); }
+    const ros::Time& minStamp() const { return transaction->minStamp(); }
+    const ros::Time& maxStamp() const { return transaction->maxStamp(); }
   };
 
   /**

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -262,9 +262,6 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction, const r
     return;
   }
 
-  // Use the most recent transaction time as the current time
-  const auto current_time = pending_transactions_.front().stamp();
-
   // If we just started because an ignition sensor transaction was received, we try to process it individually. This is
   // important because we need to update the graph with the ignition sensor transaction in order to get the motion
   // models notified of the initial state. The motion models will typically maintain a state history in order to create
@@ -335,6 +332,9 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction, const r
       return;
     }
   }
+
+  // Use the most recent transaction time as the current time
+  const auto current_time = pending_transactions_.front().stamp();
 
   // Attempt to process each pending transaction
   auto sensor_blacklist = std::vector<std::string>();


### PR DESCRIPTION
This is on top of https://github.com/locusrobotics/fuse/pull/173. I actually cherry-picked your commit, @svwilliams .

This stores the transaction's mininum involved stamp into the `pending_transactions_` queue, instead of the transaction stamp. And when purging, the `last_pending_time` or `current_time` is set to the maximum of all transactions's maximum involved stamp.

This gets rids of the following **WARN** and **ERROR** messages:
``` bash
[INFO]: Received a set_pose request (stamp: 173.570000000, x: 1.4, y: 0.525, yaw: -0.0350735)
[WARN ]: Unable to locate a state in this history with stamp <= 173.540000000. Variables will all be initialized to 0.

[ERROR]: The queued transaction with timestamp 2589.220000000 from sensor laser_odometry is not an ignition sensor transaction. This transaction will not be processed individually.
```

I could work on a unit test to exercise this. The idea would be to extend the existing fixed lag ignition test to create a transaction with a relative constraints that has a minimum involved timestamp older than the transaction with the ignition timestamp, but a transaction stamp (and maximum involved timestamp) newer than it. If you think this PR is a good change, I can work on that. :thinking: 

Consider this a quick change, not very well tested, and still open to discussion, that complements the comments in https://github.com/locusrobotics/fuse/pull/173. I'm still not sure if we really need the transaction `stamp()` method and `stamp_` attribute, or we could just rely on the involved stamps, and return `ros::Time(0, 0)` if there's none. I guess that's not an option if the reason there's no involved stamps is because the variables aren't `Stamped`. I guess this answers my question. :smile: 

Another thin still unclear to me is whether we should queue with the minimum involved stamp or not, or whether there are side effects if we do so. :thinking: 

There are two minor commits here as well.