### PR TITLE
Fix typo in jacobian comments

### DIFF
--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
@@ -185,28 +185,28 @@ public:
         jacobian.applyOnTheLeft(-A_);
       }
 
-      // Update jacobian wrt pyaw1
+      // Update jacobian wrt yaw1
       if (jacobians[1])
       {
         Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[1]);
         jacobian.applyOnTheLeft(-A_);
       }
 
-      // Update jacobian wrt pvel_linear1
+      // Update jacobian wrt vel_linear1
       if (jacobians[2])
       {
         Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[2]);
         jacobian.applyOnTheLeft(-A_);
       }
 
-      // Update jacobian wrt pvel_yaw1
+      // Update jacobian wrt vel_yaw1
       if (jacobians[3])
       {
         Eigen::Map<fuse_core::Vector8d> jacobian(jacobians[3]);
         jacobian.applyOnTheLeft(-A_);
       }
 
-      // Update jacobian wrt pacc_linear1
+      // Update jacobian wrt acc_linear1
       if (jacobians[4])
       {
         Eigen::Map<fuse_core::Matrix<double, 8, 2>> jacobian(jacobians[4]);


### PR DESCRIPTION
Simply saw this typo while I was looking at this trying to figure out how hard it'd be to have analytic jacobians for the absolute and relative 2D pose cost constraints, i.e. for the normal prior and delta specialization for 2D poses they use:
* https://github.com/locusrobotics/fuse/blob/53752ee41de7b5da893e50b567e885f9f92f1dbc/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h#L100-L114
* https://github.com/locusrobotics/fuse/blob/53752ee41de7b5da893e50b567e885f9f92f1dbc/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h#L111-L134

This is a bit off-topic in this PR, but it looks like the main reason they don't use analytic jacobians is because those functors don't have access to the specific pose components/indices that are being used, i.e. `x`, `y` and/or `yaw`. I wonder:
1. if it'd be possible and relatively clean to pass the indices to these cost functors. Actually to the corresponding cost function that would evaluate the jacobians analytically
2. and what would be the benefit of using analytic jacobians over automatic differentiation for each one of these two types of constraints.

Sorry I'm hijacking this PR to open this topic, but I'd like to know your thoughts on this @svwilliams :smiley: 

I'd be happy to give this a try. The analytic jacobians are indeed trivial for the absolute constraint (the normal prior) case, since it's just the matrix `A_` for the full pose, and simply some blocks depending on the indices used.