### PR TITLE
Check canTransform output and show error if false

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -932,7 +932,7 @@ inline bool processTwistWithCovariance(
 
   if (!transformMessage(tf_buffer, twist, transformed_message))
   {
-    ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << twist.header.stamp);
+    ROS_ERROR_STREAM("Cannot create constraint from twist message with stamp " << twist.header.stamp);
     return false;
   }
 

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -224,7 +224,8 @@ template <typename T>
 bool transformMessage(const tf2_ros::Buffer& tf_buffer, const T& input, T& output)
 {
   geometry_msgs::TransformStamped trans;
-  if (tf_buffer.canTransform(output.header.frame_id, input.header.frame_id, input.header.stamp))
+  std::string error_msg;
+  if (tf_buffer.canTransform(output.header.frame_id, input.header.frame_id, input.header.stamp, &error_msg))
   {
     try
     {
@@ -236,6 +237,12 @@ bool transformMessage(const tf2_ros::Buffer& tf_buffer, const T& input, T& outpu
         output.header.frame_id << ". Error was " << ex.what());
       return false;
     }
+  }
+  else
+  {
+    ROS_WARN_STREAM("Could not transform message from " << input.header.frame_id << " to " <<
+      output.header.frame_id << ". Error before lookup was " << error_msg);
+    return false;
   }
 
   tf2::doTransform(input, output, trans);


### PR DESCRIPTION
This checks the output of `canTransform` and show the `error_msg` if it returns `false`.

There's also a typo in a message fixed.