### PR TITLE
[RST-3240] Fix how the variables to be marginalized are selected.

### DIFF
--- a/fuse_optimizers/src/variable_stamp_index.cpp
+++ b/fuse_optimizers/src/variable_stamp_index.cpp
@@ -43,10 +43,8 @@
 #include <stdexcept>
 #include <vector>
 
-
 namespace fuse_optimizers
 {
-
 ros::Time VariableStampIndex::currentStamp() const
 {
   auto compare_stamps = [](const StampedMap::value_type& lhs, const StampedMap::value_type& rhs)
@@ -62,22 +60,6 @@ ros::Time VariableStampIndex::currentStamp() const
   {
     return ros::Time(0, 0);
   }
-}
-
-ros::Time VariableStampIndex::at(const fuse_core::UUID& variable) const
-{
-  auto stamped_iter = stamped_index_.find(variable);
-  if (stamped_iter != stamped_index_.end())
-  {
-    return stamped_iter->second;
-  }
-  auto unstamped_iter = unstamped_index_.find(variable);
-  if (unstamped_iter != unstamped_index_.end())
-  {
-    return getMaxConstraintStamp(unstamped_iter->second);
-  }
-  throw std::out_of_range("The requested variable UUID '" + fuse_core::uuid::to_string(variable) + "' does not "
-                          "exist in this VariableStampIndex object.");
 }
 
 void VariableStampIndex::addNewTransaction(const fuse_core::Transaction& transaction)
@@ -101,27 +83,10 @@ void VariableStampIndex::applyAddedConstraints(const fuse_core::Transaction& tra
 {
   for (const auto& constraint : transaction.addedConstraints())
   {
-    auto stamp = ros::Time(0, 0);
-    auto unstamped_uuids = std::vector<fuse_core::UUID>();
+    constraints_[constraint.uuid()].insert(constraint.variables().begin(), constraint.variables().end());
     for (const auto& variable_uuid : constraint.variables())
     {
-      auto stamped_iter = stamped_index_.find(variable_uuid);
-      if (stamped_iter != stamped_index_.end())
-      {
-        if (stamped_iter->second > stamp)
-        {
-          stamp = stamped_iter->second;
-        }
-      }
-      else
-      {
-        unstamped_uuids.push_back(variable_uuid);
-      }
-    }
-    auto contraint_info = ConstraintInfo::value_type(constraint.uuid(), stamp);
-    for (const auto& unstamped_uuid : unstamped_uuids)
-    {
-      unstamped_index_[unstamped_uuid].insert(contraint_info);
+      variables_[variable_uuid].insert(constraint.uuid());
     }
   }
 }
@@ -135,10 +100,7 @@ void VariableStampIndex::applyAddedVariables(const fuse_core::Transaction& trans
     {
       stamped_index_[variable.uuid()] = stamped_variable->stamp();
     }
-    else
-    {
-      unstamped_index_[variable.uuid()];  // Add an empty set
-    }
+    variables_[variable.uuid()];  // Add an empty set of constraints
   }
 }
 
@@ -146,45 +108,20 @@ void VariableStampIndex::applyRemovedConstraints(const fuse_core::Transaction& t
 {
   for (const auto& constraint_uuid : transaction.removedConstraints())
   {
-    for (auto& unstamped_variable : unstamped_index_)
+    for (auto& variable_uuid : constraints_[constraint_uuid])
     {
-      unstamped_variable.second.erase(constraint_uuid);
+      variables_[variable_uuid].erase(constraint_uuid);
     }
+    constraints_.erase(constraint_uuid);
   }
 }
 
 void VariableStampIndex::applyRemovedVariables(const fuse_core::Transaction& transaction)
 {
-  for (const auto& variable : transaction.removedVariables())
+  for (const auto& variable_uuid : transaction.removedVariables())
   {
-    auto stamped_iter = stamped_index_.find(variable);
-    if (stamped_iter != stamped_index_.end())
-    {
-      stamped_index_.erase(stamped_iter);
-      continue;
-    }
-    auto unstamped_iter = unstamped_index_.find(variable);
-    if (unstamped_iter != unstamped_index_.end())
-    {
-      unstamped_index_.erase(unstamped_iter);
-    }
-  }
-}
-
-ros::Time VariableStampIndex::getMaxConstraintStamp(const ConstraintInfo& constraints) const
-{
-  auto compare_stamps = [](const ConstraintInfo::value_type& lhs, const ConstraintInfo::value_type& rhs)
-  {
-    return lhs.second < rhs.second;
-  };
-  auto iter = std::max_element(constraints.begin(), constraints.end(), compare_stamps);
-  if (iter != constraints.end())
-  {
-    return iter->second;
-  }
-  else
-  {
-    return ros::Time(0, 0);
+    stamped_index_.erase(variable_uuid);
+    variables_.erase(variable_uuid);
   }
 }
 


### PR DESCRIPTION
Fix how the variables to be marginalized are selected.

The previous implementation marginalized out any stamped variable older than the threshold plus any unstamped variable that is not connected to a recent stamped variable via a constraint. This can lead to issues if there are time gaps or delays in the variable stream. If such a delay happens, then a variable may leave the smoothing window before newer instances of that variable are added. This can cause problems, particularly with relative constraints that connect between two consecutive timestamps.

This PR changes how the variables to be marginalized are selected. First, the set of variables that are newer than the threshold are found. Then any variable that is connected to that set via a constraint is found. This includes both stamped and unstamped variables. Any variable that is not included in either of those two sets will be marked for marginalization. This is a more general approach that handles unstamped variables without special treatment, and solves the previously mentioned time gap issue. A stamped variable that is outside lag time window will remain in the graph as long as it is connected to a variable inside the lag window.