### PR TITLE
Add tcp_no_delay parameter to sensor models

### DIFF
--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -68,6 +68,7 @@ struct Acceleration2DParams : public ParameterBase
 
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+      nh.getParam("tcp_no_delay", tcp_no_delay);
 
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
@@ -82,6 +83,11 @@ struct Acceleration2DParams : public ParameterBase
 
     bool disable_checks { false };
     int queue_size { 10 };
+    bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
+                                  //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,
+                                  //!< whatever the packet size. This reduces delay at the cost of network congestion,
+                                  //!< specially if the payload of a packet is smaller than the TCP header data. This is
+                                  //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -75,6 +75,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+      nh.getParam("tcp_no_delay", tcp_no_delay);
 
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
@@ -121,6 +122,11 @@ struct Imu2DParams : public ParameterBase
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
+    bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
+                                  //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,
+                                  //!< whatever the packet size. This reduces delay at the cost of network congestion,
+                                  //!< specially if the payload of a packet is smaller than the TCP header data. This is
+                                  //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     double gravitational_acceleration { 9.80665 };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -77,6 +77,7 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+      nh.getParam("tcp_no_delay", tcp_no_delay);
 
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
@@ -114,6 +115,11 @@ struct Odometry2DParams : public ParameterBase
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
+    bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
+                                  //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,
+                                  //!< whatever the packet size. This reduces delay at the cost of network congestion,
+                                  //!< specially if the payload of a packet is smaller than the TCP header data. This is
+                                  //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -71,6 +71,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("differential", differential);
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+      nh.getParam("tcp_no_delay", tcp_no_delay);
 
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
@@ -99,6 +100,11 @@ struct Pose2DParams : public ParameterBase
     bool independent { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
     int queue_size { 10 };
+    bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
+                                  //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,
+                                  //!< whatever the packet size. This reduces delay at the cost of network congestion,
+                                  //!< specially if the payload of a packet is smaller than the TCP header data. This is
+                                  //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -70,6 +70,7 @@ struct Twist2DParams : public ParameterBase
 
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
+      nh.getParam("tcp_no_delay", tcp_no_delay);
 
       double throttle_period_double = throttle_period.toSec();
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
@@ -85,6 +86,11 @@ struct Twist2DParams : public ParameterBase
 
     bool disable_checks { false };
     int queue_size { 10 };
+    bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
+                                  //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,
+                                  //!< whatever the packet size. This reduces delay at the cost of network congestion,
+                                  //!< specially if the payload of a packet is smaller than the TCP header data. This is
+                                  //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -77,8 +77,9 @@ void Acceleration2D::onStart()
 {
   if (!params_.indices.empty())
   {
-    subscriber_ = node_handle_.subscribe<geometry_msgs::AccelWithCovarianceStamped>(ros::names::resolve(params_.topic),
-        params_.queue_size, &AccelerationThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::AccelWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &AccelerationThrottledCallback::callback,
+        &throttled_callback_, ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -89,7 +89,8 @@ void Imu2D::onStart()
   {
     previous_pose_.reset();
     subscriber_ = node_handle_.subscribe<sensor_msgs::Imu>(ros::names::resolve(params_.topic), params_.queue_size,
-        &ImuThrottledCallback::callback, &throttled_callback_);
+                                                           &ImuThrottledCallback::callback, &throttled_callback_,
+                                                           ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
   }
 }
 

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -90,7 +90,8 @@ void Odometry2D::onStart()
   {
     previous_pose_.reset();
     subscriber_ = node_handle_.subscribe<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size,
-        &OdometryThrottledCallback::callback, &throttled_callback_);
+                                                             &OdometryThrottledCallback::callback, &throttled_callback_,
+                                                             ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
   }
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -80,7 +80,8 @@ void Pose2D::onStart()
       !params_.orientation_indices.empty())
   {
     subscriber_ = node_handle_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(
-        ros::names::resolve(params_.topic), params_.queue_size, &PoseThrottledCallback::callback, &throttled_callback_);
+        ros::names::resolve(params_.topic), params_.queue_size, &PoseThrottledCallback::callback, &throttled_callback_,
+        ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
   }
 }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -79,8 +79,9 @@ void Twist2D::onStart()
   if (!params_.linear_indices.empty() ||
       !params_.angular_indices.empty())
   {
-    subscriber_ = node_handle_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(ros::names::resolve(params_.topic),
-        params_.queue_size, &TwistThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &TwistThrottledCallback::callback, &throttled_callback_,
+        ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
   }
 }
 


### PR DESCRIPTION
This adds the `tcp_no_delay` ROS parameter to all sensor models. This parameter is equivalent to the `~[sensor]_nodelay` parameter in https://github.com/cra-ros-pkg/robot_localization/blob/melodic-devel/doc/state_estimation_nodes.rst#sensor_nodelay.

You can easily see the impact of enabling `TCP_NODELAY` with `rostopic delay --tcpnodelay <topic>`, which can be compared against `rostopic delay <topic>`, e.g.:
```bash
$ rostopic delay /odom
subscribed to [/odom]
average delay: 0.015
	min: 0.000s max: 0.043s std dev: 0.01371s window: 49
average delay: 0.017
	min: 0.000s max: 0.043s std dev: 0.01371s window: 100

$ rostopic delay --tcpnodelay /odom
subscribed to [/odom]
average delay: 0.000
	min: 0.000s max: 0.000s std dev: 0.00002s window: 50
average delay: 0.000
	min: 0.000s max: 0.000s std dev: 0.00002s window: 100
```

I've used this simple Python node to generate dummy messages:
```python
#!/usr/bin/env python3

import rospy

from nav_msgs.msg import Odometry

if __name__ == '__main__':
    rospy.init_node('odometry_publisher')

    try:
        pub = rospy.Publisher('odom', Odometry, queue_size=1)
        msg = Odometry()
        msg.header.frame_id = "odom"
        msg.child_frame_id = "base_link"
        msg.pose.covariance[0] = 1.0e-6
        msg.pose.covariance[7] = 1.0e-6
        msg.pose.covariance[35] = 1.0e-6
        msg.twist.covariance[0] = 1.0e-8
        msg.twist.covariance[7] = 1.0e-8
        msg.twist.covariance[35] = 1.0e-8

        rate = rospy.Rate(50.0)
        while True:
            msg.header.stamp = rospy.get_rostime()
            msg.pose.pose.position.x += 0.1
            msg.twist.twist.linear.x += 0.1 / 50.0
            pub.publish(msg)
            rate.sleep()
    except KeyboardInterrupt:
        rospy.signal_shutdown('Ctrl-c received')
```

I've also computed the delay in the `fuse_models::Odometry2D::process` method, with this changes wrt this PR:
```diff
$ git diff HEAD~1
diff --git a/fuse_models/include/fuse_models/odometry_2d.h b/fuse_models/include/fuse_models/odometry_2d.h
index 061d361..dca1807 100644
--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -133,6 +133,8 @@ protected:
 
   ros::Subscriber subscriber_;
 
+  ros::Publisher publisher_;
+
   using OdometryThrottledCallback = fuse_core::ThrottledMessageCallback<nav_msgs::Odometry>;
   OdometryThrottledCallback throttled_callback_;
 };
diff --git a/fuse_models/src/odometry_2d.cpp b/fuse_models/src/odometry_2d.cpp
index 7d159fb..eaee7dd 100644
--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -92,6 +92,8 @@ void Odometry2D::onStart()
     subscriber_ = node_handle_.subscribe<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size,
                                                              &OdometryThrottledCallback::callback, &throttled_callback_,
                                                              ros::TransportHints().tcpNoDelay(params_.tcp_no_delay));
+
+    publisher_ = node_handle_.advertise<nav_msgs::Odometry>(name_ + "/delay", 10);
   }
 }
 
@@ -102,6 +104,14 @@ void Odometry2D::onStop()
 
 void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
 {
+  const auto delay = (ros::Time::now() - msg->header.stamp).toSec();
+
+  nav_msgs::Odometry delay_msg;
+  delay_msg.header = msg->header;
+  delay_msg.pose.pose.position.x = delay;
+
+  publisher_.publish(delay_msg);
+
   // Create a transaction object
   auto transaction = fuse_core::Transaction::make_shared();
   transaction->stamp(msg->header.stamp);
```

With this I can easily plot the delay and see the impact of `TCP_NODELAY`:
* `tcp_no_delay: false` (default):
![tcp-no-delay-false-delay-wall-time](https://user-images.githubusercontent.com/382167/100597025-33141180-32fd-11eb-8015-8a10b0a79516.png)

* `tcp_no_delay: true`:
![tcp-np-delay-true-delay-walltime](https://user-images.githubusercontent.com/382167/100597036-360f0200-32fd-11eb-955e-c7dbc58f935c.png)

The next plot shows the delay for `tcp_no_delay: true` and `tcp_no_delay: false` one after the other, so it's easier to see the impact, with the same axes scale:
![tcp-np-delay-true-false-delay-walltime](https://user-images.githubusercontent.com/382167/100597166-635bb000-32fd-11eb-9125-53cc4d1779bf.png)

We could do the same in simulation, but in that case the delay is computed using the simulated time, not the wall time, so there are some discretization artifacts, e.g. with simulation running at 100Hz:
![CORE-17843-tcp-no-delay-Screenshot from 2020-11-29 20-14-26](https://user-images.githubusercontent.com/382167/100597313-969e3f00-32fd-11eb-8a63-d38b9e8c6276.png)

This also allows to see that for `nav_msgs::Odometry` messages, Nagle's algorithm buffers approximately 11-12 messages.

More information on `TCP_NODELAY` and other related topics can be found in:
https://www.extrahop.com/company/blog/2016/tcp-nodelay-nagle-quickack-best-practices/