### PR TITLE
Fix optimizer test config

### DIFF
--- a/fuse_optimizers/test/config/list/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/list/common_robot_config.yaml
@@ -28,9 +28,13 @@ unicycle_2d_ignition:
 wheel_odometry:
   topic: odom
   differential: true
+  position_dimensions: ['x', 'y']
+  orientation_dimensions: ['yaw']
   twist_target_frame: base_link
 
 laser_localization:
   topic: pose
+  position_dimensions: ['x', 'y']
+  orientation_dimensions: ['yaw']
   pose_target_frame: map
   twist_target_frame: base_link

--- a/fuse_optimizers/test/config/list/robot_with_imu_config.yaml
+++ b/fuse_optimizers/test/config/list/robot_with_imu_config.yaml
@@ -23,3 +23,5 @@ sensor_models:
 
 imu:
   topic: imu
+  angular_velocity_dimensions: ['yaw']
+  twist_target_frame: base_link

--- a/fuse_optimizers/test/config/struct/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/struct/common_robot_config.yaml
@@ -28,9 +28,13 @@ unicycle_2d_ignition:
 wheel_odometry:
   topic: odom
   differential: true
+  position_dimensions: ['x', 'y']
+  orientation_dimensions: ['yaw']
   twist_target_frame: base_link
 
 laser_localization:
   topic: pose
+  position_dimensions: ['x', 'y']
+  orientation_dimensions: ['yaw']
   pose_target_frame: map
   twist_target_frame: base_link

--- a/fuse_optimizers/test/config/struct/robot_with_imu_config.yaml
+++ b/fuse_optimizers/test/config/struct/robot_with_imu_config.yaml
@@ -10,3 +10,5 @@ sensor_models:
 
 imu:
   topic: imu
+  angular_velocity_dimensions: ['yaw']
+  twist_target_frame: base_link


### PR DESCRIPTION
* Add dimensions to the sensor models, so we do not get these warnings:
``` bash
[ WARN] [/Optimizer] [1604556511.895230377]: No dimensions were specified. Data from topic /imu will be ignored.
[ WARN] [/Optimizer] [1604556511.899319309]: No dimensions were specified. Data from topic /pose will be ignored.
[ WARN] [/Optimizer] [1604556511.905227451]: No dimensions were specified. Data from topic /odom will be ignored.
```
* Add `twist_target_frame` to `imu` sensor model, so we do not get this
  error:
``` bash
[FATAL] [/Optimizer] [1604557006.977288017]: Could not find required parameter twist_target_frame in namespace /Optimizer/imu
```