### PR TITLE
Use local latest_stamp in notifyCallback

### DIFF
--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -195,7 +195,7 @@ void Odometry2DPublisher::notifyCallback(
     }
     catch (const std::exception& e)
     {
-      ROS_WARN_STREAM("An error occurred computing the covariance information for " << latest_stamp_ << ". "
+      ROS_WARN_STREAM("An error occurred computing the covariance information for " << latest_stamp << ". "
                       "The covariance will be set to zero.\n" << e.what());
       std::fill(odom_output.pose.covariance.begin(), odom_output.pose.covariance.end(), 0.0);
       std::fill(odom_output.twist.covariance.begin(), odom_output.twist.covariance.end(), 0.0);


### PR DESCRIPTION
Sorry, but I don't know how this was missed in https://github.com/locusrobotics/fuse/pull/201

I indeed detected it with a `git diff` with my local branches.