### PR TITLE
[Issue #223] Add an optional tf_timeout parameter to the sensor models

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -218,14 +218,27 @@ inline void validatePartialMeasurement(
  * @param[in] tf_buffer - The transform buffer with which we will lookup the required transform
  * @param[in] input - The message to transform. Source frame and stamp are dictated by its header.
  * @param[in,out] output - The transformed message. Target frame is dictated by its header.
+ * @param [in] timeout - Optional. The maximum time to wait for a transform to become available.
  * @return true if the transform succeeded, false otherwise
  */
 template <typename T>
-bool transformMessage(const tf2_ros::Buffer& tf_buffer, const T& input, T& output)
+bool transformMessage(
+  const tf2_ros::Buffer& tf_buffer,
+  const T& input,
+  T& output,
+  const ros::Duration& tf_timeout = ros::Duration(0, 0))
 {
   try
   {
-    const auto trans = tf_buffer.lookupTransform(output.header.frame_id, input.header.frame_id, input.header.stamp);
+    auto trans = geometry_msgs::TransformStamped();
+    if (tf_timeout.isZero())
+    {
+      trans = tf_buffer.lookupTransform(output.header.frame_id, input.header.frame_id, input.header.stamp);
+    }
+    else
+    {
+      trans = tf_buffer.lookupTransform(output.header.frame_id, input.header.frame_id, input.header.stamp, tf_timeout);
+    }
     tf2::doTransform(input, output, trans);
     return true;
   }
@@ -265,7 +278,8 @@ inline bool processAbsolutePoseWithCovariance(
   const std::vector<size_t>& orientation_indices,
   const tf2_ros::Buffer& tf_buffer,
   const bool validate,
-  fuse_core::Transaction& transaction)
+  fuse_core::Transaction& transaction,
+  const ros::Duration& tf_timeout = ros::Duration(0, 0))
 {
   if (position_indices.empty() && orientation_indices.empty())
   {
@@ -281,9 +295,9 @@ inline bool processAbsolutePoseWithCovariance(
   {
     transformed_message.header.frame_id = target_frame;
 
-    if (!transformMessage(tf_buffer, pose, transformed_message))
+    if (!transformMessage(tf_buffer, pose, transformed_message, tf_timeout))
     {
-      ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << pose.header.stamp);
+      ROS_ERROR_STREAM_THROTTLE(10.0, "Cannot create constraint from pose message with stamp " << pose.header.stamp);
       return false;
     }
   }
@@ -855,7 +869,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM("Invalid partial differential pose measurement using the twist covariance from '"
+      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial differential pose measurement using the twist covariance from '"
                                           << source << "' source: " << ex.what());
       return false;
     }
@@ -915,7 +929,8 @@ inline bool processTwistWithCovariance(
   const std::vector<size_t>& angular_indices,
   const tf2_ros::Buffer& tf_buffer,
   const bool validate,
-  fuse_core::Transaction& transaction)
+  fuse_core::Transaction& transaction,
+  const ros::Duration& tf_timeout = ros::Duration(0, 0))
 {
   // Make sure we actually have work to do
   if (linear_indices.empty() && angular_indices.empty())
@@ -932,9 +947,9 @@ inline bool processTwistWithCovariance(
   {
     transformed_message.header.frame_id = target_frame;
 
-    if (!transformMessage(tf_buffer, twist, transformed_message))
+    if (!transformMessage(tf_buffer, twist, transformed_message, tf_timeout))
     {
-      ROS_ERROR_STREAM("Cannot create constraint from twist message with stamp " << twist.header.stamp);
+      ROS_ERROR_STREAM_THROTTLE(10.0, "Cannot create constraint from twist message with stamp " << twist.header.stamp);
       return false;
     }
   }
@@ -1077,7 +1092,8 @@ inline bool processAccelWithCovariance(
   const std::vector<size_t>& indices,
   const tf2_ros::Buffer& tf_buffer,
   const bool validate,
-  fuse_core::Transaction& transaction)
+  fuse_core::Transaction& transaction,
+  const ros::Duration& tf_timeout = ros::Duration(0, 0))
 {
   // Make sure we actually have work to do
   if (indices.empty())
@@ -1094,9 +1110,11 @@ inline bool processAccelWithCovariance(
   {
     transformed_message.header.frame_id = target_frame;
 
-    if (!transformMessage(tf_buffer, acceleration, transformed_message))
+    if (!transformMessage(tf_buffer, acceleration, transformed_message, tf_timeout))
     {
-      ROS_ERROR_STREAM("Cannot create constraint from pose message with stamp " << acceleration.header.stamp);
+      ROS_ERROR_STREAM_THROTTLE(
+        10.0,
+        "Cannot create constraint from pose message with stamp " << acceleration.header.stamp);
       return false;
     }
   }

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -1114,7 +1114,7 @@ inline bool processAccelWithCovariance(
     {
       ROS_ERROR_STREAM_THROTTLE(
         10.0,
-        "Cannot create constraint from pose message with stamp " << acceleration.header.stamp);
+        "Cannot create constraint from acceleration message with stamp " << acceleration.header.stamp);
       return false;
     }
   }

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -69,6 +69,7 @@ struct Acceleration2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
+      fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
@@ -86,6 +87,7 @@ struct Acceleration2DParams : public ParameterBase
                                   //!< whatever the packet size. This reduces delay at the cost of network congestion,
                                   //!< specially if the payload of a packet is smaller than the TCP header data. This is
                                   //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
+    ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -76,6 +76,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
+      fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
@@ -114,6 +115,7 @@ struct Imu2DParams : public ParameterBase
                                   //!< whatever the packet size. This reduces delay at the cost of network congestion,
                                   //!< specially if the payload of a packet is smaller than the TCP header data. This is
                                   //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
+    ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     double gravitational_acceleration { 9.80665 };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -78,6 +78,7 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
+      fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
@@ -112,6 +113,7 @@ struct Odometry2DParams : public ParameterBase
                                   //!< whatever the packet size. This reduces delay at the cost of network congestion,
                                   //!< specially if the payload of a packet is smaller than the TCP header data. This is
                                   //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
+    ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -72,6 +72,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
+      fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
@@ -103,6 +104,7 @@ struct Pose2DParams : public ParameterBase
                                   //!< whatever the packet size. This reduces delay at the cost of network congestion,
                                   //!< specially if the payload of a packet is smaller than the TCP header data. This is
                                   //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
+    ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -71,6 +71,7 @@ struct Twist2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
       nh.getParam("tcp_no_delay", tcp_no_delay);
+      fuse_core::getPositiveParam(nh, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
@@ -89,6 +90,7 @@ struct Twist2DParams : public ParameterBase
                                   //!< whatever the packet size. This reduces delay at the cost of network congestion,
                                   //!< specially if the payload of a packet is smaller than the TCP header data. This is
                                   //!< true for small ROS messages like geometry_msgs::AccelWithCovarianceStamped
+    ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
     std::string topic {};

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -103,7 +103,8 @@ void Acceleration2D::process(const geometry_msgs::AccelWithCovarianceStamped::Co
     params_.indices,
     tf_buffer_,
     !params_.disable_checks,
-    *transaction);
+    *transaction,
+    params_.tf_timeout);
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -150,7 +150,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
       params_.orientation_indices,
       tf_buffer_,
       validate,
-      *transaction);
+      *transaction,
+      params_.tf_timeout);
   }
 
   // Handle the twist data (only include indices for angular velocity)
@@ -165,7 +166,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
     params_.angular_velocity_indices,
     tf_buffer_,
     validate,
-    *transaction);
+    *transaction,
+    params_.tf_timeout);
 
   // Handle the acceleration data
   geometry_msgs::AccelWithCovarianceStamped accel;
@@ -205,7 +207,8 @@ void Imu2D::process(const sensor_msgs::Imu::ConstPtr& msg)
     params_.linear_acceleration_indices,
     tf_buffer_,
     validate,
-    *transaction);
+    *transaction,
+    params_.tf_timeout);
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -134,7 +134,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
       params_.orientation_indices,
       tf_buffer_,
       validate,
-      *transaction);
+      *transaction,
+      params_.tf_timeout);
   }
 
   // Handle the twist data
@@ -149,7 +150,8 @@ void Odometry2D::process(const nav_msgs::Odometry::ConstPtr& msg)
     params_.angular_velocity_indices,
     tf_buffer_,
     validate,
-    *transaction);
+    *transaction,
+    params_.tf_timeout);
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -117,7 +117,8 @@ void Pose2D::process(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& m
       params_.orientation_indices,
       tf_buffer_,
       validate,
-      *transaction);
+      *transaction,
+      params_.tf_timeout);
   }
 
   // Send the transaction object to the plugin's parent

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -107,7 +107,8 @@ void Twist2D::process(const geometry_msgs::TwistWithCovarianceStamped::ConstPtr&
     params_.angular_indices,
     tf_buffer_,
     !params_.disable_checks,
-    *transaction);
+    *transaction,
+    params_.tf_timeout);
 
   // Send the transaction object to the plugin's parent
   sendTransaction(transaction);


### PR DESCRIPTION
In Issue #223 the sensor model failed to create a constraint due to the lack of an available tf transform. This PR adds an optional `tf_timeout` to all relevant sensor models. If the timeout is non-zero, the tf `lookupTransform()` signature with a timeout parameter will be used instead. This allows the user to optionally add a timeout duration, allowing the sensor processing code to wait for a transform is one is not available immediately. Note that this will potentially delay the sensor processing, and may cause dropped messages if the tf frame is not available in a timely fashion.