### PR TITLE
Change sensor proc from gtest to gmock target

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -244,7 +244,7 @@ if(CATKIN_ENABLE_TESTING)
   )
 
   # Other tests
-  catkin_add_gtest(
+  catkin_add_gmock(
     test_sensor_proc
     test/test_sensor_proc.cpp
   )


### PR DESCRIPTION
This fix is based on:

https://answers.ros.org/question/199680/catkin-doesnt-play-nice-with-google-mock/?answer=318629#post-id-318629

By using `catkin_add_gmock` instead of `catkin_add_gtest` the sensor proc
test can use both `gtest` and `gmock`.

Otherwise, we get a compilation error because the `gmock/gmock.h` header
cannot be found:

``` bash
/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/test/test_sensor_proc.cpp:8:10: fatal error: gmock/gmock.h: No such file or directory
    8 | #include <gmock/gmock.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```

More information about `catkin_add_gmock` in:

http://docs.ros.org/en/melodic/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-add-gmock