### PR TITLE
Add ability to throttle covariance computation

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -186,6 +186,8 @@ protected:
 
   ros::Time latest_covariance_stamp_;
 
+  bool latest_covariance_valid_{ false };  //!< Whether the latest covariance computed is valid or not
+
   nav_msgs::Odometry odom_output_;
 
   geometry_msgs::AccelWithCovarianceStamped acceleration_output_;

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -81,6 +81,8 @@ public:
     nh.param("scale_process_noise", scale_process_noise, scale_process_noise);
     nh.param("velocity_norm_min", velocity_norm_min, velocity_norm_min);
 
+    fuse_core::getPositiveParam(nh, "covariance_throttle_period", covariance_throttle_period, false);
+
     double tf_cache_time_double = tf_cache_time.toSec();
     nh.getParam("tf_cache_time", tf_cache_time_double);
     tf_cache_time.fromSec(tf_cache_time_double);
@@ -128,6 +130,8 @@ public:
   fuse_core::Matrix8d process_noise_covariance;   //!< Process noise covariance matrix
   bool scale_process_noise{ false };
   double velocity_norm_min{ 1e-3 };
+  ros::Duration covariance_throttle_period { 0.0 };  //!< The throttle period duration in seconds to compute the
+                                                     //!< covariance
   ros::Duration tf_cache_time { 10.0 };
   ros::Duration tf_timeout { 0.1 };
   int queue_size { 1 };

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -150,56 +150,76 @@ void Odometry2DPublisher::notifyCallback(
 
   // Don't waste CPU computing the covariance if nobody is listening
   ros::Time latest_covariance_stamp = latest_covariance_stamp_;
+  bool latest_covariance_valid = latest_covariance_valid_;
   if (odom_pub_.getNumSubscribers() > 0 || acceleration_pub_.getNumSubscribers() > 0)
   {
-    try
+    // Throttle covariance computation
+    if (params_.covariance_throttle_period.isZero() ||
+       latest_stamp - latest_covariance_stamp > params_.covariance_throttle_period)
     {
-      std::vector<std::pair<fuse_core::UUID, fuse_core::UUID>> covariance_requests;
-      covariance_requests.emplace_back(position_uuid, position_uuid);
-      covariance_requests.emplace_back(position_uuid, orientation_uuid);
-      covariance_requests.emplace_back(orientation_uuid, orientation_uuid);
-      covariance_requests.emplace_back(velocity_linear_uuid, velocity_linear_uuid);
-      covariance_requests.emplace_back(velocity_linear_uuid, velocity_angular_uuid);
-      covariance_requests.emplace_back(velocity_angular_uuid, velocity_angular_uuid);
-      covariance_requests.emplace_back(acceleration_linear_uuid, acceleration_linear_uuid);
-
-      std::vector<std::vector<double>> covariance_matrices;
-      graph->getCovariance(covariance_requests, covariance_matrices, params_.covariance_options);
-
-      odom_output.pose.covariance[0] = covariance_matrices[0][0];
-      odom_output.pose.covariance[1] = covariance_matrices[0][1];
-      odom_output.pose.covariance[5] = covariance_matrices[1][0];
-      odom_output.pose.covariance[6] = covariance_matrices[0][2];
-      odom_output.pose.covariance[7] = covariance_matrices[0][3];
-      odom_output.pose.covariance[11] = covariance_matrices[1][1];
-      odom_output.pose.covariance[30] = covariance_matrices[1][0];
-      odom_output.pose.covariance[31] = covariance_matrices[1][1];
-      odom_output.pose.covariance[35] = covariance_matrices[2][0];
-
-      odom_output.twist.covariance[0] = covariance_matrices[3][0];
-      odom_output.twist.covariance[1] = covariance_matrices[3][1];
-      odom_output.twist.covariance[5] = covariance_matrices[4][0];
-      odom_output.twist.covariance[6] = covariance_matrices[3][2];
-      odom_output.twist.covariance[7] = covariance_matrices[3][3];
-      odom_output.twist.covariance[11] = covariance_matrices[4][1];
-      odom_output.twist.covariance[30] = covariance_matrices[4][0];
-      odom_output.twist.covariance[31] = covariance_matrices[4][1];
-      odom_output.twist.covariance[35] = covariance_matrices[5][0];
-
-      acceleration_output.accel.covariance[0] = covariance_matrices[6][0];
-      acceleration_output.accel.covariance[1] = covariance_matrices[6][1];
-      acceleration_output.accel.covariance[6] = covariance_matrices[6][2];
-      acceleration_output.accel.covariance[7] = covariance_matrices[6][3];
-
       latest_covariance_stamp = latest_stamp;
+
+      try
+      {
+        std::vector<std::pair<fuse_core::UUID, fuse_core::UUID>> covariance_requests;
+        covariance_requests.emplace_back(position_uuid, position_uuid);
+        covariance_requests.emplace_back(position_uuid, orientation_uuid);
+        covariance_requests.emplace_back(orientation_uuid, orientation_uuid);
+        covariance_requests.emplace_back(velocity_linear_uuid, velocity_linear_uuid);
+        covariance_requests.emplace_back(velocity_linear_uuid, velocity_angular_uuid);
+        covariance_requests.emplace_back(velocity_angular_uuid, velocity_angular_uuid);
+        covariance_requests.emplace_back(acceleration_linear_uuid, acceleration_linear_uuid);
+
+        std::vector<std::vector<double>> covariance_matrices;
+        graph->getCovariance(covariance_requests, covariance_matrices, params_.covariance_options);
+
+        odom_output.pose.covariance[0] = covariance_matrices[0][0];
+        odom_output.pose.covariance[1] = covariance_matrices[0][1];
+        odom_output.pose.covariance[5] = covariance_matrices[1][0];
+        odom_output.pose.covariance[6] = covariance_matrices[0][2];
+        odom_output.pose.covariance[7] = covariance_matrices[0][3];
+        odom_output.pose.covariance[11] = covariance_matrices[1][1];
+        odom_output.pose.covariance[30] = covariance_matrices[1][0];
+        odom_output.pose.covariance[31] = covariance_matrices[1][1];
+        odom_output.pose.covariance[35] = covariance_matrices[2][0];
+
+        odom_output.twist.covariance[0] = covariance_matrices[3][0];
+        odom_output.twist.covariance[1] = covariance_matrices[3][1];
+        odom_output.twist.covariance[5] = covariance_matrices[4][0];
+        odom_output.twist.covariance[6] = covariance_matrices[3][2];
+        odom_output.twist.covariance[7] = covariance_matrices[3][3];
+        odom_output.twist.covariance[11] = covariance_matrices[4][1];
+        odom_output.twist.covariance[30] = covariance_matrices[4][0];
+        odom_output.twist.covariance[31] = covariance_matrices[4][1];
+        odom_output.twist.covariance[35] = covariance_matrices[5][0];
+
+        acceleration_output.accel.covariance[0] = covariance_matrices[6][0];
+        acceleration_output.accel.covariance[1] = covariance_matrices[6][1];
+        acceleration_output.accel.covariance[6] = covariance_matrices[6][2];
+        acceleration_output.accel.covariance[7] = covariance_matrices[6][3];
+
+        latest_covariance_valid = true;
+      }
+      catch (const std::exception& e)
+      {
+        ROS_WARN_STREAM("An error occurred computing the covariance information for " << latest_stamp << ". "
+                        "The covariance will be set to zero.\n" << e.what());
+        std::fill(odom_output.pose.covariance.begin(), odom_output.pose.covariance.end(), 0.0);
+        std::fill(odom_output.twist.covariance.begin(), odom_output.twist.covariance.end(), 0.0);
+        std::fill(acceleration_output.accel.covariance.begin(), acceleration_output.accel.covariance.end(), 0.0);
+
+        latest_covariance_valid = false;
+      }
     }
-    catch (const std::exception& e)
+    else
     {
-      ROS_WARN_STREAM("An error occurred computing the covariance information for " << latest_stamp << ". "
-                      "The covariance will be set to zero.\n" << e.what());
-      std::fill(odom_output.pose.covariance.begin(), odom_output.pose.covariance.end(), 0.0);
-      std::fill(odom_output.twist.covariance.begin(), odom_output.twist.covariance.end(), 0.0);
-      std::fill(acceleration_output.accel.covariance.begin(), acceleration_output.accel.covariance.end(), 0.0);
+      // This covariance computation cycle has been skipped, so simply take the last covariance computed
+      //
+      // We do not propagate the latest covariance forward because it would grow unbounded being very different from
+      // the actual covariance we would have computed if not throttling.
+      odom_output.pose.covariance = odom_output_.pose.covariance;
+      odom_output.twist.covariance = odom_output_.twist.covariance;
+      acceleration_output.accel.covariance = acceleration_output_.accel.covariance;
     }
   }
 
@@ -208,6 +228,7 @@ void Odometry2DPublisher::notifyCallback(
 
     latest_stamp_ = latest_stamp;
     latest_covariance_stamp_ = latest_covariance_stamp;
+    latest_covariance_valid_ = latest_covariance_valid;
     odom_output_ = odom_output;
     acceleration_output_ = acceleration_output;
   }
@@ -217,6 +238,7 @@ void Odometry2DPublisher::onStart()
 {
   synchronizer_ = Synchronizer(device_id_);
   latest_stamp_ = latest_covariance_stamp_ = Synchronizer::TIME_ZERO;
+  latest_covariance_valid_ = false;
   odom_output_ = nav_msgs::Odometry();
   acceleration_output_ = geometry_msgs::AccelWithCovarianceStamped();
   publish_timer_.start();
@@ -298,6 +320,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 {
   ros::Time latest_stamp;
   ros::Time latest_covariance_stamp;
+  bool latest_covariance_valid;
   nav_msgs::Odometry odom_output;
   geometry_msgs::AccelWithCovarianceStamped acceleration_output;
   {
@@ -305,6 +328,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 
     latest_stamp = latest_stamp_;
     latest_covariance_stamp = latest_covariance_stamp_;
+    latest_covariance_valid = latest_covariance_valid_;
     odom_output = odom_output_;
     acceleration_output = acceleration_output_;
   }
@@ -367,7 +391,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 
     // Either the last covariance computation was skipped because there was no subscriber,
     // or it failed
-    if (latest_covariance_stamp == latest_stamp)
+    if (latest_covariance_valid)
     {
       fuse_core::Matrix8d covariance;
       covariance(0, 0) = odom_output.pose.covariance[0];


### PR DESCRIPTION
This PR adds the `covariance_throttle_period` ROS param to the `fuse_models::Odometry2DPublisher` to allow throttling the covariance computation. The motivation is to reduce the CPU usage by saving time not computing the covariance on every optimization cycle, i.e. every time `notifyCallback()` is called.

I've profiled the fixed-lag smoother, and the two major hotspots are Ceres solver optimization and the covariance computation, taking around half of the total computational time each.

The idea here is that we could reduce the CPU usage to almost half if we don't need the covariance at the same rate as the state. For example, if we set `covariance_throttle_period` to `2.0s`, we get approx. half the CPU usage.

By default `covariance_throttle_period` is `0.0`, which doesn't throttle the covariance computation, so we have the current behaviour.

Note that when the covariance isn't computed, we simply used the last one computed. We don't predict/propagate it forward (see code comment for more details and justification). It's still propagated if `predict_to_current_time` is enabled, but doesn't only for the small `dt` between the optimization and publish time.