### PR TITLE
Use rviz::Axes::updateAlpha

### DIFF
--- a/fuse_viz/src/pose_2d_stamped_visual.cpp
+++ b/fuse_viz/src/pose_2d_stamped_visual.cpp
@@ -113,13 +113,7 @@ void Pose2DStampedVisual::setSphereColor(const float r, const float g, const flo
 
 void Pose2DStampedVisual::setAxesAlpha(const float alpha)
 {
-  static const auto& default_x_color_ = rviz::Axes::getDefaultXColor();
-  static const auto& default_y_color_ = rviz::Axes::getDefaultYColor();
-  static const auto& default_z_color_ = rviz::Axes::getDefaultZColor();
-
-  axes_->setXColor(Ogre::ColourValue{ default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha });  // NOLINT
-  axes_->setYColor(Ogre::ColourValue{ default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha });  // NOLINT
-  axes_->setZColor(Ogre::ColourValue{ default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha });  // NOLINT
+  axes_->updateAlpha(alpha);
 }
 
 void Pose2DStampedVisual::setScale(const Ogre::Vector3& scale)

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -277,16 +277,7 @@ void RelativePose2DStampedConstraintVisual::setErrorLineColor(const float r, con
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseAxesAlpha(const float alpha)
 {
-  static const auto& default_x_color_ = rviz::Axes::getDefaultXColor();
-  static const auto& default_y_color_ = rviz::Axes::getDefaultYColor();
-  static const auto& default_z_color_ = rviz::Axes::getDefaultZColor();
-
-  relative_pose_axes_->setXColor(
-      Ogre::ColourValue{ default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha });  // NOLINT
-  relative_pose_axes_->setYColor(
-      Ogre::ColourValue{ default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha });  // NOLINT
-  relative_pose_axes_->setZColor(
-      Ogre::ColourValue{ default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha });  // NOLINT
+  relative_pose_axes_->updateAlpha(alpha);
 }
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseAxesScale(const Ogre::Vector3& scale)


### PR DESCRIPTION
This is required with the latest `rviz` version because now it does not have the `static` `getDefaultXColor()`, `getDefaultYColor()` and `getDefaultZColor()` methods.

The change was introduced in https://github.com/ros-visualization/rviz/commit/a4667509f8a9649039cbce5f6e1b3f053657bf05#diff-7825aa999d905edcd690f7b42fee90ed281e573de8481dfa915af235e07004f7R108-R113

This is part of https://github.com/ros-visualization/rviz/tree/noetic-devel, which also requires https://github.com/ros-visualization/interactive_markers/tree/noetic-devel

This PR might fail the tests if those aren't the versions in the buildfarm. I've confirmed this PR builds fine in a new workspace with the `noetic-devel` branches for `rviz` and `interactive_markers`, and this branch for `fuse_viz`.

If bumping `rviz` (and `interactive_markers`) is not an option for you atm, that's fine. I'd simply have this in my fork. I don't know if it's possible add some pre-processor `if-else` blocks depending on the `rviz` version, but that could be another option.