### PR TITLE
Call onStop() directly if !ros::ok() in stop()

### DIFF
--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -110,6 +110,7 @@ void AsyncMotionModel::stop()
   }
   else
   {
+    spinner_.stop();
     onStop();
   }
 }

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -101,10 +101,17 @@ void AsyncMotionModel::start()
 
 void AsyncMotionModel::stop()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStop, this));
-  auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
-  result.wait();
+  if (ros::ok())
+  {
+    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStop, this));
+    auto result = callback->getFuture();
+    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    result.wait();
+  }
+  else
+  {
+    onStop();
+  }
 }
 
 }  // namespace fuse_core

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -96,6 +96,7 @@ void AsyncPublisher::stop()
   }
   else
   {
+    spinner_.stop();
     onStop();
   }
 }

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -87,10 +87,17 @@ void AsyncPublisher::start()
 
 void AsyncPublisher::stop()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStop, this));
-  auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
-  result.wait();
+  if (ros::ok())
+  {
+    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStop, this));
+    auto result = callback->getFuture();
+    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    result.wait();
+  }
+  else
+  {
+    onStop();
+  }
 }
 
 }  // namespace fuse_core

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -102,6 +102,7 @@ void AsyncSensorModel::stop()
   }
   else
   {
+    spinner_.stop();
     onStop();
   }
 }

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -93,10 +93,17 @@ void AsyncSensorModel::start()
 
 void AsyncSensorModel::stop()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStop, this));
-  auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
-  result.wait();
+  if (ros::ok())
+  {
+    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStop, this));
+    auto result = callback->getFuture();
+    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    result.wait();
+  }
+  else
+  {
+    onStop();
+  }
 }
 
 }  // namespace fuse_core


### PR DESCRIPTION
When we `Ctrl+C` or request any **optimizer** node to stop, the `stop()` method of each sensor model, motion model or publisher adds a callback to the `callback_queue_` that is queried by the `AsyncSpinner`. When the node is shutting down this leads to the callbacks not being added or simply not called because the spinner stops processing them when `ros::ok()` returns `false`:
https://github.com/ros/ros_comm/blob/d82f3f09f2b9b55cbbee68ba25f36174ec2c7002/clients/roscpp/src/libros/spinner.cpp#L256-L266

This change addressed that corner case by checking `ros::ok()` and only using the callback queue when it's `true`, otherwise `onStop()` is called directly.

This solves the issue.

For me this usually happened on the `Odometry2DPublisher` because it tends to be waiting in:
https://github.com/locusrobotics/fuse/blob/24c922e5e02d88015d5cfed6a74b99ee1a8e3670/fuse_models/src/odometry_2d_publisher.cpp#L422-L426

So by the time the `onStop()` callback has to be called, `ros::ok()` (and therefore `nh_.ok()`) is `false` in the spinner loop.

This is specially easy to reproduce if you pause a bag file, or if you stop the simulated time with `gzclient`, but it could also happen quite often if the time isn't simulated and it keeps running.

As a consequence of this, when using `roslaunch`, the `SIGINT` signal didn't manage to stop the node, so after the default `15.0` seconds timeout, a `SIGTERM` signal was sent, effectively stopping the node. This is specially annoying if you're running things offline often, since you need to wait for the `SIGTERM` signal to be sent, and still the node doesn't exit cleanly.