### PR TITLE
Fix roslint 0.12.0

### DIFF
--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -49,6 +49,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -46,8 +46,10 @@
 #include <ceres/loss_function.h>
 
 #include <initializer_list>
+#include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_core/include/fuse_core/macros.h
+++ b/fuse_core/include/fuse_core/macros.h
@@ -56,6 +56,7 @@
 #define FUSE_CORE_MACROS_H
 
 #include <memory>
+#include <utility>
 #include <string>
 
 // Required by __MAKE_SHARED_ALIGNED_DEFINITION, that uses Eigen::aligned_allocator<T>().

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -41,6 +41,7 @@
 #include <boost/make_shared.hpp>
 
 #include <functional>
+#include <utility>
 #include <string>
 
 

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -41,6 +41,7 @@
 #include <boost/make_shared.hpp>
 
 #include <functional>
+#include <utility>
 #include <string>
 
 

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -41,6 +41,7 @@
 #include <boost/make_shared.hpp>
 
 #include <functional>
+#include <utility>
 #include <string>
 
 

--- a/fuse_core/src/transaction.cpp
+++ b/fuse_core/src/transaction.cpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <utility>
 
 
 namespace fuse_core

--- a/fuse_graphs/test/test_hash_graph.cpp
+++ b/fuse_graphs/test/test_hash_graph.cpp
@@ -49,98 +49,110 @@
 #include <utility>
 #include <vector>
 
-
 /**
- * @brief Static variable to hold the last unit test error description
+ * @brief Test fixture for the HashGraph
+ *
+ * This test fixture provides methods to compare variables and constraints, and allows to retrieve the last failure
+ * description, if any.
  */
-static std::string failure_description;
-
-/**
- * @brief Compare all the properties of two Variable objects
- * @return True if all the properties match, false otherwise
- */
-bool compareVariables(const fuse_core::Variable& expected, const fuse_core::Variable& actual)
+class HashGraphTestFixture : public ::testing::Test
 {
-  failure_description = "";
-  bool variables_equal = true;
-  if (expected.type() != actual.type())
+public:
+  /**
+   * @brief Compare all the properties of two Variable objects
+   *
+   * @param[in] expected - The expected variable
+   * @param[in] actual - The actual variable
+   * @return True if all the properties match, false otherwise
+   */
+  bool compareVariables(const fuse_core::Variable& expected, const fuse_core::Variable& actual)
   {
-    variables_equal = false;
-    failure_description += "The variables have different types.\n"
-      "  expected type is '" + expected.type() + "'\n"
-      "    actual type is '" + actual.type() + "'\n";
-  }
-  if (expected.size() != actual.size())
-  {
-    variables_equal = false;
-    failure_description += "The variables have different sizes.\n"
-      "  expected size is '" + std::to_string(expected.size()) + "'\n"
-      "    actual size is '" + std::to_string(actual.size()) + "'\n";
-  }
-  if (expected.uuid() != actual.uuid())
-  {
-    variables_equal = false;
-    failure_description += "The variables have different UUIDs.\n"
-      "  expected UUID is '" + fuse_core::uuid::to_string(expected.uuid()) + "'\n"
-      "    actual UUID is '" + fuse_core::uuid::to_string(actual.uuid()) + "'\n";
-  }
-  for (size_t i = 0; i < expected.size(); ++i)
-  {
-    if (expected.data()[i] != actual.data()[i])
+    failure_description = "";
+    bool variables_equal = true;
+    if (expected.type() != actual.type())
     {
       variables_equal = false;
-      failure_description += "The variables have different values.\n"
-        "  expected data(" + std::to_string(i) + ") is '" + std::to_string(expected.data()[i]) + "'\n"
-        "    actual data(" + std::to_string(i) + ") is '" + std::to_string(actual.data()[i]) + "'\n";
+      failure_description += "The variables have different types.\n"
+        "  expected type is '" + expected.type() + "'\n"
+        "    actual type is '" + actual.type() + "'\n";
     }
+    if (expected.size() != actual.size())
+    {
+      variables_equal = false;
+      failure_description += "The variables have different sizes.\n"
+        "  expected size is '" + std::to_string(expected.size()) + "'\n"
+        "    actual size is '" + std::to_string(actual.size()) + "'\n";
+    }
+    if (expected.uuid() != actual.uuid())
+    {
+      variables_equal = false;
+      failure_description += "The variables have different UUIDs.\n"
+        "  expected UUID is '" + fuse_core::uuid::to_string(expected.uuid()) + "'\n"
+        "    actual UUID is '" + fuse_core::uuid::to_string(actual.uuid()) + "'\n";
+    }
+    for (size_t i = 0; i < expected.size(); ++i)
+    {
+      if (expected.data()[i] != actual.data()[i])
+      {
+        variables_equal = false;
+        failure_description += "The variables have different values.\n"
+          "  expected data(" + std::to_string(i) + ") is '" + std::to_string(expected.data()[i]) + "'\n"
+          "    actual data(" + std::to_string(i) + ") is '" + std::to_string(actual.data()[i]) + "'\n";
+      }
+    }
+    return variables_equal;
   }
-  return variables_equal;
-}
 
-/**
- * @brief Compare all the properties of two Constraint objects
- * @return True if all the properties match, false otherwise
- */
-bool compareConstraints(const fuse_core::Constraint& expected, const fuse_core::Constraint& actual)
-{
-  failure_description = "";
-  bool constraints_equal = true;
-  if (expected.type() != actual.type())
+  /**
+   * @brief Compare all the properties of two Constraint objects
+   *
+   * @param[in] expected - The expected constraint
+   * @param[in] actual - The actual constraint
+   * @return True if all the properties match, false otherwise
+   */
+  bool compareConstraints(const fuse_core::Constraint& expected, const fuse_core::Constraint& actual)
   {
-    constraints_equal = false;
-    failure_description += "The constraints have different types.\n"
-      "  expected type is '" + expected.type() + "'\n"
-      "    actual type is '" + actual.type() + "'\n";
-  }
-  if (expected.uuid() != actual.uuid())
-  {
-    constraints_equal = false;
-    failure_description += "The constraints have different UUIDs.\n"
-      "  expected UUID is '" + fuse_core::uuid::to_string(expected.uuid()) + "'\n"
-      "    actual UUID is '" + fuse_core::uuid::to_string(actual.uuid()) + "'\n";
-  }
-  if (expected.variables().size() != actual.variables().size())
-  {
-    constraints_equal = false;
-    failure_description += "The constraints involve a different number of variables.\n"
-      "  expected variable count is '" + std::to_string(expected.variables().size()) + "'\n"
-      "    actual variable count is '" + std::to_string(actual.variables().size()) + "'\n";
-  }
-  for (size_t i = 0; i < expected.variables().size(); ++i)
-  {
-    if (expected.variables().at(i) != actual.variables().at(i))
+    failure_description = "";
+    bool constraints_equal = true;
+    if (expected.type() != actual.type())
     {
       constraints_equal = false;
-      std::string i_str = std::to_string(i);
-      failure_description += "The constraints involve different variable UUIDs.\n"
-        "  expected variables(" + i_str + ") is '" + fuse_core::uuid::to_string(expected.variables()[i]) + "'\n"
-        "    actual variables(" + i_str + ") is '" + fuse_core::uuid::to_string(actual.variables()[i]) + "'\n";
+      failure_description += "The constraints have different types.\n"
+        "  expected type is '" + expected.type() + "'\n"
+        "    actual type is '" + actual.type() + "'\n";
     }
+    if (expected.uuid() != actual.uuid())
+    {
+      constraints_equal = false;
+      failure_description += "The constraints have different UUIDs.\n"
+        "  expected UUID is '" + fuse_core::uuid::to_string(expected.uuid()) + "'\n"
+        "    actual UUID is '" + fuse_core::uuid::to_string(actual.uuid()) + "'\n";
+    }
+    if (expected.variables().size() != actual.variables().size())
+    {
+      constraints_equal = false;
+      failure_description += "The constraints involve a different number of variables.\n"
+        "  expected variable count is '" + std::to_string(expected.variables().size()) + "'\n"
+        "    actual variable count is '" + std::to_string(actual.variables().size()) + "'\n";
+    }
+    for (size_t i = 0; i < expected.variables().size(); ++i)
+    {
+      if (expected.variables().at(i) != actual.variables().at(i))
+      {
+        constraints_equal = false;
+        std::string i_str = std::to_string(i);
+        failure_description += "The constraints involve different variable UUIDs.\n"
+          "  expected variables(" + i_str + ") is '" + fuse_core::uuid::to_string(expected.variables()[i]) + "'\n"
+          "    actual variables(" + i_str + ") is '" + fuse_core::uuid::to_string(actual.variables()[i]) + "'\n";
+      }
+    }
+    return constraints_equal;
   }
-  return constraints_equal;
-}
 
-TEST(HashGraph, AddVariable)
+  std::string failure_description { "" };  //!< The last failure description. Empty if no failure happened
+};
+
+TEST_F(HashGraphTestFixture, AddVariable)
 {
   // Test adding variables to the graph
   // Also tests the variableExists() function
@@ -184,7 +196,7 @@ TEST(HashGraph, AddVariable)
   EXPECT_TRUE(graph.variableExists(variable3->uuid()));
 }
 
-TEST(HashGraph, RemoveVariable)
+TEST_F(HashGraphTestFixture, RemoveVariable)
 {
   // Test removing variables from the graph
 
@@ -246,7 +258,7 @@ TEST(HashGraph, RemoveVariable)
   EXPECT_TRUE(graph.variableExists(variable2->uuid()));
 }
 
-TEST(HashGraph, GetVariable)
+TEST_F(HashGraphTestFixture, GetVariable)
 {
   // Test accessing a single variables from the graph
 
@@ -270,7 +282,7 @@ TEST(HashGraph, GetVariable)
   EXPECT_TRUE(compareVariables(*variable2, actual2)) << failure_description;
 }
 
-TEST(HashGraph, GetVariables)
+TEST_F(HashGraphTestFixture, GetVariables)
 {
   // Test accessing the variables collection from the graph
 
@@ -317,7 +329,7 @@ TEST(HashGraph, GetVariables)
   }
 }
 
-TEST(HashGraph, GetConnectedVariables)
+TEST_F(HashGraphTestFixture, GetConnectedVariables)
 {
   // Test accessing the variables connected to a specific constraint
 
@@ -381,7 +393,7 @@ TEST(HashGraph, GetConnectedVariables)
   }
 }
 
-TEST(HashGraph, AddConstraint)
+TEST_F(HashGraphTestFixture, AddConstraint)
 {
   // Test adding constraints to the graph
   // Also tests the constraintExists() function
@@ -440,7 +452,7 @@ TEST(HashGraph, AddConstraint)
   EXPECT_THROW(graph.addConstraint(constraint4), std::logic_error);
 }
 
-TEST(HashGraph, RemoveConstraint)
+TEST_F(HashGraphTestFixture, RemoveConstraint)
 {
   // Test removing constraints from the graph
 
@@ -485,7 +497,7 @@ TEST(HashGraph, RemoveConstraint)
   EXPECT_FALSE(graph.removeConstraint(constraint1->uuid()));
 }
 
-TEST(HashGraph, GetConstraint)
+TEST_F(HashGraphTestFixture, GetConstraint)
 {
   // Test accessing the constraints in the graph
 
@@ -516,7 +528,7 @@ TEST(HashGraph, GetConstraint)
   EXPECT_TRUE(compareConstraints(*constraint2, actual2)) << failure_description;
 }
 
-TEST(HashGraph, GetConstraints)
+TEST_F(HashGraphTestFixture, GetConstraints)
 {
   // Test accessing the constraints in the graph
 
@@ -567,7 +579,7 @@ TEST(HashGraph, GetConstraints)
   }
 }
 
-TEST(HashGraph, GetConnectedConstraints)
+TEST_F(HashGraphTestFixture, GetConnectedConstraints)
 {
   // Test accessing the constraints connected to a specific variable
 
@@ -644,7 +656,7 @@ TEST(HashGraph, GetConnectedConstraints)
   }
 }
 
-TEST(HashGraph, Optimize)
+TEST_F(HashGraphTestFixture, Optimize)
 {
   // Test optimizing a set of variables/constraints
 
@@ -681,7 +693,7 @@ TEST(HashGraph, Optimize)
   EXPECT_NEAR(-3.0, variable2->data()[0], 1.0e-7);
 }
 
-TEST(HashGraph, HoldVariable)
+TEST_F(HashGraphTestFixture, HoldVariable)
 {
   // Test placing a variable on hold. The value of the variable should remain constant even after the optimization
 
@@ -718,7 +730,7 @@ TEST(HashGraph, HoldVariable)
   EXPECT_NEAR(-3.0, variable2->data()[0], 1.0e-7);
 }
 
-TEST(HashGraph, GetCovariance)
+TEST_F(HashGraphTestFixture, GetCovariance)
 {
   // Create variables that match the Ceres unit test
   auto x = ExampleVariable::make_shared(2);
@@ -826,7 +838,7 @@ TEST(HashGraph, GetCovariance)
   }
 }
 
-TEST(HashGraph, Copy)
+TEST_F(HashGraphTestFixture, Copy)
 {
     // Create the graph
   fuse_graphs::HashGraph graph;
@@ -908,7 +920,7 @@ TEST(HashGraph, Copy)
   }
 }
 
-TEST(HashGraph, Serialization)
+TEST_F(HashGraphTestFixture, Serialization)
 {
   // Create the graph
   fuse_graphs::HashGraph expected;

--- a/fuse_loss/include/fuse_loss/composed_loss.h
+++ b/fuse_loss/include/fuse_loss/composed_loss.h
@@ -40,6 +40,7 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
 
+#include <memory>
 #include <ostream>
 #include <string>
 

--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -35,7 +35,6 @@
 #ifndef FUSE_LOSS_QWT_LOSS_PLOT_H
 #define FUSE_LOSS_QWT_LOSS_PLOT_H
 
-
 #include <qwt_legend.h>
 #include <qwt_plot.h>
 #include <qwt_plot_curve.h>
@@ -46,9 +45,9 @@
 #include <qwt_plot_zoomer.h>
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
-
 
 namespace fuse_loss
 {

--- a/fuse_loss/include/fuse_loss/scaled_loss.h
+++ b/fuse_loss/include/fuse_loss/scaled_loss.h
@@ -40,6 +40,7 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
 
+#include <memory>
 #include <ostream>
 #include <string>
 

--- a/fuse_loss/src/composed_loss.cpp
+++ b/fuse_loss/src/composed_loss.cpp
@@ -40,6 +40,7 @@
 
 #include <boost/serialization/export.hpp>
 
+#include <memory>
 #include <ostream>
 #include <string>
 

--- a/fuse_loss/src/scaled_loss.cpp
+++ b/fuse_loss/src/scaled_loss.cpp
@@ -39,6 +39,7 @@
 
 #include <boost/serialization/export.hpp>
 
+#include <memory>
 #include <ostream>
 #include <string>
 

--- a/fuse_loss/test/test_qwt_loss_plot.cpp
+++ b/fuse_loss/test/test_qwt_loss_plot.cpp
@@ -49,6 +49,7 @@
 
 #include <QApplication>
 
+#include <memory>
 #include <vector>
 
 

--- a/fuse_loss/test/test_scaled_loss.cpp
+++ b/fuse_loss/test/test_scaled_loss.cpp
@@ -40,6 +40,9 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include<memory>
+
+
 TEST(ScaledLoss, Constructor)
 {
   // Create a default loss

--- a/fuse_loss/test/test_tukey_loss.cpp
+++ b/fuse_loss/test/test_tukey_loss.cpp
@@ -39,6 +39,8 @@
 #include <ceres/solver.h>
 #include <gtest/gtest.h>
 
+#include <memory>
+
 TEST(TukeyLoss, Constructor)
 {
   // Create a default loss

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -45,6 +45,8 @@
 #include <ros/ros.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <memory>
+
 
 namespace fuse_models
 {

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -45,6 +45,7 @@
 #include <sensor_msgs/Imu.h>
 
 #include <memory>
+#include <utility>
 
 
 // Register this sensor model with ROS as a plugin.

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -43,6 +43,9 @@
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
+#include <memory>
+#include <utility>
+
 
 // Register this sensor model with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(fuse_models::Odometry2D, fuse_core::SensorModel)

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -47,6 +47,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <utility>

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -54,6 +54,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_models/test/test_unicycle_2d_ignition.cpp
+++ b/fuse_models/test/test_unicycle_2d_ignition.cpp
@@ -46,6 +46,7 @@
 #include <functional>
 #include <future>
 #include <string>
+#include <utility>
 #include <vector>
 
 using fuse_constraints::AbsolutePosition2DStampedConstraint;

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -48,6 +48,7 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -46,6 +46,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <thread>
 
 

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -46,6 +46,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 

--- a/fuse_optimizers/test/example_optimizer.h
+++ b/fuse_optimizers/test/example_optimizer.h
@@ -37,6 +37,7 @@
 #include <fuse_optimizers/optimizer.h>
 
 #include <string>
+#include <utility>
 
 
 /**

--- a/fuse_viz/src/pose_2d_stamped_visual.cpp
+++ b/fuse_viz/src/pose_2d_stamped_visual.cpp
@@ -45,6 +45,9 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
+#include <memory>
+
+
 namespace rviz
 {
 

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -51,7 +51,9 @@
 #include <OgreSceneNode.h>
 
 #include <algorithm>
+#include <memory>
 #include <string>
+
 
 namespace rviz
 {


### PR DESCRIPTION
This fixes a bunch of `rosling` 0.12.0 warnings that the previous version didn't find.

This is mostly about `include_what_you_use` for `std::move` and `std::make_shared` (and similar), and also a global `static` variable that I've made a test fixture attribute.