### PR TITLE
Use empty transaction

### DIFF
--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -169,10 +169,7 @@ void BatchOptimizer::optimizerTimerCallback(const ros::TimerEvent& /*event*/)
   // Check if there is any pending information to be applied to the graph.
   {
     std::lock_guard<std::mutex> lock(combined_transaction_mutex_);
-    optimization_request_ = !combined_transaction_->addedConstraints().empty() ||
-                            !combined_transaction_->removedConstraints().empty() ||
-                            !combined_transaction_->addedVariables().empty() ||
-                            !combined_transaction_->removedVariables().empty();
+    optimization_request_ = !combined_transaction_->empty();
   }
   // If there is some pending work, trigger the next optimization cycle.
   // If the optimizer has not completed the previous optimization cycle, then it


### PR DESCRIPTION
This is a trivial simplification, although I had to change the implementation of `Transaction::empty()` a bit so it doesn't check the `involved_stamps_`, and I updated the unit test accordingly.