### PR TITLE
Factorize differential mode processing

### DIFF
--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -127,6 +127,18 @@ protected:
    */
   void onStop() override;
 
+  /**
+   * @brief Process a pose message in differential mode
+   *
+   * @param[in] pose - The pose message to process in differential mode
+   * @param[in] twist - The twist message used in case the twist covariance is used in differential mode
+   * @param[in] validate - Whether to validate the pose and twist coavriance or not
+   * @param[out] transaction - The generated variables and constraints are added to this transaction
+   */
+  void processDifferential(const geometry_msgs::PoseWithCovarianceStamped& pose,
+                           const geometry_msgs::TwistWithCovarianceStamped& twist, const bool validate,
+                           fuse_core::Transaction& transaction);
+
   ParameterType params_;
 
   std::unique_ptr<geometry_msgs::PoseWithCovarianceStamped> previous_pose_;

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -123,6 +123,18 @@ protected:
    */
   void onStop() override;
 
+  /**
+   * @brief Process a pose message in differential mode
+   *
+   * @param[in] pose - The pose message to process in differential mode
+   * @param[in] twist - The twist message used in case the twist covariance is used in differential mode
+   * @param[in] validate - Whether to validate the pose and twist coavriance or not
+   * @param[out] transaction - The generated variables and constraints are added to this transaction
+   */
+  void processDifferential(const geometry_msgs::PoseWithCovarianceStamped& pose,
+                           const geometry_msgs::TwistWithCovarianceStamped& twist, const bool validate,
+                           fuse_core::Transaction& transaction);
+
   ParameterType params_;
 
   std::unique_ptr<geometry_msgs::PoseWithCovarianceStamped> previous_pose_;

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -112,6 +112,16 @@ protected:
    */
   void onStop() override;
 
+  /**
+   * @brief Process a pose message in differential mode
+   *
+   * @param[in] pose - The pose message to process in differential mode
+   * @param[in] validate - Whether to validate the pose or not
+   * @param[out] transaction - The generated variables and constraints are added to this transaction
+   */
+  void processDifferential(const geometry_msgs::PoseWithCovarianceStamped& pose, const bool validate,
+                           fuse_core::Transaction& transaction);
+
   ParameterType params_;
 
   geometry_msgs::PoseWithCovarianceStamped::ConstPtr previous_pose_msg_;

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -221,8 +221,9 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_ERROR_STREAM("Cannot transform pose message with stamp "
-                     << pose.header.stamp << " to orientation target frame " << params_.orientation_target_frame);
+    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp " << pose.header.stamp
+                                                                              << " to orientation target frame "
+                                                                              << params_.orientation_target_frame);
     return;
   }
 
@@ -240,8 +241,9 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
 
     if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
     {
-      ROS_ERROR_STREAM("Cannot transform twist message with stamp "
-                       << twist.header.stamp << " to twist target frame " << params_.twist_target_frame);
+      ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform twist message with stamp " << twist.header.stamp
+                                                                                 << " to twist target frame "
+                                                                                 << params_.twist_target_frame);
     }
     else
     {

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -136,65 +136,7 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
 
   if (params_.differential)
   {
-    auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
-    transformed_pose->header.frame_id =
-        params_.orientation_target_frame.empty() ? pose->header.frame_id : params_.orientation_target_frame;
-
-    if (!common::transformMessage(tf_buffer_, *pose, *transformed_pose))
-    {
-      ROS_ERROR_STREAM("Cannot transform pose message with stamp "
-                       << pose->header.stamp << " to orientation target frame " << params_.orientation_target_frame);
-    }
-    else
-    {
-      if (previous_pose_)
-      {
-        if (params_.use_twist_covariance)
-        {
-          geometry_msgs::TwistWithCovarianceStamped transformed_twist;
-          transformed_twist.header.frame_id =
-              params_.twist_target_frame.empty() ? twist.header.frame_id : params_.twist_target_frame;
-
-          if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
-          {
-            ROS_ERROR_STREAM("Cannot transform twist message with stamp "
-                             << twist.header.stamp << " to twist target frame " << params_.twist_target_frame);
-          }
-          else
-          {
-            common::processDifferentialPoseWithTwistCovariance(
-              name(),
-              device_id_,
-              *previous_pose_,
-              *transformed_pose,
-              twist,
-              params_.minimum_pose_relative_covariance,
-              params_.pose_loss,
-              {},
-              params_.orientation_indices,
-              validate,
-              *transaction);
-          }
-        }
-        else
-        {
-          common::processDifferentialPoseWithCovariance(
-            name(),
-            device_id_,
-            *previous_pose_,
-            *transformed_pose,
-            params_.independent,
-            params_.minimum_pose_relative_covariance,
-            params_.pose_loss,
-            {},
-            params_.orientation_indices,
-            validate,
-            *transaction);
-        }
-      }
-
-      previous_pose_ = std::move(transformed_pose);
-    }
+    processDifferential(*pose, twist, validate, *transaction);
   }
   else
   {
@@ -267,6 +209,73 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);
+}
+
+void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& pose,
+                                const geometry_msgs::TwistWithCovarianceStamped& twist, const bool validate,
+                                fuse_core::Transaction& transaction)
+{
+  auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
+  transformed_pose->header.frame_id =
+      params_.orientation_target_frame.empty() ? pose.header.frame_id : params_.orientation_target_frame;
+
+  if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
+  {
+    ROS_ERROR_STREAM("Cannot transform pose message with stamp "
+                     << pose.header.stamp << " to orientation target frame " << params_.orientation_target_frame);
+    return;
+  }
+
+  if (!previous_pose_)
+  {
+    previous_pose_ = std::move(transformed_pose);
+    return;
+  }
+
+  if (params_.use_twist_covariance)
+  {
+    geometry_msgs::TwistWithCovarianceStamped transformed_twist;
+    transformed_twist.header.frame_id =
+        params_.twist_target_frame.empty() ? twist.header.frame_id : params_.twist_target_frame;
+
+    if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
+    {
+      ROS_ERROR_STREAM("Cannot transform twist message with stamp "
+                       << twist.header.stamp << " to twist target frame " << params_.twist_target_frame);
+    }
+    else
+    {
+      common::processDifferentialPoseWithTwistCovariance(
+        name(),
+        device_id_,
+        *previous_pose_,
+        *transformed_pose,
+        twist,
+        params_.minimum_pose_relative_covariance,
+        params_.pose_loss,
+        {},
+        params_.orientation_indices,
+        validate,
+        transaction);
+    }
+  }
+  else
+  {
+    common::processDifferentialPoseWithCovariance(
+      name(),
+      device_id_,
+      *previous_pose_,
+      *transformed_pose,
+      params_.independent,
+      params_.minimum_pose_relative_covariance,
+      params_.pose_loss,
+      {},
+      params_.orientation_indices,
+      validate,
+      transaction);
+  }
+
+  previous_pose_ = std::move(transformed_pose);
 }
 
 }  // namespace fuse_models

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -165,8 +165,8 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_ERROR_STREAM("Cannot transform pose message with stamp " << pose.header.stamp << " to pose target frame "
-                                                                 << params_.pose_target_frame);
+    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp "
+                                      << pose.header.stamp << " to pose target frame " << params_.pose_target_frame);
     return;
   }
 
@@ -184,8 +184,9 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
 
     if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
     {
-      ROS_ERROR_STREAM("Cannot transform twist message with stamp "
-                       << twist.header.stamp << " to twist target frame " << params_.twist_target_frame);
+      ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform twist message with stamp " << twist.header.stamp
+                                                                                 << " to twist target frame "
+                                                                                 << params_.twist_target_frame);
     }
     else
     {

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -132,8 +132,8 @@ void Pose2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped&
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_ERROR_STREAM("Cannot transform pose message with stamp " << pose.header.stamp << " to target frame "
-                                                                 << params_.target_frame);
+    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp "
+                                      << pose.header.stamp << " to target frame " << params_.target_frame);
     return;
   }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -103,34 +103,7 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
 
   if (params_.differential)
   {
-    auto transformed_msg = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
-    transformed_msg->header.frame_id = params_.target_frame.empty() ? msg->header.frame_id : params_.target_frame;
-
-    if (!common::transformMessage(tf_buffer_, *msg, *transformed_msg))
-    {
-      ROS_ERROR_STREAM("Cannot transform pose message with stamp " << msg->header.stamp << " to target frame "
-                                                                   << params_.target_frame);
-    }
-    else
-    {
-      if (previous_pose_msg_)
-      {
-        common::processDifferentialPoseWithCovariance(
-          name(),
-          device_id_,
-          *previous_pose_msg_,
-          *transformed_msg,
-          params_.independent,
-          params_.minimum_pose_relative_covariance,
-          params_.loss,
-          params_.position_indices,
-          params_.orientation_indices,
-          validate,
-          *transaction);
-      }
-
-      previous_pose_msg_ = std::move(transformed_msg);
-    }
+    processDifferential(*msg, validate, *transaction);
   }
   else
   {
@@ -149,6 +122,38 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);
+}
+
+void Pose2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& pose, const bool validate,
+                                 fuse_core::Transaction& transaction)
+{
+  auto transformed_pose = std::make_unique<geometry_msgs::PoseWithCovarianceStamped>();
+  transformed_pose->header.frame_id = params_.target_frame.empty() ? pose.header.frame_id : params_.target_frame;
+
+  if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
+  {
+    ROS_ERROR_STREAM("Cannot transform pose message with stamp " << pose.header.stamp << " to target frame "
+                                                                 << params_.target_frame);
+    return;
+  }
+
+  if (previous_pose_msg_)
+  {
+    common::processDifferentialPoseWithCovariance(
+      name(),
+      device_id_,
+      *previous_pose_msg_,
+      *transformed_pose,
+      params_.independent,
+      params_.minimum_pose_relative_covariance,
+      params_.loss,
+      params_.position_indices,
+      params_.orientation_indices,
+      validate,
+      transaction);
+  }
+
+  previous_pose_msg_ = std::move(transformed_pose);
 }
 
 }  // namespace fuse_models


### PR DESCRIPTION
As discussed in #216 and suggested in https://github.com/locusrobotics/fuse/pull/216#pullrequestreview-549689323, this moves the `differential` mode processing into a separate method, so its a bit cleaner.