### PR TITLE
Adding QT5 dependency in package.xml

### DIFF
--- a/fuse_viz/package.xml
+++ b/fuse_viz/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>qtbase5-dev</build_depend>
+
   <depend>eigen</depend>
   <depend>fuse_constraints</depend>
   <depend>fuse_core</depend>

--- a/fuse_viz/src/pose_2d_stamped_visual.cpp
+++ b/fuse_viz/src/pose_2d_stamped_visual.cpp
@@ -113,13 +113,13 @@ void Pose2DStampedVisual::setSphereColor(const float r, const float g, const flo
 
 void Pose2DStampedVisual::setAxesAlpha(const float alpha)
 {
-  static const auto& default_x_color_ = rviz::Axes::getDefaultXColor();
-  static const auto& default_y_color_ = rviz::Axes::getDefaultYColor();
-  static const auto& default_z_color_ = rviz::Axes::getDefaultZColor();
+  static const auto& default_x_color_ = axes_->getDefaultXColor();
+  static const auto& default_y_color_ = axes_->getDefaultYColor();
+  static const auto& default_z_color_ = axes_->getDefaultZColor();
 
-  axes_->setXColor(Ogre::ColourValue{ default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha });  // NOLINT
-  axes_->setYColor(Ogre::ColourValue{ default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha });  // NOLINT
-  axes_->setZColor(Ogre::ColourValue{ default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha });  // NOLINT
+  axes_->setXColor(Ogre::ColourValue( default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha ));  // NOLINT
+  axes_->setYColor(Ogre::ColourValue( default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha ));  // NOLINT
+  axes_->setZColor(Ogre::ColourValue( default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha ));  // NOLINT
 }
 
 void Pose2DStampedVisual::setScale(const Ogre::Vector3& scale)

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -277,16 +277,16 @@ void RelativePose2DStampedConstraintVisual::setErrorLineColor(const float r, con
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseAxesAlpha(const float alpha)
 {
-  static const auto& default_x_color_ = rviz::Axes::getDefaultXColor();
-  static const auto& default_y_color_ = rviz::Axes::getDefaultYColor();
-  static const auto& default_z_color_ = rviz::Axes::getDefaultZColor();
+  static const auto& default_x_color_ = relative_pose_axes_->getDefaultXColor();
+  static const auto& default_y_color_ = relative_pose_axes_->getDefaultYColor();
+  static const auto& default_z_color_ = relative_pose_axes_->getDefaultZColor();
 
   relative_pose_axes_->setXColor(
-      Ogre::ColourValue{ default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha });  // NOLINT
+      Ogre::ColourValue( default_x_color_.r, default_x_color_.g, default_x_color_.b, alpha ));  // NOLINT
   relative_pose_axes_->setYColor(
-      Ogre::ColourValue{ default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha });  // NOLINT
+      Ogre::ColourValue( default_y_color_.r, default_y_color_.g, default_y_color_.b, alpha ));  // NOLINT
   relative_pose_axes_->setZColor(
-      Ogre::ColourValue{ default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha });  // NOLINT
+      Ogre::ColourValue( default_z_color_.r, default_z_color_.g, default_z_color_.b, alpha ));  // NOLINT
 }
 
 void RelativePose2DStampedConstraintVisual::setRelativePoseAxesScale(const Ogre::Vector3& scale)


### PR DESCRIPTION
This dependency is required for the build to pass on the build farm. Without it, the QT5 libraries are not installed, and `fuse_viz` fails at the CMake step.