### PR TITLE
Fixed compile error when using the latest version of rviz

### DIFF
--- a/fuse_viz/include/fuse_viz/serialized_graph_display.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_display.h
@@ -41,20 +41,15 @@
 #include <fuse_msgs/SerializedGraph.h>
 
 #include <rviz/message_filter_display.h>
+
+#include <OgreColourValue.h>
+#include <OgreSceneNode.h>
 #endif  // Q_MOC_RUN
 
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
-
-namespace Ogre
-{
-
-class SceneNode;
-class ColourValue;
-
-}  // namespace Ogre
 
 namespace rviz
 {


### PR DESCRIPTION
When using the latest melodic version of rviz (1.13.15), I get the following compile error:
```
from fuse_viz/include/fuse_viz/moc_serialized_graph_display.cpp:9:
/usr/include/c++/7/bits/stl_pair.h: In instantiation of ‘struct std::pair<const std::__cxx11::basic_string<char>, Ogre::ColourValue>’:
...
/usr/include/c++/7/bits/stl_pair.h:215:11: error: ‘std::pair<_T1, _T2>::second’ has incomplete type
       _T2 second;                /// @c second is a copy of the second object
           ^~~~~~
note: forward declaration of ‘class Ogre::ColourValue’
     class ColourValue;
           ^~~~~~~~~~~
```

The problem seems to be the forward declarations here:
https://github.com/locusrobotics/fuse/blob/devel/fuse_viz/include/fuse_viz/serialized_graph_display.h#L51-L57

But the header needs the full class definitions here:
https://github.com/locusrobotics/fuse/blob/devel/fuse_viz/include/fuse_viz/serialized_graph_display.h#L100

I suspect that the previous version of rviz was including the required headers somewhere, and this file was compiling due to this indirect include. Something in rviz subsequently changed, exposing the error here.

Technically I could leave the SceneNode as a forward declaration, as we only use a pointer to a SceneNode in this header. If that is preferred, or some other solution to this issue is desired, just let me know. I'm not exactly sure why there were forward declared to begin with.