### PR TITLE
Add use_twist_covariance ROS param and logic to Imu2D differential orientation measurements

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -784,7 +784,6 @@ inline bool processDifferentialPoseWithTwistCovariance(
     twist.twist.covariance[31],
     twist.twist.covariance[35];
 
-  fuse_core::Matrix3d pose_relative_covariance;
   // For dependent pose measurements p1 and p2, we assume they're computed as:
   //
   // p2 = p1 * p12    [1]
@@ -829,7 +828,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
   j_twist.setIdentity();
   j_twist *= dt;
 
-  pose_relative_covariance = j_twist * cov * j_twist.transpose() + minimum_pose_relative_covariance;
+  fuse_core::Matrix3d pose_relative_covariance = j_twist * cov * j_twist.transpose() + minimum_pose_relative_covariance;
 
   // Build the sub-vector and sub-matrices based on the requested indices
   fuse_core::VectorXd pose_relative_mean_partial(position_indices.size() + orientation_indices.size());

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -123,7 +123,7 @@ protected:
 
   ParameterType params_;
 
-  geometry_msgs::PoseWithCovarianceStamped::Ptr previous_pose_;
+  std::unique_ptr<geometry_msgs::PoseWithCovarianceStamped> previous_pose_;
 
   tf2_ros::Buffer tf_buffer_;
 

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -88,12 +88,10 @@ struct Imu2DParams : public ParameterBase
       if (differential)
       {
         nh.getParam("independent", independent);
+        nh.getParam("use_twist_covariance", use_twist_covariance);
 
-        if (!independent)
-        {
-          minimum_pose_relative_covariance =
-              fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
-        }
+        minimum_pose_relative_covariance =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
       }
 
       if (!linear_acceleration_indices.empty())
@@ -119,6 +117,7 @@ struct Imu2DParams : public ParameterBase
     bool differential { false };
     bool disable_checks { false };
     bool independent { true };
+    bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -103,7 +103,7 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
   transaction->stamp(msg->header.stamp);
 
   // Handle the pose data
-  auto pose = boost::make_shared<geometry_msgs::PoseWithCovarianceStamped>();
+  auto pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
   pose->header = msg->header;
   pose->pose = msg->pose;
 
@@ -150,7 +150,7 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
       }
     }
 
-    previous_pose_ = pose;
+    previous_pose_ = std::move(pose);
   }
   else
   {


### PR DESCRIPTION
This simply adds the `use_twist_covariance` ROS param and logic to the `Imu2D` sensor model, which is equivalent to the one added to the `Odometry2D` sensor model in https://github.com/locusrobotics/fuse/pull/138

I also did two additional minor changes:
1. `std::move` the current `pose` into the `previous_pose_` in `Odometry2D`, so it's doing the same as `Imu2D`, which seems more efficient.
2. Move the `pose_relative_covariance` declaration in `processDifferentialPoseWithTwistCovariance()` closer to where it's used.