### PR TITLE
Substract minimum twist covariance from twist covariance

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -725,7 +725,7 @@ inline bool processDifferentialPoseWithCovariance(
  * @param[in] twist - The second (and temporally later) TwistWithCovarianceStamped message
  * @param[in] minimum_pose_relative_covariance - The minimum pose relative covariance that is always added to the
  *                                               resulting pose relative covariance
- * @param[in] minimum_twist_covariance - The minimum twist covariance that was added to the twist covariance and must be
+ * @param[in] twist_covariance_offset - The twist covariance offset that was added to the twist covariance and must be
  *                                       substracted from it before computing the pose relative covariance from it
  * @param[in] loss - The loss function for the 2D pose constraint generated
  * @param[in] validate - Whether to validate the measurements or not. If the validation fails no constraint is added
@@ -739,7 +739,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
   const geometry_msgs::PoseWithCovarianceStamped& pose2,
   const geometry_msgs::TwistWithCovarianceStamped& twist,
   const fuse_core::Matrix3d& minimum_pose_relative_covariance,
-  const fuse_core::Matrix3d& minimum_twist_covariance,
+  const fuse_core::Matrix3d& twist_covariance_offset,
   const fuse_core::Loss::SharedPtr& loss,
   const std::vector<size_t>& position_indices,
   const std::vector<size_t>& orientation_indices,
@@ -823,8 +823,8 @@ inline bool processDifferentialPoseWithTwistCovariance(
   // In some cases the twist covariance T12 is very small and it could yield to an ill-conditioned C12 covariance. For
   // that reason a minimum covariance is added to [2].
   //
-  // It is also common that for the same reason, the twist covariance T12 already has a minimum covariance added to
-  // it by the publisher, so we have to remove it before using it.
+  // It is also common that for the same reason, the twist covariance T12 already has a minimum covariance offset added
+  // to it by the publisher, so we have to remove it before using it.
   const auto dt = (pose2.header.stamp - pose1.header.stamp).toSec();
 
   if (dt < 1e-6)
@@ -838,7 +838,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
   j_twist *= dt;
 
   fuse_core::Matrix3d pose_relative_covariance =
-      j_twist * (cov - minimum_twist_covariance) * j_twist.transpose() + minimum_pose_relative_covariance;
+      j_twist * (cov - twist_covariance_offset) * j_twist.transpose() + minimum_pose_relative_covariance;
 
   // Build the sub-vector and sub-matrices based on the requested indices
   fuse_core::VectorXd pose_relative_mean_partial(position_indices.size() + orientation_indices.size());

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -823,8 +823,8 @@ inline bool processDifferentialPoseWithTwistCovariance(
   // In some cases the twist covariance T12 is very small and it could yield to an ill-conditioned C12 covariance. For
   // that reason a minimum covariance is added to [2].
   //
-  // It is also common that for the same reason, the twist covariance T12 has already been added a minimum covariacne to
-  // it, so we have to remove it before using it.
+  // It is also common that for the same reason, the twist covariance T12 already has a minimum covariance added to
+  // it by the publisher, so we have to remove it before using it.
   const auto dt = (pose2.header.stamp - pose1.header.stamp).toSec();
 
   if (dt < 1e-6)

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -725,6 +725,8 @@ inline bool processDifferentialPoseWithCovariance(
  * @param[in] twist - The second (and temporally later) TwistWithCovarianceStamped message
  * @param[in] minimum_pose_relative_covariance - The minimum pose relative covariance that is always added to the
  *                                               resulting pose relative covariance
+ * @param[in] minimum_twist_covariance - The minimum twist covariance that was added to the twist covariance and must be
+ *                                       substracted from it before computing the pose relative covariance from it
  * @param[in] loss - The loss function for the 2D pose constraint generated
  * @param[in] validate - Whether to validate the measurements or not. If the validation fails no constraint is added
  * @param[out] transaction - The generated variables and constraints are added to this transaction
@@ -737,6 +739,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
   const geometry_msgs::PoseWithCovarianceStamped& pose2,
   const geometry_msgs::TwistWithCovarianceStamped& twist,
   const fuse_core::Matrix3d& minimum_pose_relative_covariance,
+  const fuse_core::Matrix3d& minimum_twist_covariance,
   const fuse_core::Loss::SharedPtr& loss,
   const std::vector<size_t>& position_indices,
   const std::vector<size_t>& orientation_indices,
@@ -819,6 +822,9 @@ inline bool processDifferentialPoseWithTwistCovariance(
   //
   // In some cases the twist covariance T12 is very small and it could yield to an ill-conditioned C12 covariance. For
   // that reason a minimum covariance is added to [2].
+  //
+  // It is also common that for the same reason, the twist covariance T12 has already been added a minimum covariacne to
+  // it, so we have to remove it before using it.
   const auto dt = (pose2.header.stamp - pose1.header.stamp).toSec();
 
   if (dt < 1e-6)
@@ -831,7 +837,8 @@ inline bool processDifferentialPoseWithTwistCovariance(
   j_twist.setIdentity();
   j_twist *= dt;
 
-  fuse_core::Matrix3d pose_relative_covariance = j_twist * cov * j_twist.transpose() + minimum_pose_relative_covariance;
+  fuse_core::Matrix3d pose_relative_covariance =
+      j_twist * (cov - minimum_twist_covariance) * j_twist.transpose() + minimum_pose_relative_covariance;
 
   // Build the sub-vector and sub-matrices based on the requested indices
   fuse_core::VectorXd pose_relative_mean_partial(position_indices.size() + orientation_indices.size());

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -91,8 +91,8 @@ struct Imu2DParams : public ParameterBase
 
         minimum_pose_relative_covariance =
             fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
-        minimum_twist_covariance =
-            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_twist_covariance_diagonal", 0.0);
+        twist_covariance_offset =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "twist_covariance_offset_diagonal", 0.0);
       }
 
       nh.getParam("acceleration_target_frame", acceleration_target_frame);
@@ -109,7 +109,8 @@ struct Imu2DParams : public ParameterBase
     bool independent { true };
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
-    fuse_core::Matrix3d minimum_twist_covariance;          //!< Minimum twist covariance matrix
+    fuse_core::Matrix3d twist_covariance_offset;  //!< Offset already added to the twist covariance matrix, that will be
+                                                  //!< substracted in order to recover the raw values
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
     bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -91,6 +91,8 @@ struct Imu2DParams : public ParameterBase
 
         minimum_pose_relative_covariance =
             fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
+        minimum_twist_covariance =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_twist_covariance_diagonal", 0.0);
       }
 
       nh.getParam("acceleration_target_frame", acceleration_target_frame);
@@ -107,6 +109,7 @@ struct Imu2DParams : public ParameterBase
     bool independent { true };
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
+    fuse_core::Matrix3d minimum_twist_covariance;          //!< Minimum twist covariance matrix
     bool remove_gravitational_acceleration { false };
     int queue_size { 10 };
     bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -94,6 +94,8 @@ struct Odometry2DParams : public ParameterBase
 
         minimum_pose_relative_covariance =
             fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
+        minimum_twist_covariance =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_twist_covariance_diagonal", 0.0);
       }
 
       pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
@@ -106,6 +108,7 @@ struct Odometry2DParams : public ParameterBase
     bool independent { true };
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
+    fuse_core::Matrix3d minimum_twist_covariance;          //!< Minimum twist covariance matrix
     int queue_size { 10 };
     bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
                                   //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -94,8 +94,8 @@ struct Odometry2DParams : public ParameterBase
 
         minimum_pose_relative_covariance =
             fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
-        minimum_twist_covariance =
-            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_twist_covariance_diagonal", 0.0);
+        twist_covariance_offset =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "twist_covariance_offset_diagonal", 0.0);
       }
 
       pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
@@ -108,7 +108,8 @@ struct Odometry2DParams : public ParameterBase
     bool independent { true };
     bool use_twist_covariance { true };
     fuse_core::Matrix3d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance matrix
-    fuse_core::Matrix3d minimum_twist_covariance;          //!< Minimum twist covariance matrix
+    fuse_core::Matrix3d twist_covariance_offset;  //!< Offset already added to the twist covariance matrix, that will be
+                                                  //!< substracted in order to recover the raw values
     int queue_size { 10 };
     bool tcp_no_delay { false };  //!< Whether to use TCP_NODELAY, i.e. disable Nagle's algorithm, in the subscriber
                                   //!< socket or not. TCP_NODELAY forces a socket to send the data in its buffer,

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -254,6 +254,7 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
         *transformed_pose,
         twist,
         params_.minimum_pose_relative_covariance,
+        params_.minimum_twist_covariance,
         params_.pose_loss,
         {},
         params_.orientation_indices,

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -254,7 +254,7 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
         *transformed_pose,
         twist,
         params_.minimum_pose_relative_covariance,
-        params_.minimum_twist_covariance,
+        params_.twist_covariance_offset,
         params_.pose_loss,
         {},
         params_.orientation_indices,

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -197,6 +197,7 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
         *transformed_pose,
         transformed_twist,
         params_.minimum_pose_relative_covariance,
+        params_.minimum_twist_covariance,
         params_.pose_loss,
         params_.position_indices,
         params_.orientation_indices,

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -197,7 +197,7 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
         *transformed_pose,
         transformed_twist,
         params_.minimum_pose_relative_covariance,
-        params_.minimum_twist_covariance,
+        params_.twist_covariance_offset,
         params_.pose_loss,
         params_.position_indices,
         params_.orientation_indices,


### PR DESCRIPTION
This might sound a bit awkward at first, but I believe there's a use case for it, that I explain in a bit below.

### First, what's the issue this is trying to solve?

If the twist covariance already had a minimum twist covariance added to it in order to prevent ill-conditioned covariance matrices, we need a way to substract that minimum twist covariance from it before we compute the pose relative covariance.

Otherwise, we cannot get the original pose relative covariance because the minimum twist covariance term is
multiplied by the time delta, which could actually make the resulting pose relative covariance ill-conditioned or very small, i.e.
overconfident.

### How can we fix this?

In practice, this means that we can use the same minimum twist covariance that was added to the _raw_ twist covariance to obtain the _raw_ twist covariance and then compute the pose relative covariance and, if needed, add a minimum pose relative covariance to the result, which could be the same as the minimum twist covariance or different.

### Use case

If we don't care too much about having a pose relative covariance that matches exactly what it should be for the _raw_ twist covariance, it's true that with a minimum pose relative covariance we should be fine to guarantee the pose relative covariance isn't ill-conditioned.

However, we might not be able to remove the minimum twist covariance because other consumers might not have protection for ill-conditioned covariance matrices. For context, https://github.com/clearpathrobotics/ros_controllers/blob/38e474f3d05e42de1500f8486eb180803613d79d/diff_drive_controller/src/odometry.cpp#L203 is an example of an odometry producer that does this, and its output could be consumed by multiple consumers, not all able to handle the twist covariance if it were zero or very close to it.