### PR TITLE
Set latch param false by default

### DIFF
--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -61,7 +61,7 @@ void SerializedPublisher::onInit()
   // Configure the publisher
   private_node_handle_.getParam("frame_id", frame_id_);
 
-  bool latch = true;
+  bool latch = false;
   private_node_handle_.getParam("latch", latch);
 
   // Advertise the topics


### PR DESCRIPTION
Set `latch` param to `false` by default in `fuse_publishers::SerializedPublisher`.

The motivation is the same one that is described in https://github.com/locusrobotics/fuse/pull/183

If we want to record graph and transaction messages and play them back, we likely need to throttle recording the graph messages because it'd take too much disk and BW to record all.

Therefore, when playing things back, we don't want to have the throttled graph played back as latched, because then the node is ignited/started at time when the transaction that happened right after the graph was likely published too long ago.

Consider this example:
* The graph is throttled so only one message is recorded every `10.0s`
* We play back a bag file at time `t_b = 170.0`
* If the recorded graph message was published by a `latch`ed topic, then it'd be published `latch`ed by `rosbag play`. So we get the graph from time `t_g < t_b` published, e.g. `t_g = 165.0`.
* The next transaction that could be published would be at time `t_t >= t_b`, e.g. `t_t = 170.1`, which is way after the graph.

This means the transaction cannot be applied to the graph from `t_g` because it'd likely reference non-existent constraints or variables.

I can certainly set the `latch` param to `false` in my config, but it took me some time to figure this out, so I believe the default value should be `false`.