### PR TITLE
Remove deprecated ::Model models leftovers

### DIFF
--- a/fuse_models/fuse_plugins.xml
+++ b/fuse_models/fuse_plugins.xml
@@ -44,11 +44,6 @@
     another node
     </description>
   </class>
-  <class type="fuse_models::twist_2d::Model" base_class_type="fuse_core::SensorModel">
-    <description>
-    An adapter-type sensor that produces absolute velocity constraints from information published by another node
-    </description>
-  </class>
   <class type="fuse_models::Twist2D" base_class_type="fuse_core::SensorModel">
     <description>
     An adapter-type sensor that produces absolute velocity constraints from information published by another node
@@ -59,5 +54,4 @@
     A fuse_models ignition sensor designed to be used in conjunction with the unicycle 2D motion model.
     </description>
   </class>
-  
 </library>

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -63,7 +63,7 @@ namespace fuse_models
  *   2. Creates 2D velocity variables and constraints.
  *
  * This sensor really just separates out the orientation, angular velocity, and linear acceleration components of the
- * message, and processes them just like the pose_2d::Model, twist_2d::Model, and acceleration_2d::Model classes.
+ * message, and processes them just like the Pose2D, Twist2D, and Acceleration2D classes.
  *
  * Parameters:
  *  - device_id (uuid string, default: 00000000-0000-0000-0000-000000000000) The device/robot ID to publish

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -62,7 +62,7 @@ namespace fuse_models
  *   2. Creates 2D velocity variables and constraints.
  *
  * This sensor really just separates out the pose and twist components of the message, and processes them just like the
- * pose_2d::Odometry2D and twist_2d::Odometry2D classes.
+ * Pose2D and Twist2D classes.
  *
  * Parameters:
  *  - device_id (uuid string, default: 00000000-0000-0000-0000-000000000000) The device/robot ID to publish


### PR DESCRIPTION
* Remove `fuse_models::twist_2d::Model` plugin declaration
* Remove empty space in `fuse_plugins.xml`
* Update `::Model` names to new names in doxygen comments