### PR TITLE
Reduce create problem allocations

### DIFF
--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -464,11 +464,12 @@ void HashGraph::createProblem(ceres::Problem& problem) const
     }
   }
   // Add the constraints
+  std::vector<double*> parameter_blocks;
   for (auto& uuid__constraint : constraints_)
   {
     fuse_core::Constraint& constraint = *(uuid__constraint.second);
     // We need the memory address of each variable value referenced by this constraint
-    std::vector<double*> parameter_blocks;
+    parameter_blocks.clear();
     parameter_blocks.reserve(constraint.variables().size());
     for (const auto& uuid : constraint.variables())
     {


### PR DESCRIPTION
On top of https://github.com/locusrobotics/fuse/pull/214, this moves `parameter_blocks` out of the loop that adds the residual blocks to the `ceres::Problem` created with the graph constraints.

This turns out to be a marginal improvement. Indeed, the CPU time is roughly the same according to the benchmark results:
```bash
2020-12-03 10:08:41
Running ./benchmark_create_problem
Run on (16 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x8)
  L1 Instruction 32K (x8)
  L2 Unified 512K (x8)
  L3 Unified 16384K (x2)
Load Average: 0.03, 0.28, 0.40
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_createProblem/200/2       124606 ns       124607 ns         5905
BM_createProblem/256/2       164698 ns       164695 ns         4280
BM_createProblem/512/2       359864 ns       359847 ns         1890
BM_createProblem/1024/2      813617 ns       813624 ns          920
BM_createProblem/2048/2     1674784 ns      1674737 ns          426
BM_createProblem/4000/2     3352385 ns      3352229 ns          212
BM_createProblem/200/4       192466 ns       192455 ns         3410
BM_createProblem/256/4       259837 ns       259829 ns         2505
BM_createProblem/512/4       577659 ns       577648 ns         1194
BM_createProblem/1024/4     1240251 ns      1240231 ns          569
BM_createProblem/2048/4     2596711 ns      2596421 ns          267
BM_createProblem/4000/4     5539479 ns      5539413 ns          123
BM_createProblem/200/8       373014 ns       373006 ns         1932
BM_createProblem/256/8       508080 ns       508050 ns         1278
BM_createProblem/512/8      1026084 ns      1026050 ns          692
BM_createProblem/1024/8     2241448 ns      2241251 ns          318
BM_createProblem/2048/8     4686068 ns      4685903 ns          149
BM_createProblem/4000/8    11403262 ns     11402702 ns           58
BM_createProblem/200/12      525974 ns       525941 ns         1385
BM_createProblem/256/12      733360 ns       733343 ns          923
BM_createProblem/512/12     1514037 ns      1513944 ns          460
BM_createProblem/1024/12    3178791 ns      3178632 ns          218
BM_createProblem/2048/12    7275065 ns      7274640 ns           93
BM_createProblem/4000/12   21954607 ns     21953315 ns           30
```

The numbers of allocations and allocated memory goes down for the `parameter_blocks` vector, but that wasn't the main contributor to memory allocations in `fuse_graphs::HashGraph::createProblem`:
![heaptrack-allocated-Screenshot from 2020-12-02 22-19-23](https://user-images.githubusercontent.com/382167/100993063-36a1d580-3555-11eb-8aca-4f16a148fc81.png)
![heaptrack-allocations-Screenshot from 2020-12-02 22-19-02](https://user-images.githubusercontent.com/382167/100993065-373a6c00-3555-11eb-9adc-700aa6805d23.png)
![heaptrack-Screenshot from 2020-12-02 22-12-10](https://user-images.githubusercontent.com/382167/100993067-37d30280-3555-11eb-8962-2ef07051bab3.png)
![heaptrack-Screenshot from 2020-12-02 22-16-25](https://user-images.githubusercontent.com/382167/100993069-37d30280-3555-11eb-8a1c-a5d9bda18a74.png)

When compared with the results in https://github.com/locusrobotics/fuse/pull/214, we have the following for the benchmark executable:
Case | Allocations | Allocated
--------|----------------|--------------
| https://github.com/locusrobotics/fuse/pull/214 | 4810920 | 211,8MB
| https://github.com/locusrobotics/fuse/pull/215 | 10730 | 479.1kB

It's a big improvement for `parameter_blocks` alone, but almost nothing overall. And almost no impact on CPU time. But I believe it's a good change.