### PR TITLE
Port the unstamped 3D point variable into devel

### DIFF
--- a/fuse_core/include/fuse_core/uuid.h
+++ b/fuse_core/include/fuse_core/uuid.h
@@ -168,6 +168,17 @@ namespace uuid
    * @return                     A repeatable UUID specific to the provided namespace and timestamp
    */
   UUID generate(const std::string& namespace_string, const ros::Time& stamp, const UUID& id);
+
+    /**
+   * @brief Generate a UUID from a namespace string and a user provided id
+   *
+   * Every unique user id will generate a unique UUID
+   *
+   * @param[in] namespace_string A namespace or parent string used to generate non-overlapping UUIDs
+   * @param[in] user_id          A uint64_t user generated id
+   * @return                     A repeatable UUID specific to the provided namespace and user id
+   */
+  UUID generate(const std::string& namespace_string, const uint64_t& user_id);
 }  // namespace uuid
 
 }  // namespace fuse_core

--- a/fuse_core/src/uuid.cpp
+++ b/fuse_core/src/uuid.cpp
@@ -96,6 +96,11 @@ UUID generate(const std::string& namespace_string, const ros::Time& stamp, const
   return generate(namespace_string, buffer.data(), buffer.size());
 }
 
+UUID generate(const std::string& namespace_string, const uint64_t& user_id)
+{
+  return generate(namespace_string, reinterpret_cast<const unsigned char*>(&user_id), sizeof(user_id));
+}
+
 }  // namespace uuid
 
 }  // namespace fuse_core

--- a/fuse_core/test/test_uuid.cpp
+++ b/fuse_core/test/test_uuid.cpp
@@ -147,6 +147,21 @@ TEST(UUID, Generate)
     ASSERT_NE(id1, id4);
     ASSERT_NE(id1, id5);
   }
+  // Generate a UUID from a namespace, and a uint64_t
+  {
+    std::string name1 = "McLaughlin";
+    std::string name2 = "Aero";
+    uint64_t user_id1 = 0;
+    uint64_t user_id2 = 1;
+
+    UUID id1 = fuse_core::uuid::generate(name1, user_id1);
+    UUID id2 = fuse_core::uuid::generate(name1, user_id1);
+    UUID id3 = fuse_core::uuid::generate(name2, user_id1);
+    UUID id4 = fuse_core::uuid::generate(name1, user_id2);
+    ASSERT_EQ(id1, id2);
+    ASSERT_NE(id1, id3);
+    ASSERT_NE(id1, id4);
+  }
 }
 
 void generateUUIDs(UUIDs& uuids)

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${PROJECT_NAME}
   src/acceleration_linear_3d_stamped.cpp
   src/orientation_2d_stamped.cpp
   src/orientation_3d_stamped.cpp
+  src/point_3d_landmark.cpp
   src/position_2d_stamped.cpp
   src/position_3d_stamped.cpp
   src/stamped.cpp
@@ -330,6 +331,30 @@ if(CATKIN_ENABLE_TESTING)
     ${CERES_LIBRARIES}
   )
   set_target_properties(test_position_3d_stamped
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
+  # Point 3D landmark tests
+  catkin_add_gtest(test_point_3d_landmark
+    test/test_point_3d_landmark.cpp
+  )
+  add_dependencies(test_point_3d_landmark
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_point_3d_landmark
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_point_3d_landmark
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+  )
+  set_target_properties(test_point_3d_landmark
     PROPERTIES
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES

--- a/fuse_variables/include/fuse_variables/point_3d_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_3d_landmark.h
@@ -1,0 +1,168 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Author:    Jake McLaughlin
+ *  Created:   07.22.2021
+ * 
+ *  Copyright (c) 2021, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_VARIABLES_POINT_3D_LANDMARK_H
+#define FUSE_VARIABLES_POINT_3D_LANDMARK_H
+
+#include <fuse_core/serialization.h>
+#include <fuse_core/uuid.h>
+#include <fuse_core/variable.h>
+#include <fuse_variables/fixed_size_variable.h>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+#include <ostream>
+
+namespace fuse_variables
+{
+
+/**
+ * @brief Variable representing a 3D point landmark that exists across time.
+ *
+ * This is commonly used to represent locations of visual feature locations. The
+ * UUID of this class is constant after construction and dependent on a user
+ * input database id. As such, the database id cannot be altered after
+ * construction.
+ */
+class Point3DLandmark : public FixedSizeVariable<3>
+{
+public:
+  FUSE_VARIABLE_DEFINITIONS(Point3DLandmark);
+
+  /**
+   * @brief Can be used to directly index variables in the data array
+   */
+  enum : size_t { X = 0, Y = 1, Z = 2 };
+
+  /**
+   * @brief Default constructor
+   */
+  Point3DLandmark() = default;
+
+  /**
+   * @brief Return size of variables data
+   */
+  size_t size() const override { return data_.size(); }
+
+  /**
+   * @brief Construct a point 3D variable given a landmarks id
+   *
+   * @param[in] landmark_id  The id associated to a landmark
+   */
+  explicit Point3DLandmark(const uint64_t& landmark_id);
+
+  /**
+   * @brief read only access to data
+   */
+  const double* data() const override { return data_.data(); }
+
+  /**
+   * @brief read-write access to data
+   */
+  double* data() override { return data_.data(); }
+
+  /**
+   * @brief Read-write access to the X-axis position.
+   */
+  double& x() { return data_[X]; }
+
+  /**
+   * @brief Read-only access to the X-axis position.
+   */
+  const double& x() const { return data_[X]; }
+
+  /**
+   * @brief Read-write access to the Y-axis position.
+   */
+  double& y() { return data_[Y]; }
+
+  /**
+   * @brief Read-only access to the Y-axis position.
+   */
+  const double& y() const { return data_[Y]; }
+
+  /**
+   * @brief Read-write access to the Z-axis position.
+   */
+  double& z() { return data_[Z]; }
+
+  /**
+   * @brief Read-only access to the Z-axis position.
+   */
+  const double& z() const { return data_[Z]; }
+
+  /**
+   * @brief Read-only access to the id
+   */
+  const uint64_t& id() const { return id_; }
+
+  /**
+   * @brief Print a human-readable description of the variable to the provided
+   * stream.
+   *
+   * @param[out] stream The stream to write to. Defaults to stdout.
+   */
+  void print(std::ostream& stream = std::cout) const override;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+  uint64_t id_;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive& boost::serialization::base_object<FixedSizeVariable<SIZE>>(*this);
+    archive & id_;
+  }
+};
+
+}  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Point3DLandmark);
+
+#endif  // FUSE_VARIABLES_POINT_3D_LANDMARK_H

--- a/fuse_variables/src/point_3d_landmark.cpp
+++ b/fuse_variables/src/point_3d_landmark.cpp
@@ -1,0 +1,68 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_variables/point_3d_landmark.h>
+
+#include <fuse_core/uuid.h>
+#include <fuse_variables/fixed_size_variable.h>
+#include <fuse_variables/stamped.h>
+#include <pluginlib/class_list_macros.h>
+
+#include <boost/serialization/export.hpp>
+
+#include <string>
+
+namespace fuse_variables
+{
+
+Point3DLandmark::Point3DLandmark(const uint64_t& landmark_id)
+    : FixedSizeVariable(fuse_core::uuid::generate(detail::type(), landmark_id)), id_(landmark_id)
+{
+}
+
+void Point3DLandmark::print(std::ostream& stream) const
+{
+  stream << type() << ":\n"
+         << "  uuid: " << uuid() << "\n"
+         << "  size: " << size() << "\n"
+         << "  landmark id: " << id() << "\n"
+         << "  data:\n"
+         << "  - x: " << x() << "\n"
+         << "  - y: " << y() << "\n"
+         << "  - z: " << z() << "\n";
+}
+
+}  // namespace fuse_variables
+
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Point3DLandmark);
+PLUGINLIB_EXPORT_CLASS(fuse_variables::Point3DLandmark, fuse_core::Variable);

--- a/fuse_variables/test/test_point_3d_landmark.cpp
+++ b/fuse_variables/test/test_point_3d_landmark.cpp
@@ -1,0 +1,154 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/serialization.h>
+#include <fuse_variables/point_3d_landmark.h>
+#include <fuse_variables/stamped.h>
+#include <ros/time.h>
+
+#include <ceres/autodiff_cost_function.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <vector>
+
+using fuse_variables::Point3DLandmark;
+
+
+TEST(Point3DLandmark, Type)
+{
+  Point3DLandmark variable(0);
+  EXPECT_EQ("fuse_variables::Point3DLandmark", variable.type());
+}
+
+TEST(Point3DLandmark, UUID)
+{
+  // Verify two positions with the same landmark ids produce the same uuids
+  {
+    Point3DLandmark variable1(0);
+    Point3DLandmark variable2(0);
+    EXPECT_EQ(variable1.uuid(), variable2.uuid());
+  }
+
+    // Verify two positions with the different landmark ids  produce different uuids
+  {
+    Point3DLandmark variable1(0);
+    Point3DLandmark variable2(1);
+    EXPECT_NE(variable1.uuid(), variable2.uuid());
+  }
+}
+
+struct CostFunctor
+{
+  CostFunctor() {}
+
+  template <typename T> bool operator()(const T* const x, T* residual) const
+  {
+    residual[0] = x[0] - T(3.0);
+    residual[1] = x[1] + T(8.0);
+    residual[2] = x[2] - T(3.1);
+    return true;
+  }
+};
+
+TEST(Point3DLandmark, Optimization)
+{
+  // Create a Point3DLandmark
+  Point3DLandmark position(0);
+  position.x() = 1.5;
+  position.y() = -3.0;
+  position.z() = 0.8;
+
+  // Create a simple a constraint
+  ceres::CostFunction* cost_function = new ceres::AutoDiffCostFunction<CostFunctor, 3, 3>(new CostFunctor());
+
+  // Build the problem.
+  ceres::Problem problem;
+  problem.AddParameterBlock(
+    position.data(),
+    position.size());
+  std::vector<double*> parameter_blocks;
+  parameter_blocks.push_back(position.data());
+  problem.AddResidualBlock(
+    cost_function,
+    nullptr,
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+
+  // Check
+  EXPECT_NEAR(3.0, position.x(), 1.0e-5);
+  EXPECT_NEAR(-8.0, position.y(), 1.0e-5);
+  EXPECT_NEAR(3.1, position.z(), 1.0e-5);
+}
+
+TEST(Point3DLandmark, Serialization)
+{
+  // Create a Point3DLandmark
+  Point3DLandmark expected(0);
+  expected.x() = 1.5;
+  expected.y() = -3.0;
+  expected.z() = 0.8;
+
+  // Serialize the variable into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new variable from that same stream
+  Point3DLandmark actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.id(), actual.id());
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.x(), actual.x());
+  EXPECT_EQ(expected.y(), actual.y());
+  EXPECT_EQ(expected.z(), actual.z());
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Port the unstamped 3D point variable from kinetic-devel into devel
* Add unstamped 3D landmark variable
* Add landmark test and new uuid generator
Co-authored-by: Stephen Williams <swilliams@locusrobotics.com>