### PR TITLE
Add linear acceleration to synchronizer

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -61,7 +61,7 @@ namespace fuse_models
 /**
  * @class Odometry2DPublisher plugin that publishes a nav_msgs::Odometry message and broadcasts a tf transform for optimized 2D
  * state data (combination of Position2DStamped, Orientation2DStamped, VelocityLinear2DStamped, and
- * VelocityAngular2DStamped).
+ * VelocityAngular2DStamped, AccelerationLinear2DStamped).
  *
  * Parameters:
  *  - device_id (uuid string, default: 00000000-0000-0000-0000-000000000000) The device/robot ID to publish
@@ -175,7 +175,8 @@ protected:
   using Synchronizer = fuse_publishers::StampedVariableSynchronizer<fuse_variables::Orientation2DStamped,
                                                                     fuse_variables::Position2DStamped,
                                                                     fuse_variables::VelocityLinear2DStamped,
-                                                                    fuse_variables::VelocityAngular2DStamped>;
+                                                                    fuse_variables::VelocityAngular2DStamped,
+                                                                    fuse_variables::AccelerationLinear2DStamped>;
 
   fuse_core::UUID device_id_;  //!< The UUID of this device
 


### PR DESCRIPTION
This is a potential bug since the acceleration publisher was added in https://github.com/locusrobotics/fuse/pull/129 and since then `getState` also retrieves the linear acceleration:
https://github.com/clearpathrobotics/fuse/blob/def59088a0ee3ff148a4e5a2d3abb8f853bbbb2d/fuse_models/src/odometry_2d_publisher.cpp#L234-L236

However, I forgot to add the linear acceleration to the synchronizer that's used to retrieve the latest common timestamp in https://github.com/clearpathrobotics/fuse/blob/def59088a0ee3ff148a4e5a2d3abb8f853bbbb2d/fuse_models/src/odometry_2d_publisher.cpp#L98

This fixes this potential issue.