### PR TITLE
Add fuse_models::GraphIgnition sensor model

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -32,6 +32,7 @@ add_service_files(
   DIRECTORY
     srv
   FILES
+    SetGraph.srv
     SetPose.srv
     SetPoseDeprecated.srv
 )
@@ -39,6 +40,7 @@ add_service_files(
 generate_messages(
   DEPENDENCIES
     geometry_msgs
+    fuse_msgs
     std_msgs
 )
 
@@ -82,6 +84,7 @@ add_compile_options(-Wall -Werror)
 ## Declare a C++ library
 add_library(${PROJECT_NAME}
   src/acceleration_2d.cpp
+  src/graph_ignition.cpp
   src/imu_2d.cpp
   src/odometry_2d.cpp
   src/odometry_2d_publisher.cpp
@@ -198,7 +201,33 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
-  # Ignition tests
+  # Graph Ignition tests
+  add_rostest_gtest(
+    test_graph_ignition
+    test/graph_ignition.test
+    test/test_graph_ignition.cpp
+  )
+  add_dependencies(test_graph_ignition
+    ${${PROJECT_NAME}_EXPORTED_TARGETS}
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_graph_ignition
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  target_link_libraries(test_graph_ignition
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_graph_ignition
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
+  # Unicycle2D Ignition tests
   add_rostest_gtest(
     test_unicycle_2d_ignition
     test/unicycle_2d_ignition.test

--- a/fuse_models/fuse_plugins.xml
+++ b/fuse_models/fuse_plugins.xml
@@ -26,6 +26,14 @@
     another node
     </description>
   </class>
+  <class type="fuse_models::GraphIgnition" base_class_type="fuse_core::SensorModel">
+    <description>
+    An ignition sensor designed to be used to reset the optimizer graph to an input graph. This is useful for debugging
+    purposes because it allows to play back the recorded transactions from a previous run starting from the same graph,
+    so we obtain the same intermediate graphs and publishers' outputs. This is specially useful when we cannot record
+    all the graph messages because that would take too much bandwidth or disk, so the recorded graph must be throttled.
+    </description>
+  </class>
   <class type="fuse_models::Imu2D" base_class_type="fuse_core::SensorModel">
     <description>
     An adapter-type sensor that produces orientation (relative or absolute), angular velocity, and linear

--- a/fuse_models/include/fuse_models/graph_ignition.h
+++ b/fuse_models/include/fuse_models/graph_ignition.h
@@ -1,0 +1,158 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_GRAPH_IGNITION_H
+#define FUSE_MODELS_GRAPH_IGNITION_H
+
+#include <fuse_models/SetGraph.h>
+#include <fuse_models/parameters/graph_ignition_params.h>
+
+#include <fuse_core/async_sensor_model.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/graph_deserializer.h>
+
+#include <fuse_msgs/SerializedGraph.h>
+#include <ros/ros.h>
+
+#include <atomic>
+
+namespace fuse_models
+{
+
+/**
+ * @brief A ignition sensor designed to be used to reset the optimizer graph to an input graph. This is useful for
+ * debugging purposes because it allows to play back the recorded transactions from a previous run starting from the
+ * same graph, so we obtain the same intermediate graphs and publishers' outputs. This is specially useful when we
+ * cannot record all the graph messages because that would take too much bandwidth or disk, so the recorded graph must
+ * be throttled.
+ *
+ * This class publishes a transaction equivalent to the supplied graph. When the sensor is first loaded, it does not
+ * send any transactions. It waits for a graph to do so. Whenever a graph is received, either
+ * on the set_graph service or the topic, this ignition sensor resets the optimizer then publishes a new transaction
+ * equivalent to the specified graph.
+ *
+ * Parameters:
+ *  - ~queue_size (int, default: 10) The subscriber queue size for the graph messages
+ *  - ~reset_service (string, default: "~reset") The name of the reset service to call before sending a transaction
+ *  - ~set_graph_service (string, default: "~set_graph") The name of the set_graph service to advertise
+ *  - ~topic (string, default: "~graph") The topic name for received Graph messages
+ */
+class GraphIgnition : public fuse_core::AsyncSensorModel
+{
+public:
+  SMART_PTR_DEFINITIONS(GraphIgnition);
+  using ParameterType = parameters::GraphIgnitionParams;
+
+  /**
+   * @brief Default constructor
+   *
+   * All plugins are required to have a constructor that accepts no arguments
+   */
+  GraphIgnition();
+
+  /**
+   * @brief Destructor
+   */
+  ~GraphIgnition() = default;
+
+  /**
+   * @brief Subscribe to the input topic to start sending transactions to the optimizer
+   *
+   * As a very special case, we are overriding the start() method instead of providing an onStart() implementation.
+   * This is because the GraphIgnition sensor calls reset() on the optimizer, which in turn calls stop() and start(). If
+   * we used the AsyncSensorModel implementations of start() and stop(), the system would hang inside of one callback
+   * function while waiting for another callback to complete.
+   */
+  void start() override;
+
+  /**
+   * @brief Unsubscribe from the input topic to stop sending transactions to the optimizer
+   *
+   * As a very special case, we are overriding the stop() method instead of providing an onStop() implementation.
+   * This is because the GraphIgnition sensor calls reset() on the optimizer, which in turn calls stop() and start(). If
+   * we used the AsyncSensorModel implementations of start() and stop(), the system would hang inside of one callback
+   * function while waiting for another callback to complete.
+   */
+  void stop() override;
+
+protected:
+  /**
+   * @brief Triggers the publication of a new transaction equivalent to the supplied graph
+   */
+  void subscriberCallback(const fuse_msgs::SerializedGraph::ConstPtr& msg);
+
+  /**
+   * @brief Triggers the publication of a new transaction equivalent to the supplied graph
+   */
+  bool setGraphServiceCallback(fuse_models::SetGraph::Request& req, fuse_models::SetGraph::Response& res);
+
+  /**
+   * @brief Perform any required initialization for the kinematic ignition sensor
+   */
+  void onInit() override;
+
+  /**
+   * @brief Process a received graph from one of the ROS comm channels
+   *
+   * This method validates the input graph, resets the optimizer, then constructs and sends the initial state
+   * constraints (by calling sendGraph()).
+   *
+   * @param[in] msg - The graph message
+   */
+  void process(const fuse_msgs::SerializedGraph& msg);
+
+  /**
+   * @brief Create and send a transaction equivalent to the supplied graph
+   *
+   * @param[in] graph - The graph
+   * @param[in] stamp - The graph stamp
+   */
+  void sendGraph(const fuse_core::Graph& graph, const ros::Time& stamp);
+
+  std::atomic_bool started_;  //!< Flag indicating the sensor has been started
+
+  ParameterType params_;  //!< Object containing all of the configuration parameters
+
+  ros::ServiceClient reset_client_;  //!< Service client used to call the "reset" service on the optimizer
+
+  ros::ServiceServer set_graph_service_;  //!< ROS service server that receives SetGraph requests
+
+  ros::Subscriber subscriber_;  //!< ROS subscriber that receives SerializedGraph messages
+
+  fuse_core::GraphDeserializer graph_deserializer_;  //!< Deserializer for SerializedGraph messages
+};
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_GRAPH_IGNITION_H

--- a/fuse_models/include/fuse_models/parameters/graph_ignition_params.h
+++ b/fuse_models/include/fuse_models/parameters/graph_ignition_params.h
@@ -1,0 +1,94 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_PARAMETERS_GRAPH_IGNITION_PARAMS_H
+#define FUSE_MODELS_PARAMETERS_GRAPH_IGNITION_PARAMS_H
+
+#include <fuse_models/parameters/parameter_base.h>
+
+#include <ros/node_handle.h>
+
+#include <string>
+
+namespace fuse_models
+{
+
+namespace parameters
+{
+
+/**
+ * @brief Defines the set of parameters required by the GraphIgnition class
+ */
+struct GraphIgnitionParams : public fuse_models::parameters::ParameterBase
+{
+public:
+  /**
+   * @brief Method for loading parameter values from ROS.
+   *
+   * @param[in] nh - The ROS node handle with which to load parameters
+   */
+  void loadFromROS(const ros::NodeHandle& nh) final
+  {
+    nh.getParam("queue_size", queue_size);
+    nh.getParam("reset_service", reset_service);
+    nh.getParam("set_graph_service", set_graph_service);
+    nh.getParam("topic", topic);
+  }
+
+  /**
+   * @brief The size of the subscriber queue for the topic
+   */
+  int queue_size{ 10 };
+
+  /**
+   * @brief The name of the reset service to call before sending transactions to the optimizer
+   */
+  std::string reset_service{ "~reset" };
+
+  /**
+   * @brief The name of the set_graph service to advertise
+   */
+  std::string set_graph_service{ "~set_graph" };
+
+  /**
+   * @brief The topic name for received SerializedGraph messages
+   */
+  std::string topic{ "~graph" };
+};
+
+}  // namespace parameters
+
+}  // namespace fuse_models
+
+#endif  // FUSE_MODELS_PARAMETERS_GRAPH_IGNITION_PARAMS_H

--- a/fuse_models/src/graph_ignition.cpp
+++ b/fuse_models/src/graph_ignition.cpp
@@ -1,0 +1,194 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_models/graph_ignition.h>
+
+#include <std_srvs/Empty.h>
+
+#include <pluginlib/class_list_macros.h>
+
+#include <boost/range/algorithm.hpp>
+#include <boost/range/empty.hpp>
+#include <boost/range/size.hpp>
+
+// Register this sensor model with ROS as a plugin.
+PLUGINLIB_EXPORT_CLASS(fuse_models::GraphIgnition, fuse_core::SensorModel);
+
+namespace fuse_models
+{
+
+GraphIgnition::GraphIgnition() : fuse_core::AsyncSensorModel(1), started_(false)
+{
+}
+
+void GraphIgnition::onInit()
+{
+  // Read settings from the parameter sever
+  params_.loadFromROS(private_node_handle_);
+
+  // Connect to the reset service
+  if (!params_.reset_service.empty())
+  {
+    reset_client_ = node_handle_.serviceClient<std_srvs::Empty>(ros::names::resolve(params_.reset_service));
+  }
+
+  // Advertise
+  subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
+                                       &GraphIgnition::subscriberCallback, this);
+  set_graph_service_ = node_handle_.advertiseService(ros::names::resolve(params_.set_graph_service),
+                                                     &GraphIgnition::setGraphServiceCallback, this);
+}
+
+void GraphIgnition::start()
+{
+  started_ = true;
+}
+
+void GraphIgnition::stop()
+{
+  started_ = false;
+}
+
+void GraphIgnition::subscriberCallback(const fuse_msgs::SerializedGraph::ConstPtr& msg)
+{
+  try
+  {
+    process(*msg);
+  }
+  catch (const std::exception& e)
+  {
+    ROS_ERROR_STREAM(e.what() << " Ignoring message.");
+  }
+}
+
+bool GraphIgnition::setGraphServiceCallback(fuse_models::SetGraph::Request& req, fuse_models::SetGraph::Response& res)
+{
+  try
+  {
+    process(req.graph);
+    res.success = true;
+  }
+  catch (const std::exception& e)
+  {
+    res.success = false;
+    res.message = e.what();
+    ROS_ERROR_STREAM(e.what() << " Ignoring request.");
+  }
+  return true;
+}
+
+void GraphIgnition::process(const fuse_msgs::SerializedGraph& msg)
+{
+  // Verify we are in the correct state to process set graph requests
+  if (!started_)
+  {
+    throw std::runtime_error("Attempting to set the graph while the sensor is stopped.");
+  }
+
+  // Deserialize the graph message
+  const auto graph = graph_deserializer_.deserialize(msg);
+
+  // Validate the requested graph before we do anything
+  if (boost::empty(graph->getConstraints()))
+  {
+    throw std::runtime_error("Attempting to set a graph with no constraints.");
+  }
+
+  if (boost::empty(graph->getVariables()))
+  {
+    throw std::runtime_error("Attempting to set a graph with no variables.");
+  }
+
+  // Tell the optimizer to reset before providing the initial state
+  if (!params_.reset_service.empty())
+  {
+    // Wait for the reset service
+    while (!reset_client_.waitForExistence(ros::Duration(10.0)) && ros::ok())
+    {
+      ROS_WARN_STREAM("Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
+    }
+
+    auto srv = std_srvs::Empty();
+    if (!reset_client_.call(srv))
+    {
+      // The reset() service failed. Propagate that failure to the caller of this service.
+      throw std::runtime_error("Failed to call the '" + reset_client_.getService() + "' service.");
+    }
+  }
+
+  // Now that the optimizer has been reset, actually send the initial state constraints to the optimizer
+  sendGraph(*graph, msg.header.stamp);
+}
+
+void GraphIgnition::sendGraph(const fuse_core::Graph& graph, const ros::Time& stamp)
+{
+  // Create a transaction equivalent to the graph
+  auto transaction = fuse_core::Transaction::make_shared();
+  transaction->stamp(stamp);
+
+  // Add variables
+  for (const auto& variable : graph.getVariables())
+  {
+    transaction->addVariable(variable.clone());
+
+    // If the variable is a fuse_variables::Stamped variable, set the involved stamp
+    const auto stamped_variable = dynamic_cast<const fuse_variables::Stamped*>(&variable);
+    if (stamped_variable)
+    {
+      transaction->addInvolvedStamp(stamped_variable->stamp());
+    }
+  }
+
+  // If the transaction ended up with no involved stamps, we use a single involved stamped equal to the
+  // transaction/graph stamp
+  if (boost::empty(transaction->involvedStamps()))
+  {
+    transaction->addInvolvedStamp(stamp);
+  }
+
+  // Add constraints
+  for (const auto& constraint : graph.getConstraints())
+  {
+    transaction->addConstraint(constraint.clone());
+  }
+
+  // Send the transaction to the optimizer.
+  sendTransaction(transaction);
+
+  ROS_INFO_STREAM("Received a set_graph request (stamp: "
+                  << transaction->stamp() << ", constraints: " << boost::size(transaction->addedConstraints())
+                  << ", variables: " << boost::size(transaction->addedVariables()) << ")");
+}
+
+}  // namespace fuse_models

--- a/fuse_models/srv/SetGraph.srv
+++ b/fuse_models/srv/SetGraph.srv
@@ -1,0 +1,4 @@
+fuse_msgs/SerializedGraph graph
+---
+bool success
+string message

--- a/fuse_models/test/example_constraint.h
+++ b/fuse_models/test/example_constraint.h
@@ -1,0 +1,118 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}
+#define FUSE_MODELS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}
+
+#include <fuse_core/constraint.h>
+#include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
+#include <fuse_core/uuid.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+#include <string>
+
+/**
+ * @brief Dummy constraint implementation for testing
+ */
+class ExampleConstraint : public fuse_core::Constraint
+{
+public:
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+
+  ExampleConstraint() = default;
+
+  ExampleConstraint(const std::string& source, std::initializer_list<fuse_core::UUID> variable_uuid_list)
+    : fuse_core::Constraint(source, variable_uuid_list), data(0.0)
+  {
+  }
+
+  template <typename VariableUuidIterator>
+  ExampleConstraint(const std::string& source, VariableUuidIterator first, VariableUuidIterator last)
+    : fuse_core::Constraint(source, first, last), data(0.0)
+  {
+  }
+
+  void print(std::ostream& stream = std::cout) const override
+  {
+    stream << type() << ":\n"
+           << "  source: " << source() << '\n'
+           << "  uuid: " << uuid() << '\n'
+           << "  variables: [";
+
+    const auto& variable_uuids = variables();
+    if (!variable_uuids.empty())
+    {
+      std::copy(variable_uuids.begin(), variable_uuids.end() - 1, std::ostream_iterator<fuse_core::UUID>(stream, ", "));
+      stream << variable_uuids.back();
+    }
+
+    stream << "]\n"
+           << "  data: " << data << '\n';
+  }
+
+  ceres::CostFunction* costFunction() const override
+  {
+    return nullptr;
+  }
+
+  double data;  // Public member variable just for testing
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive& boost::serialization::base_object<fuse_core::Constraint>(*this);
+    archive& data;
+  }
+};
+
+BOOST_CLASS_EXPORT(ExampleConstraint);
+
+#endif  // FUSE_MODELS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}

--- a/fuse_models/test/example_variable.h
+++ b/fuse_models/test/example_variable.h
@@ -1,0 +1,103 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
+#define FUSE_MODELS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
+
+#include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+/**
+ * @brief Dummy variable implementation for testing
+ */
+class ExampleVariable : public fuse_core::Variable
+{
+public:
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
+
+  ExampleVariable() : fuse_core::Variable(fuse_core::uuid::generate()), data_(0.0)
+  {
+  }
+
+  size_t size() const override
+  {
+    return 1;
+  }
+
+  const double* data() const override
+  {
+    return &data_;
+  }
+
+  double* data() override
+  {
+    return &data_;
+  }
+
+  void print(std::ostream& stream = std::cout) const override
+  {
+    stream << type() << ":\n"
+           << "  uuid: " << uuid() << '\n'
+           << "  data: " << data_ << '\n';
+  }
+
+private:
+  double data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive& boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive& data_;
+  }
+};
+
+BOOST_CLASS_EXPORT(ExampleVariable);
+
+#endif  // FUSE_MODELS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}

--- a/fuse_models/test/example_variable_stamped.h
+++ b/fuse_models/test/example_variable_stamped.h
@@ -1,0 +1,112 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FUSE_MODELS_TEST_EXAMPLE_VARIABLE_STAMPED_H  // NOLINT{build/header_guard}
+#define FUSE_MODELS_TEST_EXAMPLE_VARIABLE_STAMPED_H  // NOLINT{build/header_guard}
+
+#include <fuse_core/macros.h>
+#include <fuse_core/serialization.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
+#include <fuse_variables/stamped.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+/**
+ * @brief Dummy variable stamped implementation for testing
+ */
+class ExampleVariableStamped : public fuse_core::Variable, public fuse_variables::Stamped
+{
+public:
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariableStamped);
+
+  ExampleVariableStamped() = default;
+
+  explicit ExampleVariableStamped(const ros::Time& stamp, const fuse_core::UUID& device_id = fuse_core::uuid::NIL)
+    : fuse_core::Variable(fuse_core::uuid::generate(detail::type(), stamp, device_id))
+    , Stamped(stamp, device_id)
+    , data_(0.0)
+  {
+  }
+
+  size_t size() const override
+  {
+    return 1;
+  }
+
+  const double* data() const override
+  {
+    return &data_;
+  }
+
+  double* data() override
+  {
+    return &data_;
+  }
+
+  void print(std::ostream& stream = std::cout) const override
+  {
+    stream << type() << ":\n"
+           << "  uuid: " << uuid() << '\n'
+           << "  stamp: " << stamp() << '\n'
+           << "  device_id: " << deviceId() << '\n'
+           << "  data: " << data_ << '\n';
+  }
+
+private:
+  double data_;
+
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive& boost::serialization::base_object<fuse_core::Variable>(*this);
+    archive& boost::serialization::base_object<fuse_variables::Stamped>(*this);
+    archive& data_;
+  }
+};
+
+BOOST_CLASS_EXPORT(ExampleVariableStamped);
+
+#endif  // FUSE_MODELS_TEST_EXAMPLE_VARIABLE_STAMPED_H  // NOLINT{build/header_guard}

--- a/fuse_models/test/graph_ignition.test
+++ b/fuse_models/test/graph_ignition.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+  <test test-name="graph_ignition_test" pkg="fuse_models" type="test_graph_ignition" />
+</launch>

--- a/fuse_models/test/test_graph_ignition.cpp
+++ b/fuse_models/test/test_graph_ignition.cpp
@@ -1,0 +1,411 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_core/constraint.h>
+#include <fuse_core/graph_deserializer.h>
+#include <fuse_core/transaction.h>
+#include <fuse_core/variable.h>
+#include <fuse_graphs/hash_graph.h>
+#include <fuse_models/SetGraph.h>
+#include <fuse_models/graph_ignition.h>
+#include <ros/ros.h>
+
+#include <test/example_constraint.h>
+#include <test/example_variable.h>
+#include <test/example_variable_stamped.h>
+
+#include <gtest/gtest.h>
+
+#include <boost/range/algorithm.hpp>
+#include <boost/range/size.hpp>
+
+#include <chrono>
+#include <future>
+#include <string>
+
+/**
+ * @brief Promise used to communicate between the tests and the callback
+ */
+std::promise<fuse_core::Transaction::SharedPtr> callback_promise;
+
+/**
+ * @brief Transaction callback that forwards the transaction into the promise result
+ */
+void transactionCallback(fuse_core::Transaction::SharedPtr transaction)
+{
+  callback_promise.set_value(std::move(transaction));
+}
+
+/**
+ * @brief Static variable to hold the last unit test error description
+ */
+static std::string failure_description;
+
+/**
+ * @brief Compare all the properties of two Variable objects
+ * @return True if all the properties match, false otherwise
+ */
+bool compareVariables(const fuse_core::Variable& expected, const fuse_core::Variable& actual)
+{
+  failure_description = "";
+  bool variables_equal = true;
+  if (expected.type() != actual.type())
+  {
+    variables_equal = false;
+    failure_description += "The variables have different types.\n  expected type is '" + expected.type() +
+                           "'\n    actual type is '" + actual.type() + "'\n";
+  }
+  if (expected.size() != actual.size())
+  {
+    variables_equal = false;
+    failure_description += "The variables have different sizes.\n  expected size is '" +
+                           std::to_string(expected.size()) + "'\n    actual size is '" + std::to_string(actual.size()) +
+                           "'\n";
+  }
+  if (expected.uuid() != actual.uuid())
+  {
+    variables_equal = false;
+    failure_description += "The variables have different UUIDs.\n  expected UUID is '" +
+                           fuse_core::uuid::to_string(expected.uuid()) + "'\n    actual UUID is '" +
+                           fuse_core::uuid::to_string(actual.uuid()) + "'\n";
+  }
+  for (size_t i = 0; i < expected.size(); ++i)
+  {
+    if (expected.data()[i] != actual.data()[i])
+    {
+      variables_equal = false;
+      failure_description += "The variables have different values.\n  expected data(" + std::to_string(i) + ") is '" +
+                             std::to_string(expected.data()[i]) + "'\n    actual data(" + std::to_string(i) + ") is '" +
+                             std::to_string(actual.data()[i]) + "'\n";
+    }
+  }
+  return variables_equal;
+}
+
+/**
+ * @brief Compare all the properties of two Constraint objects
+ * @return True if all the properties match, false otherwise
+ */
+bool compareConstraints(const fuse_core::Constraint& expected, const fuse_core::Constraint& actual)
+{
+  failure_description = "";
+  bool constraints_equal = true;
+  if (expected.type() != actual.type())
+  {
+    constraints_equal = false;
+    failure_description += "The constraints have different types.\n  expected type is '" + expected.type() +
+                           "'\n    actual type is '" + actual.type() + "'\n";
+  }
+  if (expected.uuid() != actual.uuid())
+  {
+    constraints_equal = false;
+    failure_description += "The constraints have different UUIDs.\n  expected UUID is '" +
+                           fuse_core::uuid::to_string(expected.uuid()) + "'\n    actual UUID is '" +
+                           fuse_core::uuid::to_string(actual.uuid()) + "'\n";
+  }
+  if (expected.variables().size() != actual.variables().size())
+  {
+    constraints_equal = false;
+    failure_description += "The constraints involve a different number of variables.\n  expected variable count is '" +
+                           std::to_string(expected.variables().size()) + "'\n    actual variable count is '" +
+                           std::to_string(actual.variables().size()) + "'\n";
+  }
+  for (size_t i = 0; i < expected.variables().size(); ++i)
+  {
+    if (expected.variables().at(i) != actual.variables().at(i))
+    {
+      constraints_equal = false;
+      std::string i_str = std::to_string(i);
+      failure_description += "The constraints involve different variable UUIDs.\n  expected variables(" + i_str +
+                             ") is '" + fuse_core::uuid::to_string(expected.variables()[i]) +
+                             "'\n    actual variables(" + i_str + ") is '" +
+                             fuse_core::uuid::to_string(actual.variables()[i]) + "'\n";
+    }
+  }
+  return constraints_equal;
+}
+
+namespace fuse_core
+{
+
+bool operator==(const fuse_core::Variable& rhs, const fuse_core::Variable& lhs)
+{
+  return compareVariables(rhs, lhs);
+}
+
+bool operator!=(const fuse_core::Variable& rhs, const fuse_core::Variable& lhs)
+{
+  return !(rhs == lhs);
+}
+
+bool operator==(const fuse_core::Constraint& rhs, const fuse_core::Constraint& lhs)
+{
+  return compareConstraints(rhs, lhs);
+}
+
+bool operator!=(const fuse_core::Constraint& rhs, const fuse_core::Constraint& lhs)
+{
+  return !(rhs == lhs);
+}
+
+}  // namespace fuse_core
+
+TEST(Unicycle2DIgnition, SetGraphService)
+{
+  // Set some configuration
+  ros::param::set("/graph_ignition_test/ignition_sensor/set_graph_service", "/set_graph");
+  ros::param::set("/graph_ignition_test/ignition_sensor/reset_service", "");
+
+  // Initialize the callback promise. Promises are single-use.
+  callback_promise = std::promise<fuse_core::Transaction::SharedPtr>();
+  auto callback_future = callback_promise.get_future();
+
+  // Create an ignition sensor and register the callback
+  fuse_models::GraphIgnition ignition_sensor;
+  ignition_sensor.initialize("ignition_sensor", &transactionCallback);
+  ignition_sensor.start();
+
+  // Create graph
+  fuse_graphs::HashGraph graph;
+
+  auto variable1 = ExampleVariable::make_shared();
+  variable1->data()[0] = 1.0;
+  graph.addVariable(variable1);
+
+  auto variable2 = ExampleVariable::make_shared();
+  variable2->data()[0] = 2.5;
+  graph.addVariable(variable2);
+
+  auto variable3 = ExampleVariable::make_shared();
+  variable3->data()[0] = -1.2;
+  graph.addVariable(variable3);
+
+  auto constraint1 = ExampleConstraint::make_shared(
+      "test",
+      std::initializer_list<fuse_core::UUID>{ variable1->uuid(), variable2->uuid() });  // NOLINT(whitespace/braces)
+  constraint1->data = 1.5;
+  graph.addConstraint(constraint1);
+
+  auto constraint2 = ExampleConstraint::make_shared(
+      "test",
+      std::initializer_list<fuse_core::UUID>{ variable2->uuid(), variable3->uuid() });  // NOLINT(whitespace/braces)
+  constraint2->data = -3.7;
+  graph.addConstraint(constraint2);
+
+  // Call the SetGraph service
+  fuse_models::SetGraph srv;
+  fuse_core::serializeGraph(graph, srv.request.graph);
+  const bool success = ros::service::call("/set_graph", srv);
+  ASSERT_TRUE(success);
+  EXPECT_TRUE(srv.response.success);
+
+  // The ignition sensor should publish a transaction in response to the service call. Wait for the callback to fire.
+  auto status = callback_future.wait_for(std::chrono::seconds(5));
+  ASSERT_TRUE(status == std::future_status::ready);
+
+  // Check the transaction is equivalent to the graph, i.e. it has the same constraints and transactions
+  const auto transaction = callback_future.get();
+
+  ASSERT_EQ(boost::size(graph.getConstraints()), boost::size(transaction->addedConstraints()));
+  ASSERT_EQ(boost::size(graph.getVariables()), boost::size(transaction->addedVariables()));
+
+  // We cannot compare the constraints or variables of the graph with the added constraints or variables of the
+  // transaction with:
+  //
+  //    graph.getConstraints() == transaction->addedConstraints()
+  //
+  // and
+  //
+  //    graph.getVariables() == transaction->addedVariables()
+  //
+  // because the graph could stored the constraints and variables in unordered containers. Indeed, the
+  // fuse_graphs::HashGraph uses unordered containers for both the constraints and variables.
+  //
+  // So even if the added constraints and variables are stored in std::vector containers in the transaction, we cannot
+  // compare them with the straightforward approach mentioned above. Instead, we need to check that all added
+  // constraints and varaibles are in the graph, and check they are the same.
+  for (const auto& added_constraint : transaction->addedConstraints())
+  {
+    try
+    {
+      const auto& constraint = graph.getConstraint(added_constraint.uuid());
+
+      EXPECT_EQ(constraint, added_constraint) << failure_description;
+    }
+    catch (const std::out_of_range& ex)
+    {
+      ADD_FAILURE() << ex.what();
+    }
+  }
+
+  for (const auto& added_variable : transaction->addedVariables())
+  {
+    try
+    {
+      const auto& variable = graph.getVariable(added_variable.uuid());
+
+      EXPECT_EQ(variable, added_variable) << failure_description;
+    }
+    catch (const std::out_of_range& ex)
+    {
+      ADD_FAILURE() << ex.what();
+    }
+  }
+
+  // Since the variables in the graph do not have a stamp, the transaction should have a single involved stamp, equal to
+  // the transaction stamp, that should also be equal to the requested graph message stamp
+  ASSERT_EQ(1u, boost::size(transaction->involvedStamps()));
+  EXPECT_EQ(transaction->stamp(), transaction->involvedStamps().front());
+  EXPECT_EQ(srv.request.graph.header.stamp, transaction->stamp());
+}
+
+TEST(Unicycle2DIgnition, SetGraphServiceWithStampedVariables)
+{
+  // Set some configuration
+  ros::param::set("/graph_ignition_test/ignition_sensor/set_graph_service", "/set_graph");
+  ros::param::set("/graph_ignition_test/ignition_sensor/reset_service", "");
+
+  // Initialize the callback promise. Promises are single-use.
+  callback_promise = std::promise<fuse_core::Transaction::SharedPtr>();
+  auto callback_future = callback_promise.get_future();
+
+  // Create an ignition sensor and register the callback
+  fuse_models::GraphIgnition ignition_sensor;
+  ignition_sensor.initialize("ignition_sensor", &transactionCallback);
+  ignition_sensor.start();
+
+  // Create graph
+  fuse_graphs::HashGraph graph;
+
+  auto variable1 = ExampleVariableStamped::make_shared(ros::Time(101.0));
+  variable1->data()[0] = 1.0;
+  graph.addVariable(variable1);
+
+  auto variable2 = ExampleVariableStamped::make_shared(ros::Time(102.0));
+  variable2->data()[0] = 2.5;
+  graph.addVariable(variable2);
+
+  auto variable3 = ExampleVariableStamped::make_shared(ros::Time(103.0));
+  variable3->data()[0] = -1.2;
+  graph.addVariable(variable3);
+
+  auto constraint1 = ExampleConstraint::make_shared(
+      "test",
+      std::initializer_list<fuse_core::UUID>{ variable1->uuid(), variable2->uuid() });  // NOLINT(whitespace/braces)
+  constraint1->data = 1.5;
+  graph.addConstraint(constraint1);
+
+  auto constraint2 = ExampleConstraint::make_shared(
+      "test",
+      std::initializer_list<fuse_core::UUID>{ variable2->uuid(), variable3->uuid() });  // NOLINT(whitespace/braces)
+  constraint2->data = -3.7;
+  graph.addConstraint(constraint2);
+
+  // Call the SetGraph service
+  fuse_models::SetGraph srv;
+  fuse_core::serializeGraph(graph, srv.request.graph);
+  const bool success = ros::service::call("/set_graph", srv);
+  ASSERT_TRUE(success);
+  EXPECT_TRUE(srv.response.success);
+
+  // The ignition sensor should publish a transaction in response to the service call. Wait for the callback to fire.
+  auto status = callback_future.wait_for(std::chrono::seconds(5));
+  ASSERT_TRUE(status == std::future_status::ready);
+
+  // Check the transaction is equivalent to the graph, i.e. it has the same constraints and transactions
+  const auto transaction = callback_future.get();
+
+  ASSERT_EQ(boost::size(graph.getConstraints()), boost::size(transaction->addedConstraints()));
+  ASSERT_EQ(boost::size(graph.getVariables()), boost::size(transaction->addedVariables()));
+
+  // We cannot compare the constraints or variables of the graph with the added constraints or variables of the
+  // transaction with:
+  //
+  //    graph.getConstraints() == transaction->addedConstraints()
+  //
+  // and
+  //
+  //    graph.getVariables() == transaction->addedVariables()
+  //
+  // because the graph could stored the constraints and variables in unordered containers. Indeed, the
+  // fuse_graphs::HashGraph uses unordered containers for both the constraints and variables.
+  //
+  // So even if the added constraints and variables are stored in std::vector containers in the transaction, we cannot
+  // compare them with the straightforward approach mentioned above. Instead, we need to check that all added
+  // constraints and varaibles are in the graph, and check they are the same.
+  for (const auto& added_constraint : transaction->addedConstraints())
+  {
+    try
+    {
+      const auto& constraint = graph.getConstraint(added_constraint.uuid());
+
+      EXPECT_EQ(constraint, added_constraint) << failure_description;
+    }
+    catch (const std::out_of_range& ex)
+    {
+      ADD_FAILURE() << ex.what();
+    }
+  }
+
+  for (const auto& added_variable : transaction->addedVariables())
+  {
+    try
+    {
+      const auto& variable = graph.getVariable(added_variable.uuid());
+
+      EXPECT_EQ(variable, added_variable) << failure_description;
+    }
+    catch (const std::out_of_range& ex)
+    {
+      ADD_FAILURE() << ex.what();
+    }
+  }
+
+  // Since the variables in the graph have a stamp, the transaction should have one involved stamp per variable, and the
+  // transaction stamp should be equal to the requested graph message stamp
+  ASSERT_EQ(boost::size(graph.getVariables()), boost::size(transaction->involvedStamps()));
+  EXPECT_EQ(srv.request.graph.header.stamp, transaction->stamp());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "graph_ignition_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}


### PR DESCRIPTION
* Add `fuse_models::GraphIgnition` sensor model

This complements https://github.com/locusrobotics/fuse/pull/195, so we can configure a `fixed_lag_smoother` that ignites when it receives a recorded graph and then apply recorded transactions into it.

This should help motivate #183 a bit more, and also help to test things out, if we agree on using these two sensor models to play back recorded graphs and transactions. This is certainly open to discussion, mostly because #183 is required, and it also looks that even with #183 there are still some sharp edges, so things don't always work because we don't process the correct transaction after the graph. Remember the intention is to throttle the graphs while recording, because recording all graphs takes a lot of disk and bandwidth.