### PR TITLE
Adding roslint dependency to fuse_viz

### DIFF
--- a/fuse/CMakeLists.txt
+++ b/fuse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_constraints)
 
 set(build_depends

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_core)
 
 set(build_depends

--- a/fuse_doc/CMakeLists.txt
+++ b/fuse_doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_doc)
 
 find_package(catkin REQUIRED)

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_graphs)
 
 set(build_depends

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_loss)
 
 set(build_depends

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_models)
 
 find_package(

--- a/fuse_msgs/CMakeLists.txt
+++ b/fuse_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_optimizers)
 
 set(build_depends

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_publishers)
 
 set(build_depends

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_variables)
 
 set(build_depends

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fuse_viz)
 
 set(build_depends

--- a/fuse_viz/package.xml
+++ b/fuse_viz/package.xml
@@ -23,6 +23,8 @@
   <depend>rviz</depend>
   <depend>tf2_geometry_msgs</depend>
 
+  <test_depend>roslint</test_depend>
+
   <export>
     <rviz plugin="${prefix}/rviz_plugins.xml"/>
   </export>


### PR DESCRIPTION
https://build.ros.org/job/Nbin_ufv8_uFv8__fuse_viz__ubuntu_focal_arm64__binary/2/consoleFull#console-section-15

```
07:23:47 CMake Error at CMakeLists.txt:116 (find_package):
07:23:47   By not providing "Findroslint.cmake" in CMAKE_MODULE_PATH this project has
07:23:47   asked CMake to find a package configuration file provided by "roslint", but
07:23:47   CMake did not find one.
07:23:47 
07:23:47   Could not find a package configuration file provided by "roslint" with any
07:23:47   of the following names:
07:23:47 
07:23:47     roslintConfig.cmake
07:23:47     roslint-config.cmake
07:23:47 
07:23:47   Add the installation prefix of "roslint" to CMAKE_PREFIX_PATH or set
07:23:47   "roslint_DIR" to a directory containing one of the above files.  If
07:23:47   "roslint" provides a separate development package or SDK, be sure it has
07:23:47   been installed.
```

Strangely, this passed the prerelease tests.