### PR TITLE
Fix throttle

### DIFF
--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -169,7 +169,14 @@ public:
         keep_callback_(message);
       }
 
-      last_called_time_ += throttle_period_;
+      if (last_called_time_.isValid())
+      {
+        last_called_time_ += throttle_period_;
+      }
+      else
+      {
+        last_called_time_ = now;
+      }
     }
     else if (drop_callback_)
     {

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -169,7 +169,7 @@ public:
         keep_callback_(message);
       }
 
-      last_called_time_ = now;
+      last_called_time_ += throttle_period_;
     }
     else if (drop_callback_)
     {

--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -162,20 +162,20 @@ public:
     // (b) The throttle period is zero, so we should always keep the callbacks
     // (c) The elpased time between now and the last called time is greater than the throttle period
     const ros::Time now = use_wall_time_ ? ros::Time(ros::WallTime::now().toSec()) : ros::Time::now();
-    if (!last_called_time_.isValid() || throttle_period_.isZero() || now - last_called_time_ > throttle_period_)
+    if (last_called_time_.isZero() || throttle_period_.isZero() || now - last_called_time_ > throttle_period_)
     {
       if (keep_callback_)
       {
         keep_callback_(message);
       }
 
-      if (last_called_time_.isValid())
+      if (last_called_time_.isZero())
       {
-        last_called_time_ += throttle_period_;
+        last_called_time_ = now;
       }
       else
       {
-        last_called_time_ = now;
+        last_called_time_ += throttle_period_;
       }
     }
     else if (drop_callback_)


### PR DESCRIPTION
This fixes some issues with the `ThrottledCallback` logic:
* In order to always **keep** the first message received I was relying on the `last_called_time_` attribute being initialized to zero. But instead of calling `last_called_time_.isZero()` to check for that, I was calling `!last_called_time_.isValid()`, which doesn't check for zero at all: 
https://github.com/ros/roscpp_core/blob/b2a9c0affcaacb510b6e9ec6e46b595bb145d3c9/rostime/src/time.cpp#L324-L327
* Instead of setting the `last_called_time_` to `now` when the message is kept, this change increments it by the `throttle_period_`. In other words, the last called time is updated to the expected called time instead of the actual one. This is important to actually throttle at the desired period/frequency. I found a similar issue recently in https://github.com/clearpathrobotics/ros_controllers/pull/62 . My initial implementation here was following the `topic_tools throttle` one: https://github.com/ros/ros_comm/blob/c7f7598e8a49b1b4eb6f3e42f698147e151a811d/tools/topic_tools/src/throttle.cpp#L134-L138, but I believe the approach of this PR is more accurate.
* The `last_called_time_` still have to be set to `now` the first time it's called though