### PR TITLE
Remove variables on hold

### DIFF
--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -317,6 +317,14 @@ public:
   virtual void holdVariable(const UUID& variable_uuid, bool hold_constant = true) = 0;
 
   /**
+   * @brief Check whether a variable is on hold or not
+   *
+   * @param[in] variable_uuid The variable to test
+   * @return True if the variable is on hold, false otherwise
+   */
+  virtual bool isVariableOnHold(const UUID& variable_uuid) const = 0;
+
+  /**
    * @brief Compute the marginal covariance blocks for the requested set of variable pairs.
    *
    * To compute the marginal variance of a single variable, simply supply the same variable UUID for both members of

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -267,6 +267,14 @@ public:
   void holdVariable(const fuse_core::UUID& variable_uuid, bool hold_constant = true) override;
 
   /**
+   * @brief Check whether a variable is on hold or not
+   *
+   * @param[in] variable_uuid The variable to test
+   * @return True if the variable is on hold, false otherwise
+   */
+  bool isVariableOnHold(const fuse_core::UUID& variable_uuid) const override;
+
+  /**
    * @brief Compute the marginal covariance blocks for the requested set of variable pairs.
    *
    * To compute the marginal variance of a single variable, simply supply the same variable UUID for both members of

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -289,6 +289,11 @@ void HashGraph::holdVariable(const fuse_core::UUID& variable_uuid, bool hold_con
   }
 }
 
+bool HashGraph::isVariableOnHold(const fuse_core::UUID& variable_uuid) const
+{
+  return variables_on_hold_.find(variable_uuid) != variables_on_hold_.end();
+}
+
 void HashGraph::getCovariance(
   const std::vector<std::pair<fuse_core::UUID, fuse_core::UUID>>& covariance_requests,
   std::vector<std::vector<double>>& covariance_matrices,

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -250,6 +250,7 @@ bool HashGraph::removeVariable(const fuse_core::UUID& variable_uuid)
   {
     constraints_by_variable_uuid_.erase(cross_reference_iter);
   }
+  variables_on_hold_.erase(variable_uuid);
   return true;
 }
 

--- a/fuse_graphs/test/test_hash_graph.cpp
+++ b/fuse_graphs/test/test_hash_graph.cpp
@@ -716,6 +716,12 @@ TEST(HashGraph, HoldVariable)
   // Variable1 should not have changed from its original value
   EXPECT_NEAR(1.0, variable1->data()[0], 1.0e-7);
   EXPECT_NEAR(-3.0, variable2->data()[0], 1.0e-7);
+
+  // Remove variable1, that is on hold.
+  // We need to remove constraint1 before because it uses variable1
+  EXPECT_TRUE(graph.removeConstraint(constraint1->uuid()));
+  EXPECT_TRUE(graph.removeVariable(variable1->uuid()));
+  EXPECT_FALSE(graph.isVariableOnHold(variable1->uuid()));
 }
 
 TEST(HashGraph, GetCovariance)


### PR DESCRIPTION
I'm not really holding any variables atm, but I noticed that `removeVariable` didn't `erase` the `variable_uuid` from the `variables_on_hold_` set.

This fixes that and adds a unit test that required the `isVariableOnHold()` method to be created. The unit test failed before this change.