### PR TITLE
Add fuse_models::Transaction sensor model

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(
     fuse_constraints
     fuse_core
     fuse_graphs
+    fuse_msgs
     fuse_publishers
     fuse_variables
     geometry_msgs
@@ -50,6 +51,7 @@ catkin_package(
     fuse_constraints
     fuse_core
     fuse_graphs
+    fuse_msgs
     fuse_publishers
     fuse_variables
     geometry_msgs
@@ -84,6 +86,7 @@ add_library(${PROJECT_NAME}
   src/odometry_2d.cpp
   src/odometry_2d_publisher.cpp
   src/pose_2d.cpp
+  src/transaction.cpp
   src/twist_2d.cpp
   src/unicycle_2d.cpp
   src/unicycle_2d_ignition.cpp

--- a/fuse_models/fuse_plugins.xml
+++ b/fuse_models/fuse_plugins.xml
@@ -44,6 +44,12 @@
     another node
     </description>
   </class>
+  <class type="fuse_models::Transaction" base_class_type="fuse_core::SensorModel">
+    <description>
+    An adapter-type sensor that produces transactions with the same added and removed constraints from an input
+    transaction. This is useful for debugging purposes because it allows to play back the recorded transactions.
+    </description>
+  </class>
   <class type="fuse_models::Twist2D" base_class_type="fuse_core::SensorModel">
     <description>
     An adapter-type sensor that produces absolute velocity constraints from information published by another node

--- a/fuse_models/include/fuse_models/parameters/transaction_params.h
+++ b/fuse_models/include/fuse_models/parameters/transaction_params.h
@@ -1,0 +1,76 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_PARAMETERS_TRANSACTION_PARAMS_H
+#define FUSE_MODELS_PARAMETERS_TRANSACTION_PARAMS_H
+
+#include <fuse_models/parameters/parameter_base.h>
+
+#include <fuse_core/parameter.h>
+#include <ros/node_handle.h>
+
+#include <string>
+
+namespace fuse_models
+{
+
+namespace parameters
+{
+
+/**
+ * @brief Defines the set of parameters required by the Transaction class
+ */
+struct TransactionParams : public fuse_models::parameters::ParameterBase
+{
+public:
+  /**
+   * @brief Method for loading parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load parameters
+   */
+  void loadFromROS(const ros::NodeHandle& nh) final
+  {
+    nh.getParam("queue_size", queue_size);
+    fuse_core::getParamRequired(nh, "topic", topic);
+  }
+
+  int queue_size{ 10 };
+  std::string topic{};
+};
+
+}  // namespace parameters
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_PARAMETERS_TRANSACTION_PARAMS_H

--- a/fuse_models/include/fuse_models/transaction.h
+++ b/fuse_models/include/fuse_models/transaction.h
@@ -1,0 +1,110 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_TRANSACTION_H
+#define FUSE_MODELS_TRANSACTION_H
+
+#include <fuse_models/parameters/transaction_params.h>
+
+#include <fuse_core/async_sensor_model.h>
+#include <fuse_core/transaction_deserializer.h>
+
+#include <fuse_msgs/SerializedTransaction.h>
+#include <ros/ros.h>
+
+namespace fuse_models
+{
+
+/**
+ * @brief An adapter-type sensor that produces transactions with the same added and removed constraints from an input
+ * transaction. This is useful for debugging purposes because it allows to play back the recorded transactions.
+ *
+ * This sensor subscribes to a fuse_msgs::SerializedTransaction topic and deserializes each received message into a
+ * transaction.
+ *
+ * Parameters:
+ *  - ~queue_size (int, default: 10) The subscriber queue size for the transaction messages
+ *  - ~topic (string) The topic to which to subscribe for the transaction messages
+ *
+ * Subscribes:
+ *  - topic (fuse_msgs::SerializedTransaction) Transaction
+ */
+class Transaction : public fuse_core::AsyncSensorModel
+{
+public:
+  SMART_PTR_DEFINITIONS(Transaction);
+  using ParameterType = parameters::TransactionParams;
+
+  /**
+   * @brief Default constructor
+   */
+  Transaction();
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~Transaction() = default;
+
+protected:
+  /**
+   * @brief Loads ROS parameters and subscribes to the parameterized topic
+   */
+  void onInit() override;
+
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   */
+  void onStart() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   */
+  void onStop() override;
+
+  /**
+   * @brief Callback for transaction messages
+   * @param[in] msg - The transaction message to process
+   */
+  void process(const fuse_msgs::SerializedTransaction::ConstPtr& msg);
+
+  ParameterType params_;  //!< Object containing all of the configuration parameters
+
+  ros::Subscriber subscriber_;  //!< ROS subscriber that receives SerializedTransaction messages
+
+  fuse_core::TransactionDeserializer transaction_deserializer_;  //!< Deserializer for SerializedTransaction messages
+};
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_TRANSACTION_H

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -20,6 +20,7 @@
   <depend>fuse_constraints</depend>
   <depend>fuse_core</depend>
   <depend>fuse_graphs</depend>
+  <depend>fuse_msgs</depend>
   <depend>fuse_publishers</depend>
   <depend>fuse_variables</depend>
   <depend>geometry_msgs</depend>

--- a/fuse_models/src/transaction.cpp
+++ b/fuse_models/src/transaction.cpp
@@ -1,0 +1,73 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_models/transaction.h>
+
+#include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+
+// Register this sensor model with ROS as a plugin.
+PLUGINLIB_EXPORT_CLASS(fuse_models::Transaction, fuse_core::SensorModel)
+
+namespace fuse_models
+{
+
+Transaction::Transaction() : fuse_core::AsyncSensorModel(1)
+{
+}
+
+void Transaction::onInit()
+{
+  // Read settings from the parameter sever
+  params_.loadFromROS(private_node_handle_);
+}
+
+void Transaction::onStart()
+{
+  subscriber_ =
+      node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size, &Transaction::process, this);
+}
+
+void Transaction::onStop()
+{
+  subscriber_.shutdown();
+}
+
+void Transaction::process(const fuse_msgs::SerializedTransaction::ConstPtr& msg)
+{
+  // Deserialize and send the transaction to the plugin's parent
+  sendTransaction(transaction_deserializer_.deserialize(msg).clone());
+}
+
+}  // namespace fuse_models


### PR DESCRIPTION
* Add `fuse_models::Transaction` sensor model

I'm going to send another PR with a `fuse_models::GraphIgnition` that complements this one and also adds a rostest. This should hopefully motivate https://github.com/locusrobotics/fuse/pull/183 a bit more, although I understand the last comments there and they might actually be an issue. I still have to look at that.

I'm open to other approaches to load a recorded graph and transactions.