### PR TITLE
Improve logs on graph update exception thrown

### DIFF
--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -127,7 +127,7 @@ bool HashGraph::addConstraint(fuse_core::Constraint::SharedPtr constraint)
     if (!variableExists(variable_uuid))
     {
       throw std::logic_error("Attempting to add a constraint (" + fuse_core::uuid::to_string(constraint->uuid()) +
-                             ") that uses an unknown variable (" + fuse_core::uuid::to_string(variable_uuid) + ")");
+                             ") that uses an unknown variable (" + fuse_core::uuid::to_string(variable_uuid) + ").");
     }
   }
   // Add the constraint to the list of known constraints
@@ -242,7 +242,7 @@ bool HashGraph::removeVariable(const fuse_core::UUID& variable_uuid)
   {
     throw std::logic_error("Attempting to remove a variable (" + fuse_core::uuid::to_string(variable_uuid)
       + ") that is used by existing constraints (" + fuse_core::uuid::to_string(cross_reference_iter->second.front())
-      + " plus " + std::to_string(cross_reference_iter->second.size() - 1) + " others)");
+      + " plus " + std::to_string(cross_reference_iter->second.size() - 1) + " others).");
   }
   // Remove the variable from all containers
   variables_.erase(variables_iter);  // Does not throw

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <iterator>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -200,7 +201,24 @@ void FixedLagSmoother::optimizationLoop()
       // Combine the new transactions with any marginal transaction from the end of the last cycle
       new_transaction->merge(marginal_transaction_);
       // Update the graph
-      graph_->update(*new_transaction);
+      try
+      {
+        graph_->update(*new_transaction);
+      }
+      catch (const std::exception& ex)
+      {
+        std::ostringstream oss;
+        oss << "Graph:\n";
+        graph_->print(oss);
+        oss << "\nTransaction:\n";
+        new_transaction->print(oss);
+
+        ROS_FATAL_STREAM("Failed to update graph with transaction: " << ex.what()
+                                                                     << "\nLeaving optimization loop and requesting "
+                                                                        "node shutdown...\n" << oss.str());
+        ros::requestShutdown();
+        break;
+      }
       // Optimize the entire graph
       summary_ = graph_->optimize(params_.solver_options);
 


### PR DESCRIPTION
* Catch graph update exceptions and log `FATAL` message
    
    When the graph `update()` method throws an exception the node crashes and
    there is no way to know what transaction caused the exception because we
    call `notify` after successfully updating the graph.
    
    This catches any exception thrown by the graph update method and logs a
    `FATAL` message that includes the current graph and the new transaction.

* Add full stop to exception messages
    
    This homogenizes the exception messages from all exceptions thrown by
    the `HashGraph` class.
