### PR TITLE
Only call generator if motion model history empty

### DIFF
--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -153,14 +153,17 @@ void TimestampManager::query(
   // Add a dummy entry for the last stamp if one does not already exist
   if (motion_model_history_.empty() || (motion_model_history_.rbegin()->first < last_stamp))
   {
+    if (motion_model_history_.empty())
+    {
+      // Call the motion model generator so it inserts the last timestamp into its state history.
+      std::vector<Constraint::SharedPtr> constraints;
+      std::vector<Variable::SharedPtr> variables;
+      generator_(last_stamp, last_stamp, constraints, variables);
+    }
+
     // Insert the last timestamp into the motion model history, but with no constraints. The last entry in the motion
     // model history will always contain no constraints.
     motion_model_history_.emplace(last_stamp, MotionModelSegment());
-
-    // Call the motion model generator so it inserts the last timestamp into its state history.
-    std::vector<Constraint::SharedPtr> constraints;
-    std::vector<Variable::SharedPtr> variables;
-    generator_(last_stamp, last_stamp, constraints, variables);
   }
   // Purge any old entries from the motion model history
   purgeHistory();

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -554,7 +554,7 @@ TEST_F(TimestampManagerTestFixture, MultiSegment)
   ASSERT_EQ(0ul, generated_time_spans.size());
 }
 
-TEST_F(TimestampManagerTestFixture, MultiSegmentBeforBeginning)
+TEST_F(TimestampManagerTestFixture, MultiSegmentBeforeBeginning)
 {
   // Test:
   // Existing: |------111111112222222233333333-------> t

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -112,12 +112,9 @@ TEST_F(TimestampManagerTestFixture, Empty)
   EXPECT_EQ(ros::Time(20, 0), *stamp_range_iter);
 
   // Verify the expected queries were performed
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  ASSERT_EQ(1ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(20, 0), generated_time_spans[0].second);
-  EXPECT_EQ(ros::Time(20, 0), generated_time_spans[1].first);
-  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, Exceptions)
@@ -423,12 +420,9 @@ TEST_F(TimestampManagerTestFixture, AfterEndAligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  ASSERT_EQ(1ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
-  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
-  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
@@ -461,14 +455,11 @@ TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(3ul, generated_time_spans.size());
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
-  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
-  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
@@ -501,16 +492,13 @@ TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(4ul, generated_time_spans.size());
+  ASSERT_EQ(3ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(30, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[2].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].second);
-  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[3].first);
-  EXPECT_EQ(generated_time_spans[3].first, generated_time_spans[3].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegment)
@@ -542,7 +530,7 @@ TEST_F(TimestampManagerTestFixture, MultiSegment)
   ASSERT_EQ(0ul, generated_time_spans.size());
 }
 
-TEST_F(TimestampManagerTestFixture, MultiSegmentBeforeBeginning)
+TEST_F(TimestampManagerTestFixture, MultiSegmentBeforBeginning)
 {
   // Test:
   // Existing: |------111111112222222233333333-------> t
@@ -603,12 +591,9 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastEnd)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  ASSERT_EQ(1ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
-  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
-  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
@@ -641,14 +626,11 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  // And additional time span is generated for the last stamp as beginning and ending stamp
-  ASSERT_EQ(3ul, generated_time_spans.size());
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(5, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
-  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
-  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, SplitBeginning)

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -117,6 +117,30 @@ TEST_F(TimestampManagerTestFixture, Empty)
   EXPECT_EQ(ros::Time(20, 0), generated_time_spans[0].second);
 }
 
+TEST_F(TimestampManagerTestFixture, EmptySingleStamp)
+{
+  // Test:
+  // Existing: |-------------------------------------> t
+  // Adding:   |------*------------------------------> t
+  // Expected: |------*------------------------------> t
+
+  // Perform a single query
+  fuse_core::Transaction transaction;
+  transaction.addInvolvedStamp(ros::Time(10, 0));
+  manager.query(transaction);
+
+  // Verify the manager contains the timestamps
+  auto stamp_range = manager.stamps();
+  ASSERT_EQ(1, std::distance(stamp_range.begin(), stamp_range.end()));
+  auto stamp_range_iter = stamp_range.begin();
+  EXPECT_EQ(ros::Time(10, 0), *stamp_range_iter);
+
+  // Verify the expected queries were performed
+  ASSERT_EQ(1ul, generated_time_spans.size());
+  EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].first);
+  EXPECT_EQ(generated_time_spans[0].first, generated_time_spans[0].second);
+}
+
 TEST_F(TimestampManagerTestFixture, Exceptions)
 {
   // Set a finite buffer length and populate it with some queries

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -179,7 +179,6 @@ void Unicycle2D::generateMotionModel(
   }
 
   StateHistoryElement state1;
-  StateHistoryElement state2;
 
   // If the nearest state we had was before the beginning stamp, we need to project that state to the beginning stamp
   if (base_time != beginning_stamp)
@@ -203,6 +202,7 @@ void Unicycle2D::generateMotionModel(
   const double dt = (ending_stamp - beginning_stamp).toSec();
 
   // Now predict to get an initial guess for the state at the ending stamp
+  StateHistoryElement state2;
   predict(
     state1.pose,
     state1.velocity_linear,

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -201,7 +201,21 @@ void Unicycle2D::generateMotionModel(
     state1 = base_state;
   }
 
+  // If dt is zero, we only need to update the state history:
   const double dt = (ending_stamp - beginning_stamp).toSec();
+
+  if (dt == 0.0)
+  {
+    state1.position_uuid = fuse_variables::Position2DStamped(beginning_stamp, device_id_).uuid();
+    state1.yaw_uuid = fuse_variables::Orientation2DStamped(beginning_stamp, device_id_).uuid();
+    state1.vel_linear_uuid = fuse_variables::VelocityLinear2DStamped(beginning_stamp, device_id_).uuid();
+    state1.vel_yaw_uuid = fuse_variables::VelocityAngular2DStamped(beginning_stamp, device_id_).uuid();
+    state1.acc_linear_uuid = fuse_variables::AccelerationLinear2DStamped(beginning_stamp, device_id_).uuid();
+
+    state_history_.emplace(beginning_stamp, std::move(state1));
+
+    return;
+  }
 
   // Now predict to get an initial guess for the state at the ending stamp
   StateHistoryElement state2;

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -159,6 +159,8 @@ void Unicycle2D::generateMotionModel(
   std::vector<fuse_core::Constraint::SharedPtr>& constraints,
   std::vector<fuse_core::Variable::SharedPtr>& variables)
 {
+  assert(beginning_stamp < ending_stamp || (beginning_stamp == ending_stamp && state_history_.empty()));
+
   StateHistoryElement base_state;
   ros::Time base_time;
 


### PR DESCRIPTION
# Changelog

This simplifies the changes from https://github.com/locusrobotics/fuse/pull/154 by doing:
* Only call generator if motion model history empty.
* Assert `beginning stamp < ending stamp`. Or `beginning stamp == ending stamp` for the special case when the state history is empty.
* Handle the `dt == 0` special case in motion model, so no variables or constraints are generator, and no prediction is performed, or the same state is inserted twice into the history.
* Revert the changes to the `test_timestamp_manager.cpp` unit test
* Add a new test for the case when the transaction has a single involved stamp, since that was precisely the case not handled. Indeed, that test fails w/o #154 or this PR.
* [minor] Declare `state2` closer to where it is used.

The special case mentioned above is always the same.

From my tests locally, with a bunch of prints, I confirmed the state history already have the state for the given stamp, so IIRC that's all that was required for #154 . The `assert` added in this PR enforces the generator function isn't called for those cases it did before, so I think that constitutes a test for this change.