### PR TITLE
Transform message in differential mode

### DIFF
--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -89,11 +89,12 @@ struct Odometry2DParams : public ParameterBase
         fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
       }
 
-      if (!differential && (!position_indices.empty() || !orientation_indices.empty()))
+      if (!position_indices.empty() || !orientation_indices.empty())
       {
         fuse_core::getParamRequired(nh, "pose_target_frame", pose_target_frame);
       }
-      else
+
+      if (differential)
       {
         nh.getParam("independent", independent);
         nh.getParam("use_twist_covariance", use_twist_covariance);

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -136,41 +136,63 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
 
   if (params_.differential)
   {
-    if (previous_pose_)
-    {
-      if (params_.use_twist_covariance)
-      {
-        common::processDifferentialPoseWithTwistCovariance(
-          name(),
-          device_id_,
-          *previous_pose_,
-          *pose,
-          twist,
-          params_.minimum_pose_relative_covariance,
-          params_.pose_loss,
-          {},
-          params_.orientation_indices,
-          validate,
-          *transaction);
-      }
-      else
-      {
-        common::processDifferentialPoseWithCovariance(
-          name(),
-          device_id_,
-          *previous_pose_,
-          *pose,
-          params_.independent,
-          params_.minimum_pose_relative_covariance,
-          params_.pose_loss,
-          {},
-          params_.orientation_indices,
-          validate,
-          *transaction);
-      }
-    }
+    auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
+    transformed_pose->header.frame_id = params_.orientation_target_frame;
 
-    previous_pose_ = std::move(pose);
+    if (!common::transformMessage(tf_buffer_, *pose, *transformed_pose))
+    {
+      ROS_ERROR_STREAM("Cannot transform pose message with stamp "
+                       << pose->header.stamp << " to orientation target frame " << params_.orientation_target_frame);
+    }
+    else
+    {
+      if (previous_pose_)
+      {
+        if (params_.use_twist_covariance)
+        {
+          geometry_msgs::TwistWithCovarianceStamped transformed_twist;
+          transformed_twist.header.frame_id = params_.twist_target_frame;
+
+          if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
+          {
+            ROS_ERROR_STREAM("Cannot transform twist message with stamp "
+                             << twist.header.stamp << " to twist target frame " << params_.twist_target_frame);
+          }
+          else
+          {
+            common::processDifferentialPoseWithTwistCovariance(
+              name(),
+              device_id_,
+              *previous_pose_,
+              *transformed_pose,
+              twist,
+              params_.minimum_pose_relative_covariance,
+              params_.pose_loss,
+              {},
+              params_.orientation_indices,
+              validate,
+              *transaction);
+          }
+        }
+        else
+        {
+          common::processDifferentialPoseWithCovariance(
+            name(),
+            device_id_,
+            *previous_pose_,
+            *transformed_pose,
+            params_.independent,
+            params_.minimum_pose_relative_covariance,
+            params_.pose_loss,
+            {},
+            params_.orientation_indices,
+            validate,
+            *transaction);
+        }
+      }
+
+      previous_pose_ = std::move(transformed_pose);
+    }
   }
   else
   {

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -41,6 +41,9 @@
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
+#include <memory>
+#include <utility>
+
 
 // Register this sensor model with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(fuse_models::Pose2D, fuse_core::SensorModel)

--- a/fuse_optimizers/test/config/list/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/list/common_robot_config.yaml
@@ -30,6 +30,7 @@ wheel_odometry:
   differential: true
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
+  pose_target_frame: odom
   twist_target_frame: base_link
 
 laser_localization:

--- a/fuse_optimizers/test/config/struct/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/struct/common_robot_config.yaml
@@ -30,6 +30,7 @@ wheel_odometry:
   differential: true
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
+  pose_target_frame: odom
   twist_target_frame: base_link
 
 laser_localization:


### PR DESCRIPTION
This is important because the relative transformation is not the same if the **sensor** and **target** frame are different.

Consider for example the case of an IMU sensor upside down:
* The robot base frame is `base_link`
* The IMU sensor frame is `imu_link`
* The `imu_link` transformation wrt `base_link` is `180` degrees wrt the `y` or `x` axis
* The angular velocity around the `z` axis has **opposite sign** in the **sensor** frame wrt the **target** frame

This only impacts the `Imu2D`, `Pose2D` and `Odometry2D` sensor models. The changes are similar for each, but with some differences. For this reason I've refrained from trying to factorize things out somehow. TBH it doesn't look trivial and probably not worth it, but at the same time I think there are too many `if-else` blocks and indentation levels. Any thoughts?

I'd be happy to make the implementation of this logic cleaner/simpler. :smiley: 

For now I advise you to hide the whitespace changes when you inspect the changes.