### PR TITLE
Target frame optional

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -273,12 +273,19 @@ inline bool processAbsolutePoseWithCovariance(
   }
 
   geometry_msgs::PoseWithCovarianceStamped transformed_message;
-  transformed_message.header.frame_id = target_frame;
-
-  if (!transformMessage(tf_buffer, pose, transformed_message))
+  if (target_frame.empty())
   {
-    ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << pose.header.stamp);
-    return false;
+    transformed_message = pose;
+  }
+  else
+  {
+    transformed_message.header.frame_id = target_frame;
+
+    if (!transformMessage(tf_buffer, pose, transformed_message))
+    {
+      ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << pose.header.stamp);
+      return false;
+    }
   }
 
   // Convert the pose into tf2_2d transform
@@ -917,12 +924,19 @@ inline bool processTwistWithCovariance(
   }
 
   geometry_msgs::TwistWithCovarianceStamped transformed_message;
-  transformed_message.header.frame_id = target_frame;
-
-  if (!transformMessage(tf_buffer, twist, transformed_message))
+  if (target_frame.empty())
   {
-    ROS_ERROR_STREAM("Cannot create constraint from twist message with stamp " << twist.header.stamp);
-    return false;
+    transformed_message = twist;
+  }
+  else
+  {
+    transformed_message.header.frame_id = target_frame;
+
+    if (!transformMessage(tf_buffer, twist, transformed_message))
+    {
+      ROS_ERROR_STREAM("Cannot create constraint from twist message with stamp " << twist.header.stamp);
+      return false;
+    }
   }
 
   bool constraints_added = false;
@@ -1072,12 +1086,19 @@ inline bool processAccelWithCovariance(
   }
 
   geometry_msgs::AccelWithCovarianceStamped transformed_message;
-  transformed_message.header.frame_id = target_frame;
-
-  if (!transformMessage(tf_buffer, acceleration, transformed_message))
+  if (target_frame.empty())
   {
-    ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << acceleration.header.stamp);
-    return false;
+    transformed_message = acceleration;
+  }
+  else
+  {
+    transformed_message.header.frame_id = target_frame;
+
+    if (!transformMessage(tf_buffer, acceleration, transformed_message))
+    {
+      ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << acceleration.header.stamp);
+      return false;
+    }
   }
 
   // Create the acceleration variables

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -93,20 +93,9 @@ struct Imu2DParams : public ParameterBase
             fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
       }
 
-      if (!linear_acceleration_indices.empty())
-      {
-        fuse_core::getParamRequired(nh, "acceleration_target_frame", acceleration_target_frame);
-      }
-
-      if (!orientation_indices.empty())
-      {
-        fuse_core::getParamRequired(nh, "orientation_target_frame", orientation_target_frame);
-      }
-
-      if (!angular_velocity_indices.empty())
-      {
-        fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
-      }
+      nh.getParam("acceleration_target_frame", acceleration_target_frame);
+      nh.getParam("orientation_target_frame", orientation_target_frame);
+      nh.getParam("twist_target_frame", twist_target_frame);
 
       pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
       angular_velocity_loss = fuse_core::loadLossConfig(nh, "angular_velocity_loss");

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -84,15 +84,8 @@ struct Odometry2DParams : public ParameterBase
 
       fuse_core::getParamRequired(nh, "topic", topic);
 
-      if (!linear_velocity_indices.empty() || !angular_velocity_indices.empty())
-      {
-        fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);
-      }
-
-      if (!position_indices.empty() || !orientation_indices.empty())
-      {
-        fuse_core::getParamRequired(nh, "pose_target_frame", pose_target_frame);
-      }
+      nh.getParam("twist_target_frame", twist_target_frame);
+      nh.getParam("pose_target_frame", pose_target_frame);
 
       if (differential)
       {

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -77,7 +77,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
 
       fuse_core::getParamRequired(nh, "topic", topic);
-      fuse_core::getParamRequired(nh, "target_frame", target_frame);
+      nh.getParam("target_frame", target_frame);
 
       if (differential)
       {

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -137,7 +137,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
   if (params_.differential)
   {
     auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
-    transformed_pose->header.frame_id = params_.orientation_target_frame;
+    transformed_pose->header.frame_id =
+        params_.orientation_target_frame.empty() ? pose->header.frame_id : params_.orientation_target_frame;
 
     if (!common::transformMessage(tf_buffer_, *pose, *transformed_pose))
     {
@@ -151,7 +152,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
         if (params_.use_twist_covariance)
         {
           geometry_msgs::TwistWithCovarianceStamped transformed_twist;
-          transformed_twist.header.frame_id = params_.twist_target_frame;
+          transformed_twist.header.frame_id =
+              params_.twist_target_frame.empty() ? twist.header.frame_id : params_.twist_target_frame;
 
           if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
           {

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -121,7 +121,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
   if (params_.differential)
   {
     auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
-    transformed_pose->header.frame_id = params_.pose_target_frame;
+    transformed_pose->header.frame_id =
+        params_.pose_target_frame.empty() ? pose->header.frame_id : params_.pose_target_frame;
 
     if (!common::transformMessage(tf_buffer_, *pose, *transformed_pose))
     {
@@ -135,7 +136,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
         if (params_.use_twist_covariance)
         {
           geometry_msgs::TwistWithCovarianceStamped transformed_twist;
-          transformed_twist.header.frame_id = params_.twist_target_frame;
+          transformed_twist.header.frame_id =
+              params_.twist_target_frame.empty() ? twist.header.frame_id : params_.twist_target_frame;
 
           if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
           {

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -104,7 +104,7 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
   if (params_.differential)
   {
     auto transformed_msg = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
-    transformed_msg->header.frame_id = params_.target_frame;
+    transformed_msg->header.frame_id = params_.target_frame.empty() ? msg->header.frame_id : params_.target_frame;
 
     if (!common::transformMessage(tf_buffer_, *msg, *transformed_msg))
     {

--- a/fuse_optimizers/test/config/list/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/list/common_robot_config.yaml
@@ -30,12 +30,8 @@ wheel_odometry:
   differential: true
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
-  pose_target_frame: odom
-  twist_target_frame: base_link
 
 laser_localization:
   topic: pose
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
-  pose_target_frame: map
-  twist_target_frame: base_link

--- a/fuse_optimizers/test/config/list/robot_with_imu_config.yaml
+++ b/fuse_optimizers/test/config/list/robot_with_imu_config.yaml
@@ -24,4 +24,3 @@ sensor_models:
 imu:
   topic: imu
   angular_velocity_dimensions: ['yaw']
-  twist_target_frame: base_link

--- a/fuse_optimizers/test/config/struct/common_robot_config.yaml
+++ b/fuse_optimizers/test/config/struct/common_robot_config.yaml
@@ -30,12 +30,8 @@ wheel_odometry:
   differential: true
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
-  pose_target_frame: odom
-  twist_target_frame: base_link
 
 laser_localization:
   topic: pose
   position_dimensions: ['x', 'y']
   orientation_dimensions: ['yaw']
-  pose_target_frame: map
-  twist_target_frame: base_link

--- a/fuse_optimizers/test/config/struct/robot_with_imu_config.yaml
+++ b/fuse_optimizers/test/config/struct/robot_with_imu_config.yaml
@@ -11,4 +11,3 @@ sensor_models:
 imu:
   topic: imu
   angular_velocity_dimensions: ['yaw']
-  twist_target_frame: base_link

--- a/fuse_optimizers/test/fixed_lag_ignition.test
+++ b/fuse_optimizers/test/fixed_lag_ignition.test
@@ -38,7 +38,6 @@
       pose_sensor:
         differential: true
         topic: relative_pose
-        target_frame: base_link
         position_dimensions: ['x', 'y']
         orientation_dimensions: ['yaw']
 


### PR DESCRIPTION
On top of https://github.com/locusrobotics/fuse/pull/216, this also makes the target frame parameters optional.

If not set, the target frame parameters default to `empty()`. In that case not transformation is performed. In this implementation, I actually fallback to the message `header.frame_id`, because it looks cleaner, but we could also consider bigger changes to factorize things out.