### PR TITLE
Support throttling serialized graph publisher

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -427,6 +427,22 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Throttle callback test
+  add_rostest_gtest(
+    test_throttled_callback
+    test/throttled_callback.test
+    test/test_throttled_callback.cpp
+  )
+  target_link_libraries(test_throttled_callback
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_throttled_callback
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Util tests
   catkin_add_gtest(test_util
     test/test_util.cpp

--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -93,6 +93,23 @@ void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& par
 }
 
 /**
+ * @brief Helper function that loads positive duration values from the parameter server
+ *
+ * @param[in] node_handle - The node handle used to load the parameter
+ * @param[in] parameter_name - The parameter name to load
+ * @param[in, out] default_value - A default value to use if the provided parameter name does not exist. As output it
+ *                                 has the loaded (or default) value
+ * @param[in] strict - Whether to check the loaded value is strictly positive or not, i.e. whether 0 is accepted or not
+ */
+inline void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name,
+                             ros::Duration& default_value, const bool strict = true)
+{
+  double default_value_sec = default_value.toSec();
+  getPositiveParam(node_handle, parameter_name, default_value_sec, strict);
+  default_value.fromSec(default_value_sec);
+}
+
+/**
  * @brief Helper function that loads a covariance matrix diagonal vector from the parameter server and checks the size
  * and the values are invalid, i.e. they are positive.
  *

--- a/fuse_core/include/fuse_core/throttled_callback.h
+++ b/fuse_core/include/fuse_core/throttled_callback.h
@@ -31,18 +31,15 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
-#define FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
+#ifndef FUSE_CORE_THROTTLED_CALLBACK_H
+#define FUSE_CORE_THROTTLED_CALLBACK_H
 
 #include <ros/subscriber.h>
 
 #include <functional>
 
 
-namespace fuse_models
-{
-
-namespace common
+namespace fuse_core
 {
 
 /**
@@ -197,4 +194,4 @@ private:
 
 }  // namespace fuse_models
 
-#endif  // FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
+#endif  // FUSE_CORE_THROTTLED_CALLBACK_H

--- a/fuse_core/include/fuse_core/throttled_callback.h
+++ b/fuse_core/include/fuse_core/throttled_callback.h
@@ -37,31 +37,28 @@
 #include <ros/subscriber.h>
 
 #include <functional>
+#include <utility>
 
 
 namespace fuse_core
 {
 
 /**
- * @brief A throttled callback that encapsulates the logic to throttle a message callback so it is only called after a
- * given period in seconds (or more). The dropped messages can optionally be received in a dropped callback, that could
- * be used to count the number of messages dropped.
+ * @brief A throttled callback that encapsulates the logic to throttle a callback so it is only called after a given
+ * period in seconds (or more). The dropped calls can optionally be received in a dropped callback, that could be used
+ * to count the number of calls dropped.
  *
- * @tparam M The message the callback receives
+ * @tparam Callback The std::function callback
  */
-template <class M>
+template <class Callback>
 class ThrottledCallback
 {
 public:
-  using MessageConstPtr = typename M::ConstPtr;
-  using Callback = std::function<void(const MessageConstPtr&)>;
-
   /**
    * @brief Constructor
    *
-   * @param[in] keep_callback   The callback to call when the message is kept, i.e. not dropped. Defaults to nullptr
-   * @param[in] drop_callback   The callback to call when the message is dropped because of the throttling. Defaults to
-   *                            nullptr
+   * @param[in] keep_callback   The callback to call when kept, i.e. not dropped. Defaults to nullptr
+   * @param[in] drop_callback   The callback to call when dropped because of the throttling. Defaults to nullptr
    * @param[in] throttle_period The throttling period duration in seconds. Defaults to 0.0, i.e. no throttling
    * @param[in] use_wall_time   Whether to use ros::WallTime or not. Defaults to false
    */
@@ -146,12 +143,13 @@ public:
   }
 
   /**
-   * @brief Message callback that throttles the calls to the keep callback provided. When the message is dropped because
+   * @brief Callback that throttles the calls to the keep callback provided. When dropped because
    * of throttling, the drop callback is called instead.
    *
-   * @param[in] message The input message
+   * @param[in] args The input arguments
    */
-  void callback(const MessageConstPtr& message)
+  template <class... Args>
+  void callback(Args&&... args)
   {
     // Keep the callback if:
     //
@@ -163,7 +161,7 @@ public:
     {
       if (keep_callback_)
       {
-        keep_callback_(message);
+        keep_callback_(std::forward<Args>(args)...);
       }
 
       if (last_called_time_.isZero())
@@ -177,21 +175,38 @@ public:
     }
     else if (drop_callback_)
     {
-      drop_callback_(message);
+      drop_callback_(std::forward<Args>(args)...);
     }
   }
 
+  /**
+   * @brief Operator() that simply calls the callback() method forwarding the input arguments
+   *
+   * @param[in] args The input arguments
+   */
+  template <class... Args>
+  void operator()(Args&&... args)
+  {
+    callback(std::forward<Args>(args)...);
+  }
+
 private:
-  Callback keep_callback_;         //!< The callback to call when the message is kept, i.e. not dropped
-  Callback drop_callback_;         //!< The callback to call when the message is dropped because of throttling
+  Callback keep_callback_;         //!< The callback to call when kept, i.e. not dropped
+  Callback drop_callback_;         //!< The callback to call when dropped because of throttling
   ros::Duration throttle_period_;  //!< The throttling period duration in seconds
   bool use_wall_time_;             //<! The flag to indicate whether to use ros::WallTime or not
 
   ros::Time last_called_time_;  //!< The last time the keep callback was called
 };
 
-}  // namespace common
+/**
+ * @brief Throttled callback for ROS messages
+ *
+ * @tparam M The ROS message type, which should have the M::ConstPtr nested type
+ */
+template <class M>
+using ThrottledMessageCallback = ThrottledCallback<std::function<void(const typename M::ConstPtr&)>>;
 
-}  // namespace fuse_models
+}  // namespace fuse_core
 
 #endif  // FUSE_CORE_THROTTLED_CALLBACK_H

--- a/fuse_core/test/test_throttled_callback.cpp
+++ b/fuse_core/test/test_throttled_callback.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_models/common/throttled_callback.h>
+#include <fuse_core/throttled_callback.h>
 #include <geometry_msgs/Point.h>
 #include <ros/ros.h>
 
@@ -94,8 +94,8 @@ private:
 };
 
 /**
- * @brief A dummy point sensor model that uses a fuse_models::common::ThrottledCallback<geometry_msgs::Point> with a
- * keep and drop callback.
+ * @brief A dummy point sensor model that uses a fuse_core::ThrottledMessageCallback<geometry_msgs::Point> with a keep
+ * and drop callback.
  *
  * The callbacks simply count the number of times they are called, for testing purposes. The keep callback also caches
  * the last message received, also for testing purposes.
@@ -170,7 +170,7 @@ private:
   ros::NodeHandle node_handle_;  //!< The node handle
   ros::Subscriber subscriber_;   //!< The subscriber
 
-  using PointThrottledCallback = fuse_models::common::ThrottledCallback<geometry_msgs::Point>;
+  using PointThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::Point>;
   PointThrottledCallback throttled_callback_;  //!< The throttled callback
 
   size_t kept_messages_{ 0 };                         //!< Messages kept

--- a/fuse_core/test/test_throttled_callback.cpp
+++ b/fuse_core/test/test_throttled_callback.cpp
@@ -112,7 +112,8 @@ public:
     : throttled_callback_(std::bind(&PointSensorModel::keepCallback, this, std::placeholders::_1),
                           std::bind(&PointSensorModel::dropCallback, this, std::placeholders::_1), throttle_period)
   {
-    subscriber_ = node_handle_.subscribe("point", 10, &PointThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::Point>(
+        "point", 10, &PointThrottledCallback::callback, &throttled_callback_);
   }
 
   /**
@@ -170,7 +171,7 @@ private:
   ros::NodeHandle node_handle_;  //!< The node handle
   ros::Subscriber subscriber_;   //!< The subscriber
 
-  using PointThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::Point>;
+  using PointThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::Point>;
   PointThrottledCallback throttled_callback_;  //!< The throttled callback
 
   size_t kept_messages_{ 0 };                         //!< Messages kept

--- a/fuse_core/test/throttled_callback.test
+++ b/fuse_core/test/throttled_callback.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>	
+  <test test-name="throttled_callback_test" pkg="fuse_core" type="test_throttled_callback" />
+</launch>

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -244,7 +244,7 @@ if(CATKIN_ENABLE_TESTING)
   )
 
   # Other tests
-  catkin_add_gtest(
+  catkin_add_gmock(
     test_sensor_proc
     test/test_sensor_proc.cpp
   )

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -258,21 +258,6 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
-  add_rostest_gtest(
-    test_throttled_callback
-    test/throttled_callback.test
-    test/test_throttled_callback.cpp
-  )
-  target_link_libraries(test_throttled_callback
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-  )
-  set_target_properties(test_throttled_callback
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
-
   # Benchmarks
   find_package(benchmark QUIET)
 

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_ACCELERATION_2D_H
 
 #include <fuse_models/parameters/acceleration_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/AccelWithCovarianceStamped.h>
@@ -117,7 +117,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using AccelerationThrottledCallback = common::ThrottledCallback<geometry_msgs::AccelWithCovarianceStamped>;
+  using AccelerationThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::AccelWithCovarianceStamped>;
   AccelerationThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -117,7 +117,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using AccelerationThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::AccelWithCovarianceStamped>;
+  using AccelerationThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::AccelWithCovarianceStamped>;
   AccelerationThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -137,7 +137,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using ImuThrottledCallback = fuse_core::ThrottledCallback<sensor_msgs::Imu>;
+  using ImuThrottledCallback = fuse_core::ThrottledMessageCallback<sensor_msgs::Imu>;
   ImuThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -35,7 +35,7 @@
 #define FUSE_MODELS_IMU_2D_H
 
 #include <fuse_models/parameters/imu_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
+#include <fuse_core/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -137,7 +137,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using ImuThrottledCallback = common::ThrottledCallback<sensor_msgs::Imu>;
+  using ImuThrottledCallback = fuse_core::ThrottledCallback<sensor_msgs::Imu>;
   ImuThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -35,7 +35,7 @@
 #define FUSE_MODELS_ODOMETRY_2D_H
 
 #include <fuse_models/parameters/odometry_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
+#include <fuse_core/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -133,7 +133,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using OdometryThrottledCallback = common::ThrottledCallback<nav_msgs::Odometry>;
+  using OdometryThrottledCallback = fuse_core::ThrottledCallback<nav_msgs::Odometry>;
   OdometryThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -133,7 +133,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using OdometryThrottledCallback = fuse_core::ThrottledCallback<nav_msgs::Odometry>;
+  using OdometryThrottledCallback = fuse_core::ThrottledMessageCallback<nav_msgs::Odometry>;
   OdometryThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -122,7 +122,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using PoseThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::PoseWithCovarianceStamped>;
+  using PoseThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::PoseWithCovarianceStamped>;
   PoseThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_POSE_2D_H
 
 #include <fuse_models/parameters/pose_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -122,7 +122,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using PoseThrottledCallback = common::ThrottledCallback<geometry_msgs::PoseWithCovarianceStamped>;
+  using PoseThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::PoseWithCovarianceStamped>;
   PoseThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -111,7 +111,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using TwistThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::TwistWithCovarianceStamped>;
+  using TwistThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::TwistWithCovarianceStamped>;
   TwistThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -35,7 +35,7 @@
 #define FUSE_MODELS_TWIST_2D_H
 
 #include <fuse_models/parameters/twist_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
+#include <fuse_core/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>
@@ -111,7 +111,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using TwistThrottledCallback = common::ThrottledCallback<geometry_msgs::TwistWithCovarianceStamped>;
+  using TwistThrottledCallback = fuse_core::ThrottledCallback<geometry_msgs::TwistWithCovarianceStamped>;
   TwistThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -77,8 +77,8 @@ void Acceleration2D::onStart()
 {
   if (!params_.indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &AccelerationThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::AccelWithCovarianceStamped>(ros::names::resolve(params_.topic),
+        params_.queue_size, &AccelerationThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -88,8 +88,8 @@ void Imu2D::onStart()
       !params_.angular_velocity_indices.empty())
   {
     previous_pose_.reset();
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &ImuThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<sensor_msgs::Imu>(ros::names::resolve(params_.topic), params_.queue_size,
+        &ImuThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -89,8 +89,8 @@ void Odometry2D::onStart()
       !params_.angular_velocity_indices.empty())
   {
     previous_pose_.reset();
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &OdometryThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size,
+        &OdometryThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -79,8 +79,8 @@ void Pose2D::onStart()
   if (!params_.position_indices.empty() ||
       !params_.orientation_indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &PoseThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &PoseThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -79,8 +79,8 @@ void Twist2D::onStart()
   if (!params_.linear_indices.empty() ||
       !params_.angular_indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &TwistThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(ros::names::resolve(params_.topic),
+        params_.queue_size, &TwistThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/test/throttled_callback.test
+++ b/fuse_models/test/throttled_callback.test
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<launch>	
-  <test test-name="throttled_callback_test" pkg="fuse_models" type="test_throttled_callback" />
-</launch>

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -93,14 +93,10 @@ public:
     }
     else
     {
-      double optimization_period_sec{ optimization_period.toSec() };
-      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period_sec);
-      optimization_period.fromSec(optimization_period_sec);
+      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period);
     }
 
-    double transaction_timeout_sec{ transaction_timeout.toSec() };
-    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout_sec);
-    transaction_timeout.fromSec(transaction_timeout_sec);
+    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);
   }

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -95,9 +95,7 @@ public:
   void loadFromROS(const ros::NodeHandle& nh)
   {
     // Read settings from the parameter server
-    double lag_duration_sec{ lag_duration.toSec() };
-    fuse_core::getPositiveParam(nh, "lag_duration", lag_duration_sec);
-    lag_duration.fromSec(lag_duration_sec);
+    fuse_core::getPositiveParam(nh, "lag_duration", lag_duration);
 
     if (nh.hasParam("optimization_frequency"))
     {
@@ -107,16 +105,12 @@ public:
     }
     else
     {
-      double optimization_period_sec{ optimization_period.toSec() };
-      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period_sec);
-      optimization_period.fromSec(optimization_period_sec);
+      fuse_core::getPositiveParam(nh, "optimization_period", optimization_period);
     }
 
     nh.getParam("reset_service", reset_service);
 
-    double transaction_timeout_sec{ transaction_timeout.toSec() };
-    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout_sec);
-    transaction_timeout.fromSec(transaction_timeout_sec);
+    fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);
   }

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -37,6 +37,7 @@
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/macros.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/transaction.h>
 #include <ros/ros.h>
 
@@ -81,9 +82,21 @@ public:
     fuse_core::Graph::ConstSharedPtr graph) override;
 
 protected:
-  std::string frame_id_;  //!< The name of the frame for this path
+  /**
+   * @brief Publish the serialized graph
+   *
+   * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed
+   * @param[in] stamp A ros::Time stamp used for the serialized graph message published
+   */
+  void graphPublisherCallback(fuse_core::Graph::ConstSharedPtr graph, const ros::Time& stamp) const;
+
+  std::string frame_id_;  //!< The name of the frame for the serialized graph and transaction messages published
   ros::Publisher graph_publisher_;
   ros::Publisher transaction_publisher_;
+
+  using GraphPublisherCallback = std::function<void(fuse_core::Graph::ConstSharedPtr, const ros::Time&)>;
+  using GraphPublisherThrottledCallback = fuse_core::ThrottledCallback<GraphPublisherCallback>;
+  GraphPublisherThrottledCallback graph_publisher_throttled_callback_;  //!< The graph publisher throttled callback
 };
 
 }  // namespace fuse_publishers

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -67,12 +67,10 @@ void SerializedPublisher::onInit()
   bool latch = false;
   private_node_handle_.getParam("latch", latch);
 
-  ros::Duration graph_throttle_period { 0.0 };
-  double graph_throttle_period_double = graph_throttle_period.toSec();
-  fuse_core::getPositiveParam(private_node_handle_, "graph_throttle_period", graph_throttle_period_double, false);
-  graph_throttle_period.fromSec(graph_throttle_period_double);
+  ros::Duration graph_throttle_period{ 0.0 };
+  fuse_core::getPositiveParam(private_node_handle_, "graph_throttle_period", graph_throttle_period, false);
 
-  bool graph_throttle_use_wall_time { false };
+  bool graph_throttle_use_wall_time{ false };
   private_node_handle_.getParam("graph_throttle_use_wall_time", graph_throttle_use_wall_time);
 
   graph_publisher_throttled_callback_.setThrottlePeriod(graph_throttle_period);


### PR DESCRIPTION
### Motivation

I've been throttling the serialized graph message published by the `fuse_publishers::SerializedPublisher` using the `throttle` node from `topic_tools`, so I only record a few graphs for debugging purposes. Recording all would take too much disk and bandwidth.

So far so good, but the serialized publisher is still serializing and publishing all the graphs it gets notified from the optimizer. It turns out that serializing the graph is quite fast, but it still takes a noticeable amount of time. If the optimization frequency is high, we could get too many graphs and the impact becomes more significant.

Since I'm throttling the serialized graph messages after anyway, it makes more sense to throttle the publisher directly in the serialized publisher, so we can save some cycles.

### Changelog

* Move the `fuse_models::ThrottledCallback` to `fuse_core`
* Support generic callbacks in `ThrottledCallback`. An alias template called `ThrottledMessageCallback` is provided for ROS messages. Unfortunately, the automatic type deduction in `ros::NodeHandle::subcribe()` no longer works due to the generic `ThrottledCallback::callback()` we have now. For this reason we now have to do `subscribe<Message>()` instead of just `subscribe()`. If you know how to make this cleaner, I'd like to know. :smiley: 
* Add support to throttle graph publishing. It doesn't throttle any graph by default. BTW, I'm happy to create a `parameters` folder and a class to encapsulate the `fuse_publishers::SerializedPublisher` configuration, as it's done in `fuse_models`.

### Results

If the optimization frequency or the rate of the sensor models inputs are low, the impact of this is very low. I've evaluated this with the following relevant configuration:
* 50Hz optimization frequency
* A bunch of sensor models inputs that when all are processed and the graph isn't throttled, the graph is published at approx. 30Hz

The plots below show the CPU% of the fuse optimizer node in blue, and the average in red:
* No graph publisher throttling:
![C4-2020-11-13_18-58-25_01_plot](https://user-images.githubusercontent.com/382167/99112042-55afe600-25ed-11eb-85b8-9320f5d37729.png)
* Graph publisher throttled, with a throttle period of 30s, which is a reasonable value for use case described in the motivation section (I expect similar results with smaller throttling periods though):
![C5-2020-11-13_19-01-16_01_plot](https://user-images.githubusercontent.com/382167/99112047-56487c80-25ed-11eb-9100-439d0299e4d0.png)

We save approx. 10% of CPU.