### PR TITLE
Use fuse_core::getPositiveParam for all ros::Duration parameters

### DIFF
--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -70,9 +70,7 @@ struct Acceleration2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -77,9 +77,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -79,9 +79,7 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -84,13 +84,8 @@ public:
 
     fuse_core::getPositiveParam(nh, "covariance_throttle_period", covariance_throttle_period, false);
 
-    double tf_cache_time_double = tf_cache_time.toSec();
-    nh.getParam("tf_cache_time", tf_cache_time_double);
-    tf_cache_time.fromSec(tf_cache_time_double);
-
-    double tf_timeout_double = tf_timeout.toSec();
-    nh.getParam("tf_timeout", tf_timeout_double);
-    tf_timeout.fromSec(tf_timeout_double);
+    fuse_core::getPositiveParam(nh, "tf_cache_time", tf_cache_time, false);
+    fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
     nh.getParam("queue_size", queue_size);
 

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -73,9 +73,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -72,9 +72,7 @@ struct Twist2DParams : public ParameterBase
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);


### PR DESCRIPTION
When I tried to use `fuse_core::getPositiveParam` for all `ros::Duration` parameters before, I searched for `_sec`, so I missed a few spots where we use `_double` instead. Now all `ros::Duration` parameters make use of the new `fuse_core::getPositiveParam` that supports `ros::Duration`.