### PR TITLE
Use analytic absolute pose 2d cost function

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(${PROJECT_NAME}
   src/normal_delta.cpp
   src/normal_delta_orientation_2d.cpp
   src/normal_prior_orientation_2d.cpp
+  src/normal_prior_pose_2d.cpp
   src/relative_constraint.cpp
   src/relative_orientation_3d_stamped_constraint.cpp
   src/relative_pose_2d_stamped_constraint.cpp
@@ -282,6 +283,29 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Normal Prior Pose 2D Tests
+  catkin_add_gtest(test_normal_prior_pose_2d
+    test/test_normal_prior_pose_2d.cpp
+  )
+  add_dependencies(test_normal_prior_pose_2d
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_normal_prior_pose_2d
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_normal_prior_pose_2d
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_normal_prior_pose_2d
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Relative Constraint Tests
   catkin_add_gtest(test_relative_constraint
     test/test_relative_constraint.cpp
@@ -389,4 +413,27 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
   )
+
+  # Benchmarks
+  find_package(benchmark QUIET)
+
+  if(benchmark_FOUND)
+    add_executable(benchmark_normal_prior_pose_2d
+      benchmark/benchmark_normal_prior_pose_2d.cpp
+    )
+    if(TARGET benchmark_normal_prior_pose_2d)
+      target_link_libraries(
+        benchmark_normal_prior_pose_2d
+        benchmark
+        ${PROJECT_NAME}
+        ${catkin_LIBRARIES}
+        ${CERES_LIBRARIES}
+      )
+      set_target_properties(benchmark_normal_prior_pose_2d
+        PROPERTIES
+          CXX_STANDARD 14
+          CXX_STANDARD_REQUIRED YES
+      )
+    endif()
+  endif()
 endif()

--- a/fuse_constraints/benchmark/benchmark_normal_prior_pose_2d.cpp
+++ b/fuse_constraints/benchmark/benchmark_normal_prior_pose_2d.cpp
@@ -1,0 +1,141 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/normal_prior_pose_2d.h>
+#include <fuse_constraints/normal_prior_pose_2d_cost_functor.h>
+
+#include <benchmark/benchmark.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <Eigen/Dense>
+
+#include <vector>
+
+class NormalPriorPose2DBenchmarkFixture : public benchmark::Fixture
+{
+public:
+  NormalPriorPose2DBenchmarkFixture()
+    : jacobians(num_parameter_blocks)
+    , J(num_parameter_blocks)
+  {
+    for (size_t i = 0; i < num_parameter_blocks; ++i)
+    {
+      J[i].resize(num_residuals, block_sizes[i]);
+      jacobians[i] = J[i].data();
+    }
+  }
+
+  // Mean and sqrt information matrix
+  static const fuse_core::Vector3d mean;
+  static const fuse_core::Matrix3d sqrt_information;
+
+  // Parameters
+  static const double* parameters[];
+
+  // Residuals
+  fuse_core::Vector3d residuals;
+
+  static const std::vector<int32_t>& block_sizes;
+  static const size_t num_parameter_blocks;
+
+  static const size_t num_residuals;
+
+  // Jacobians
+  std::vector<double*> jacobians;
+
+private:
+  // Cost function covariance
+  static const double covariance_diagonal[];
+
+  static const fuse_core::Matrix3d covariance;
+
+  // Parameter blocks
+  static const double position[];
+  static const double yaw[];
+
+  // Jacobian matrices
+  std::vector<fuse_core::MatrixXd> J;
+};
+
+// Cost function covariance
+const double NormalPriorPose2DBenchmarkFixture::covariance_diagonal[] = { 2e-3, 1e-3, 1e-2 };
+
+const fuse_core::Matrix3d NormalPriorPose2DBenchmarkFixture::covariance =
+    fuse_core::Vector3d(covariance_diagonal).asDiagonal();
+
+// Parameter blocks
+const double NormalPriorPose2DBenchmarkFixture::position[] = { 0.0, 0.0 };
+const double NormalPriorPose2DBenchmarkFixture::yaw[] = {0.0};
+
+// Mean and sqrt information matrix
+const fuse_core::Vector3d NormalPriorPose2DBenchmarkFixture::mean{ 1.0, 2.0, 3.0 };
+const fuse_core::Matrix3d NormalPriorPose2DBenchmarkFixture::sqrt_information(covariance.inverse().llt().matrixU());
+
+// Parameters
+const double* NormalPriorPose2DBenchmarkFixture::parameters[] = { position, yaw };
+
+const std::vector<int32_t>& NormalPriorPose2DBenchmarkFixture::block_sizes = { 2, 1};
+const size_t NormalPriorPose2DBenchmarkFixture::num_parameter_blocks = block_sizes.size();
+
+const size_t NormalPriorPose2DBenchmarkFixture::num_residuals = 3;
+
+BENCHMARK_DEFINE_F(NormalPriorPose2DBenchmarkFixture, AnalyticNormalPriorPose2D)(benchmark::State& state)
+{
+  // Create analytic cost function
+  const fuse_constraints::NormalPriorPose2D cost_function{ sqrt_information.topRows(state.range(0)), mean };
+
+  for (auto _ : state)
+  {
+    cost_function.Evaluate(parameters, residuals.data(), jacobians.data());
+  }
+}
+
+BENCHMARK_REGISTER_F(NormalPriorPose2DBenchmarkFixture, AnalyticNormalPriorPose2D)->DenseRange(1, 3);
+
+BENCHMARK_DEFINE_F(NormalPriorPose2DBenchmarkFixture, AutoDiffNormalPriorPose2D)(benchmark::State& state)
+{
+  // Create cost function using automatic differentiation on the cost functor
+  const auto partial_sqrt_information = sqrt_information.topRows(state.range(0));
+  const ceres::AutoDiffCostFunction<fuse_constraints::NormalPriorPose2DCostFunctor, ceres::DYNAMIC, 2, 1>
+      cost_function_autodiff(new fuse_constraints::NormalPriorPose2DCostFunctor(partial_sqrt_information, mean),
+                             partial_sqrt_information.rows());
+
+  for (auto _ : state)
+  {
+    cost_function_autodiff.Evaluate(parameters, residuals.data(), jacobians.data());
+  }
+}
+
+BENCHMARK_REGISTER_F(NormalPriorPose2DBenchmarkFixture, AutoDiffNormalPriorPose2D)->DenseRange(1, 3);
+
+BENCHMARK_MAIN();

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d.h
@@ -1,0 +1,102 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_2D_H
+#define FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_2D_H
+
+#include <fuse_core/eigen.h>
+
+#include <ceres/sized_cost_function.h>
+
+
+namespace fuse_constraints
+{
+
+/**
+ * @brief Create a prior cost function on both the position and orientation variables at once.
+ *
+ * The Ceres::NormalPrior cost function only supports a single variable. This is a convenience cost function that
+ * applies a prior constraint on both the position and orientation variables at once.
+ *
+ * The cost function is of the form:
+ *
+ *             ||    [  x - b(0)] ||^2
+ *   cost(x) = ||A * [  y - b(1)] ||
+ *             ||    [yaw - b(2)] ||
+ *
+ * Here, the matrix A can be of variable size, thereby permitting the computation of errors for partial measurements.
+ * The vector b is a fixed-size 3x1. In case the user is interested in implementing a cost function of the form:
+ *
+ *   cost(X) = (X - mu)^T S^{-1} (X - mu)
+ *
+ * where, mu is a vector and S is a covariance matrix, then, A = S^{-1/2}, i.e the matrix A is the square root
+ * information matrix (the inverse of the covariance).
+ */
+class NormalPriorPose2D : public ceres::SizedCostFunction<ceres::DYNAMIC, 2, 1>
+{
+public:
+  /**
+   * @brief Construct a cost function instance
+   *
+   * The residual weighting matrix can vary in size, as this cost functor can be used to compute costs for partial
+   * vectors. The number of rows of A will be the number of dimensions for which you want to compute the error, and the
+   * number of columns in A will be fixed at 3. For example, if we just want to use the values of x and yaw, then \p A
+   * will be of size 2x3.
+   *
+   * @param[in] A The residual weighting matrix, most likely the square root information matrix in order (x, y, yaw)
+   * @param[in] b The pose measurement or prior in order (x, y, yaw)
+   */
+  NormalPriorPose2D(const fuse_core::MatrixXd& A, const fuse_core::Vector3d& b);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~NormalPriorPose2D() = default;
+
+  /**
+   * @brief Compute the cost values/residuals, and optionally the Jacobians, using the provided variable/parameter
+   *        values
+   */
+  virtual bool Evaluate(
+    double const* const* parameters,
+    double* residuals,
+    double** jacobians) const;
+
+private:
+  fuse_core::MatrixXd A_;  //!< The residual weighting matrix, most likely the square root information matrix
+  fuse_core::Vector3d b_;  //!< The measured 2D pose value
+};
+
+}  // namespace fuse_constraints
+
+#endif  // FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_2D_H

--- a/fuse_constraints/package.xml
+++ b/fuse_constraints/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>fuse_constraints</name>
   <version>0.4.0</version>
   <description>
@@ -21,6 +24,7 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>suitesparse</depend>
+  <test_depend condition="$ROS_DISTRO >= melodic">benchmark</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
 
-#include <fuse_constraints/normal_prior_pose_2d_cost_functor.h>
+#include <fuse_constraints/normal_prior_pose_2d.h>
 #include <pluginlib/class_list_macros.h>
 
 #include <boost/serialization/export.hpp>
@@ -123,8 +123,7 @@ void AbsolutePose2DStampedConstraint::print(std::ostream& stream) const
 
 ceres::CostFunction* AbsolutePose2DStampedConstraint::costFunction() const
 {
-  return new ceres::AutoDiffCostFunction<NormalPriorPose2DCostFunctor, ceres::DYNAMIC, 2, 1>(
-    new NormalPriorPose2DCostFunctor(sqrt_information_, mean_), sqrt_information_.rows());
+  return new NormalPriorPose2D(sqrt_information_, mean_);
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/normal_prior_pose_2d.cpp
+++ b/fuse_constraints/src/normal_prior_pose_2d.cpp
@@ -1,0 +1,84 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/normal_prior_pose_2d.h>
+#include <fuse_core/util.h>
+
+#include <Eigen/Core>
+#include <glog/logging.h>
+
+
+namespace fuse_constraints
+{
+
+NormalPriorPose2D::NormalPriorPose2D(const fuse_core::MatrixXd& A, const fuse_core::Vector3d& b) :
+  A_(A),
+  b_(b)
+{
+  CHECK_GT(A_.rows(), 0);
+  CHECK_EQ(A_.cols(), 3);
+  set_num_residuals(A_.rows());
+}
+
+bool NormalPriorPose2D::Evaluate(
+  double const* const* parameters,
+  double* residuals,
+  double** jacobians) const
+{
+  fuse_core::Vector3d full_residuals_vector;
+  full_residuals_vector[0] = parameters[0][0] - b_[0];  // position x
+  full_residuals_vector[1] = parameters[0][1] - b_[1];  // position y
+  full_residuals_vector[2] = fuse_core::wrapAngle2D(parameters[1][0] - b_[2]);  // orientation
+
+  // Scale the residuals by the square root information matrix to account for the measurement uncertainty.
+  Eigen::Map<fuse_core::VectorXd> residuals_vector(residuals, num_residuals());
+  residuals_vector = A_ * full_residuals_vector;
+
+  if (jacobians != NULL)
+  {
+    // Jacobian wrt position
+    if (jacobians[0] != NULL)
+    {
+      Eigen::Map<fuse_core::MatrixXd>(jacobians[0], num_residuals(), 2) = A_.leftCols<2>();
+    }
+
+    // Jacobian wrt orientation
+    if (jacobians[1] != NULL)
+    {
+      Eigen::Map<fuse_core::VectorXd>(jacobians[1], num_residuals()) = A_.col(2);
+    }
+  }
+  return true;
+}
+
+}  // namespace fuse_constraints

--- a/fuse_constraints/test/test_normal_prior_pose_2d.cpp
+++ b/fuse_constraints/test/test_normal_prior_pose_2d.cpp
@@ -1,0 +1,220 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/normal_prior_pose_2d.h>
+#include <fuse_constraints/normal_prior_pose_2d_cost_functor.h>
+
+#include <gtest/gtest.h>
+#include <fuse_core/eigen_gtest.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <ceres/cost_function_to_functor.h>
+#include <Eigen/Dense>
+
+#include <memory>
+#include <vector>
+
+/**
+ * @brief A helper function to compare a expected and actual cost function.
+ *
+ * This helper function is copied and slightly adapted from:
+ *
+ *   https://github.com/ceres-solver/ceres-solver/blob/27b71795/internal/ceres/cost_function_to_functor_test.cc#L46-L119
+ *
+ * @param[in] cost_function The expected cost function
+ * @param[in] actual_cost_function The actual cost function
+ * @param[in] tolerance The tolerance to use when comparing the cost functions are equal. Defaults to 1e-18
+ */
+static void ExpectCostFunctionsAreEqual(const ceres::CostFunction& cost_function,
+                                        const ceres::CostFunction& actual_cost_function, double tolerance = 1e-18)
+{
+  EXPECT_EQ(cost_function.num_residuals(), actual_cost_function.num_residuals());
+  const size_t num_residuals = cost_function.num_residuals();
+  const std::vector<int32_t>& parameter_block_sizes = cost_function.parameter_block_sizes();
+  const std::vector<int32_t>& actual_parameter_block_sizes = actual_cost_function.parameter_block_sizes();
+  EXPECT_EQ(parameter_block_sizes.size(), actual_parameter_block_sizes.size());
+
+  size_t num_parameters = 0;
+  for (size_t i = 0; i < parameter_block_sizes.size(); ++i)
+  {
+    EXPECT_EQ(parameter_block_sizes[i], actual_parameter_block_sizes[i]);
+    num_parameters += parameter_block_sizes[i];
+  }
+
+  std::unique_ptr<double[]> parameters(new double[num_parameters]);
+  for (size_t i = 0; i < num_parameters; ++i)
+  {
+    parameters[i] = static_cast<double>(i) + 1.0;
+  }
+
+  std::unique_ptr<double[]> residuals(new double[num_residuals]);
+  std::unique_ptr<double[]> jacobians(new double[num_parameters * num_residuals]);
+
+  std::unique_ptr<double[]> actual_residuals(new double[num_residuals]);
+  std::unique_ptr<double[]> actual_jacobians(new double[num_parameters * num_residuals]);
+
+  std::unique_ptr<double* []> parameter_blocks(new double*[parameter_block_sizes.size()]);
+  std::unique_ptr<double* []> jacobian_blocks(new double*[parameter_block_sizes.size()]);
+  std::unique_ptr<double* []> actual_jacobian_blocks(new double*[parameter_block_sizes.size()]);
+
+  num_parameters = 0;
+  for (size_t i = 0; i < parameter_block_sizes.size(); ++i)
+  {
+    parameter_blocks[i] = parameters.get() + num_parameters;
+    jacobian_blocks[i] = jacobians.get() + num_parameters * num_residuals;
+    actual_jacobian_blocks[i] = actual_jacobians.get() + num_parameters * num_residuals;
+    num_parameters += parameter_block_sizes[i];
+  }
+
+  EXPECT_TRUE(cost_function.Evaluate(parameter_blocks.get(), residuals.get(), NULL));
+  EXPECT_TRUE(actual_cost_function.Evaluate(parameter_blocks.get(), actual_residuals.get(), NULL));
+  for (size_t i = 0; i < num_residuals; ++i)
+  {
+    EXPECT_NEAR(residuals[i], actual_residuals[i], tolerance) << "residual id: " << i;
+  }
+
+  EXPECT_TRUE(cost_function.Evaluate(parameter_blocks.get(), residuals.get(), jacobian_blocks.get()));
+  EXPECT_TRUE(
+      actual_cost_function.Evaluate(parameter_blocks.get(), actual_residuals.get(), actual_jacobian_blocks.get()));
+  for (size_t i = 0; i < num_residuals; ++i)
+  {
+    EXPECT_NEAR(residuals[i], actual_residuals[i], tolerance) << "residual : " << i;
+  }
+
+  for (size_t i = 0; i < num_residuals * num_parameters; ++i)
+  {
+    EXPECT_NEAR(jacobians[i], actual_jacobians[i], tolerance)
+        << "jacobian : " << i << " " << jacobians[i] << " " << actual_jacobians[i];
+  }
+}
+
+/**
+ * @brief Test fixture that initializes a full pose 2d mean and sqrt information matrix.
+ */
+class NormalPriorPose2DTestFixture : public ::testing::Test
+{
+public:
+  using AutoDiffNormalPriorPose2D =
+      ceres::AutoDiffCostFunction<fuse_constraints::NormalPriorPose2DCostFunctor, ceres::DYNAMIC, 2,
+                                  1>;  //!< The automatic differentiation cost function type for the pose 2d cost
+                                       //!< functor
+
+  /**
+   * @brief Constructor
+   */
+  NormalPriorPose2DTestFixture()
+  {
+    full_sqrt_information = covariance.inverse().llt().matrixU();
+  }
+
+  const fuse_core::Matrix3d covariance =
+      fuse_core::Vector3d(2e-3, 1e-3, 1e-2).asDiagonal();  //!< The full pose 2d covariance for the x, y and yaw
+                                                           //!< components
+  Eigen::Matrix3d full_sqrt_information;  //!< The full pose 2d sqrt information matrix for the x, y and yaw components
+  const Eigen::Vector3d full_mean{ 1.0, 2.0, 3.0 };  //!< The full pose 2d mean components: x, y and yaw
+};
+
+TEST_F(NormalPriorPose2DTestFixture, AnalyticAndAutoDiffCostFunctionsAreEqualForFullResiduals)
+{
+  // Create cost function
+  const fuse_constraints::NormalPriorPose2D cost_function{ full_sqrt_information, full_mean };
+
+  // Create automatic differentiation cost function
+  const auto num_residuals = full_sqrt_information.rows();
+
+  AutoDiffNormalPriorPose2D autodiff_cost_function(
+      new fuse_constraints::NormalPriorPose2DCostFunctor(full_sqrt_information, full_mean), num_residuals);
+
+  // Compare the expected, automatic differentiation, cost function and the actual one
+  ExpectCostFunctionsAreEqual(autodiff_cost_function, cost_function);
+}
+
+TEST_F(NormalPriorPose2DTestFixture, AnalyticAndAutoDiffCostFunctionsAreEqualForTwoResiduals)
+{
+  // Create cost function for each possible pair of two residuals, the ones in each possible pair of rows
+  using IndicesPair = std::array<int, 2>;
+  std::array<IndicesPair, 3> indices_pairs = { IndicesPair{ 0, 1 }, IndicesPair{ 0, 2 }, IndicesPair{ 1, 2 } };
+  for (const auto& indices_pair : indices_pairs)
+  {
+    // It is a shame we need Eigen 3.4+ in order to use the slicing and indexing API documented in:
+    //
+    //   https://eigen.tuxfamily.org/dox-devel/group__TutorialSlicingIndexing.html
+    //
+    // That would allow us to simply do:
+    //
+    //   const fuse_core::Matrix<double, 2, 3> partial_sqrt_information =
+    //       full_sqrt_information(indices_pair, Eigen::all);
+    fuse_core::Matrix<double, 2, 3> partial_sqrt_information;
+    for (size_t i = 0; i < indices_pair.size(); ++i)
+    {
+      partial_sqrt_information.row(i) = full_sqrt_information.row(indices_pair[i]);
+    }
+
+    const fuse_constraints::NormalPriorPose2D cost_function{ partial_sqrt_information, full_mean };
+
+    // Create automatic differentiation cost function
+    const auto num_residuals = partial_sqrt_information.rows();
+
+    AutoDiffNormalPriorPose2D autodiff_cost_function(
+        new fuse_constraints::NormalPriorPose2DCostFunctor(partial_sqrt_information, full_mean), num_residuals);
+
+    ExpectCostFunctionsAreEqual(autodiff_cost_function, cost_function);
+  }
+}
+
+TEST_F(NormalPriorPose2DTestFixture, AnalyticAndAutoDiffCostFunctionsAreEqualForOneResidual)
+{
+  // Create cost function for one residual, the one in each row
+  for (size_t i = 0; i < 3; ++i)
+  {
+    SCOPED_TRACE("Residual " + std::to_string(i));
+
+    const fuse_core::Matrix<double, 1, 3> partial_sqrt_information = full_sqrt_information.row(i);
+
+    const fuse_constraints::NormalPriorPose2D cost_function{ partial_sqrt_information, full_mean };
+
+    // Create automatic differentiation cost function
+    const auto num_residuals = partial_sqrt_information.rows();
+
+    AutoDiffNormalPriorPose2D autodiff_cost_function(
+        new fuse_constraints::NormalPriorPose2DCostFunctor(partial_sqrt_information, full_mean), num_residuals);
+
+    ExpectCostFunctionsAreEqual(autodiff_cost_function, cost_function);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
* Add analytic `NormalPriorPose2D` cost function
* Use analytic `NormalPriorPose2D` cost function in `AbsolutePose2DStampedConstraint`
* Test `NormalPriorPose2D` jacobians are correct, comparing against `NormalPriorPose2DCostFunctor` using automatic differentiation
* Benchmark `NormalPriorPose2D` vs `NormalPriorPose2DCostFunctor` using automatic differentiation for 1, 2 and 3 residuals. The latency speedup is approximately 2.36, 2.76 and 3.44, respectively.

``` bash
--------------------------------------------------------------------------------------------------------
Benchmark                                                              Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------
NormalPriorPose2DBenchmarkFixture/AnalyticNormalPriorPose2D/1       48.7 ns         48.7 ns     14250126
NormalPriorPose2DBenchmarkFixture/AnalyticNormalPriorPose2D/2       51.9 ns         51.9 ns     13250197
NormalPriorPose2DBenchmarkFixture/AnalyticNormalPriorPose2D/3       54.6 ns         54.6 ns     12986982
NormalPriorPose2DBenchmarkFixture/AutoDiffNormalPriorPose2D/1        115 ns          115 ns      6493997
NormalPriorPose2DBenchmarkFixture/AutoDiffNormalPriorPose2D/2        143 ns          143 ns      4837919
NormalPriorPose2DBenchmarkFixture/AutoDiffNormalPriorPose2D/3        188 ns          188 ns      3657156
```