### PR TITLE
Backport noetic version of ThrottledCallback into fuse_core

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -427,6 +427,22 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Throttle callback test
+  add_rostest_gtest(
+    test_throttled_callback
+    test/throttled_callback.test
+    test/test_throttled_callback.cpp
+  )
+  target_link_libraries(test_throttled_callback
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_throttled_callback
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Util tests
   catkin_add_gtest(test_util
     test/test_util.cpp

--- a/fuse_core/include/fuse_core/throttled_callback.h
+++ b/fuse_core/include/fuse_core/throttled_callback.h
@@ -31,43 +31,34 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
-#define FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
-
-#pragma message("Including header <fuse_models/common/throttled_callback.h> is deprecated, include " \
-                "<fuse_core/throttled_callback.h> instead.")
+#ifndef FUSE_CORE_THROTTLED_CALLBACK_H
+#define FUSE_CORE_THROTTLED_CALLBACK_H
 
 #include <ros/subscriber.h>
 
 #include <functional>
+#include <utility>
 
 
-namespace fuse_models
-{
-
-namespace common
+namespace fuse_core
 {
 
 /**
- * @brief A throttled callback that encapsulates the logic to throttle a message callback so it is only called after a
- * given period in seconds (or more). The dropped messages can optionally be received in a dropped callback, that could
- * be used to count the number of messages dropped.
+ * @brief A throttled callback that encapsulates the logic to throttle a callback so it is only called after a given
+ * period in seconds (or more). The dropped calls can optionally be received in a dropped callback, that could be used
+ * to count the number of calls dropped.
  *
- * @tparam M The message the callback receives
+ * @tparam Callback The std::function callback
  */
-template <class M>
+template <class Callback>
 class ThrottledCallback
 {
 public:
-  using MessageConstPtr = typename M::ConstPtr;
-  using Callback = std::function<void(const MessageConstPtr&)>;
-
   /**
    * @brief Constructor
    *
-   * @param[in] keep_callback   The callback to call when the message is kept, i.e. not dropped. Defaults to nullptr
-   * @param[in] drop_callback   The callback to call when the message is dropped because of the throttling. Defaults to
-   *                            nullptr
+   * @param[in] keep_callback   The callback to call when kept, i.e. not dropped. Defaults to nullptr
+   * @param[in] drop_callback   The callback to call when dropped because of the throttling. Defaults to nullptr
    * @param[in] throttle_period The throttling period duration in seconds. Defaults to 0.0, i.e. no throttling
    * @param[in] use_wall_time   Whether to use ros::WallTime or not. Defaults to false
    */
@@ -152,12 +143,13 @@ public:
   }
 
   /**
-   * @brief Message callback that throttles the calls to the keep callback provided. When the message is dropped because
+   * @brief Callback that throttles the calls to the keep callback provided. When dropped because
    * of throttling, the drop callback is called instead.
    *
-   * @param[in] message The input message
+   * @param[in] args The input arguments
    */
-  void callback(const MessageConstPtr& message)
+  template <class... Args>
+  void callback(Args&&... args)
   {
     // Keep the callback if:
     //
@@ -169,7 +161,7 @@ public:
     {
       if (keep_callback_)
       {
-        keep_callback_(message);
+        keep_callback_(std::forward<Args>(args)...);
       }
 
       if (last_called_time_.isZero())
@@ -183,21 +175,38 @@ public:
     }
     else if (drop_callback_)
     {
-      drop_callback_(message);
+      drop_callback_(std::forward<Args>(args)...);
     }
   }
 
+  /**
+   * @brief Operator() that simply calls the callback() method forwarding the input arguments
+   *
+   * @param[in] args The input arguments
+   */
+  template <class... Args>
+  void operator()(Args&&... args)
+  {
+    callback(std::forward<Args>(args)...);
+  }
+
 private:
-  Callback keep_callback_;         //!< The callback to call when the message is kept, i.e. not dropped
-  Callback drop_callback_;         //!< The callback to call when the message is dropped because of throttling
+  Callback keep_callback_;         //!< The callback to call when kept, i.e. not dropped
+  Callback drop_callback_;         //!< The callback to call when dropped because of throttling
   ros::Duration throttle_period_;  //!< The throttling period duration in seconds
   bool use_wall_time_;             //<! The flag to indicate whether to use ros::WallTime or not
 
   ros::Time last_called_time_;  //!< The last time the keep callback was called
 };
 
-}  // namespace common
+/**
+ * @brief Throttled callback for ROS messages
+ *
+ * @tparam M The ROS message type, which should have the M::ConstPtr nested type
+ */
+template <class M>
+using ThrottledMessageCallback = ThrottledCallback<std::function<void(const typename M::ConstPtr&)>>;
 
-}  // namespace fuse_models
+}  // namespace fuse_core
 
-#endif  // FUSE_MODELS_COMMON_THROTTLED_CALLBACK_H
+#endif  // FUSE_CORE_THROTTLED_CALLBACK_H

--- a/fuse_core/test/test_throttled_callback.cpp
+++ b/fuse_core/test/test_throttled_callback.cpp
@@ -1,0 +1,269 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_core/throttled_callback.h>
+#include <geometry_msgs/Point.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+
+/**
+ * @brief A helper class to publish a given number geometry_msgs::Point messages at a given frequency.
+ *
+ * The messages published are geometry_msgs::Point because it is simple. The 'x' field is set to the number of messages
+ * published so far, starting at 0.
+ */
+class PointPublisher
+{
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param[in] frequency The publishing frequency in Hz
+   */
+  explicit PointPublisher(const double frequency)
+    : frequency_(frequency)
+  {
+    publisher_ = node_handle_.advertise<geometry_msgs::Point>("point", 1);
+  }
+
+  /**
+   * @brief Publish the given number of messages
+   *
+   * @param[in] num_messages The number of messages to publish
+   */
+  void publish(const size_t num_messages)
+  {
+    // Wait for the subscribers to be ready before sending them data:
+    ros::WallTime subscriber_timeout = ros::WallTime::now() + ros::WallDuration(1.0);
+    while (publisher_.getNumSubscribers() < 1u && ros::WallTime::now() < subscriber_timeout)
+    {
+      ros::WallDuration(0.01).sleep();
+    }
+
+    ASSERT_GE(publisher_.getNumSubscribers(), 1u);
+
+    // Send data:
+    ros::Rate rate(frequency_);
+    for (size_t i = 0; i < num_messages; ++i)
+    {
+      geometry_msgs::Point point_message;
+      point_message.x = i;
+
+      publisher_.publish(point_message);
+
+      rate.sleep();
+    }
+  }
+
+private:
+  ros::NodeHandle node_handle_;  //!< The node handle
+  ros::Publisher publisher_;     //!< The publisher
+  double frequency_{ 10.0 };     //!< The publish rate frequency
+};
+
+/**
+ * @brief A dummy point sensor model that uses a fuse_core::ThrottledMessageCallback<geometry_msgs::Point> with a keep
+ * and drop callback.
+ *
+ * The callbacks simply count the number of times they are called, for testing purposes. The keep callback also caches
+ * the last message received, also for testing purposes.
+ */
+class PointSensorModel
+{
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param[in] throttle_period The throttle period duration in seconds
+   */
+  explicit PointSensorModel(const ros::Duration& throttle_period)
+    : throttled_callback_(std::bind(&PointSensorModel::keepCallback, this, std::placeholders::_1),
+                          std::bind(&PointSensorModel::dropCallback, this, std::placeholders::_1), throttle_period)
+  {
+    subscriber_ = node_handle_.subscribe<geometry_msgs::Point>(
+        "point", 10, &PointThrottledCallback::callback, &throttled_callback_);
+  }
+
+  /**
+   * @brief The kept messages counter getter
+   *
+   * @return The number of messages kept
+   */
+  size_t getKeptMessages() const
+  {
+    return kept_messages_;
+  }
+
+  /**
+   * @brief The dropped messages counter getter
+   *
+   * @return The number of messages dropped
+   */
+  size_t getDroppedMessages() const
+  {
+    return dropped_messages_;
+  }
+
+  /**
+   * @brief The last message kept getter
+   *
+   * @return The last message kept. It would be nullptr if no message has been kept so far
+   */
+  const geometry_msgs::Point::ConstPtr getLastKeptMessage() const
+  {
+    return last_kept_message_;
+  }
+
+private:
+  /**
+   * @brief Keep callback, that counts the number of times it has been called and caches the last message received
+   *
+   * @param[in] msg A geometry_msgs::Point message
+   */
+  void keepCallback(const geometry_msgs::Point::ConstPtr& msg)
+  {
+    ++kept_messages_;
+    last_kept_message_ = msg;
+  }
+
+  /**
+   * @brief Drop callback, that counts the number of times it has been called
+   *
+   * @param[in] msg A geometry_msgs::Point message (not used)
+   */
+  void dropCallback(const geometry_msgs::Point::ConstPtr& /*msg*/)
+  {
+    ++dropped_messages_;
+  }
+
+  ros::NodeHandle node_handle_;  //!< The node handle
+  ros::Subscriber subscriber_;   //!< The subscriber
+
+  using PointThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::Point>;
+  PointThrottledCallback throttled_callback_;  //!< The throttled callback
+
+  size_t kept_messages_{ 0 };                         //!< Messages kept
+  size_t dropped_messages_{ 0 };                      //!< Messages dropped
+  geometry_msgs::Point::ConstPtr last_kept_message_;  //!< The last message kept
+};
+
+
+TEST(ThrottledCallback, NoDroppedMessagesIfThrottlePeriodIsZero)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(0.0);
+  PointSensorModel sensor_model(throttled_period);
+
+  // Publish some messages:
+  const size_t num_messages = 10;
+  const double frequency = 10.0;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check all messages are kept and none are dropped, because when the throttle period is zero, throttling is disabled:
+  EXPECT_EQ(num_messages, sensor_model.getKeptMessages());
+  EXPECT_EQ(0u, sensor_model.getDroppedMessages());
+}
+
+TEST(ThrottledCallback, DropMessagesIfThrottlePeriodIsGreaterThanPublishPeriod)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(0.2);
+  PointSensorModel sensor_model(throttled_period);
+
+  // Publish some messages at half the throttled period:
+  const size_t num_messages = 10;
+  const double period_factor = 0.25;
+  const double period = period_factor * throttled_period.toSec();
+  const double frequency = 1.0 / period;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check the number of kept and dropped callbacks:
+  const auto expected_kept_messages = period_factor * num_messages;
+  const auto expected_dropped_messages = num_messages - expected_kept_messages;
+
+  EXPECT_NEAR(expected_kept_messages, sensor_model.getKeptMessages(), 1.0);
+  EXPECT_NEAR(expected_dropped_messages, sensor_model.getDroppedMessages(), 1.0);
+}
+
+TEST(ThrottledCallback, AlwaysKeepFirstMessageEvenIfThrottlePeriodIsTooLarge)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  // Start sensor model to listen to messages:
+  const ros::Duration throttled_period(10.0);
+  PointSensorModel sensor_model(throttled_period);
+
+  ASSERT_EQ(nullptr, sensor_model.getLastKeptMessage());
+
+  // Publish some messages:
+  const size_t num_messages = 10;
+  const double period = 0.1 * num_messages / throttled_period.toSec();
+  const double frequency = 1.0 / period;
+
+  PointPublisher publisher(frequency);
+  publisher.publish(num_messages);
+
+  // Check that regardless of the large throttled period, at least one message is ketpt:
+  EXPECT_EQ(1u, sensor_model.getKeptMessages());
+  EXPECT_EQ(num_messages - 1u, sensor_model.getDroppedMessages());
+
+  // Check the message kept was the first message:
+  const auto last_kept_message = sensor_model.getLastKeptMessage();
+  ASSERT_NE(nullptr, last_kept_message);
+  EXPECT_EQ(0.0, last_kept_message->x);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "throttled_callback_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/fuse_core/test/throttled_callback.test
+++ b/fuse_core/test/throttled_callback.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>	
+  <test test-name="throttled_callback_test" pkg="fuse_core" type="test_throttled_callback" />
+</launch>

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_ACCELERATION_2D_H
 
 #include <fuse_models/parameters/acceleration_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/AccelWithCovarianceStamped.h>
@@ -117,7 +117,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using AccelerationThrottledCallback = common::ThrottledCallback<geometry_msgs::AccelWithCovarianceStamped>;
+  using AccelerationThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::AccelWithCovarianceStamped>;
   AccelerationThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_IMU_2D_H
 
 #include <fuse_models/parameters/imu_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -137,7 +137,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using ImuThrottledCallback = common::ThrottledCallback<sensor_msgs::Imu>;
+  using ImuThrottledCallback = fuse_core::ThrottledMessageCallback<sensor_msgs::Imu>;
   ImuThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_ODOMETRY_2D_H
 
 #include <fuse_models/parameters/odometry_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -133,7 +133,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using OdometryThrottledCallback = common::ThrottledCallback<nav_msgs::Odometry>;
+  using OdometryThrottledCallback = fuse_core::ThrottledMessageCallback<nav_msgs::Odometry>;
   OdometryThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_POSE_2D_H
 
 #include <fuse_models/parameters/pose_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -122,7 +122,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using PoseThrottledCallback = common::ThrottledCallback<geometry_msgs::PoseWithCovarianceStamped>;
+  using PoseThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::PoseWithCovarianceStamped>;
   PoseThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -35,9 +35,9 @@
 #define FUSE_MODELS_TWIST_2D_H
 
 #include <fuse_models/parameters/twist_2d_params.h>
-#include <fuse_models/common/throttled_callback.h>
 
 #include <fuse_core/async_sensor_model.h>
+#include <fuse_core/throttled_callback.h>
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
@@ -111,7 +111,7 @@ protected:
 
   ros::Subscriber subscriber_;
 
-  using TwistThrottledCallback = common::ThrottledCallback<geometry_msgs::TwistWithCovarianceStamped>;
+  using TwistThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::TwistWithCovarianceStamped>;
   TwistThrottledCallback throttled_callback_;
 };
 

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -77,8 +77,9 @@ void Acceleration2D::onStart()
 {
   if (!params_.indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &AccelerationThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::AccelWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &AccelerationThrottledCallback::callback,
+        &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -88,8 +88,8 @@ void Imu2D::onStart()
       !params_.angular_velocity_indices.empty())
   {
     previous_pose_.reset();
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &ImuThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<sensor_msgs::Imu>(ros::names::resolve(params_.topic), params_.queue_size,
+        &ImuThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -89,8 +89,8 @@ void Odometry2D::onStart()
       !params_.angular_velocity_indices.empty())
   {
     previous_pose_.reset();
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &OdometryThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<nav_msgs::Odometry>(ros::names::resolve(params_.topic), params_.queue_size,
+        &OdometryThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -79,8 +79,8 @@ void Pose2D::onStart()
   if (!params_.position_indices.empty() ||
       !params_.orientation_indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &PoseThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &PoseThrottledCallback::callback, &throttled_callback_);
   }
 }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -79,8 +79,9 @@ void Twist2D::onStart()
   if (!params_.linear_indices.empty() ||
       !params_.angular_indices.empty())
   {
-    subscriber_ = node_handle_.subscribe(ros::names::resolve(params_.topic), params_.queue_size,
-                                         &TwistThrottledCallback::callback, &throttled_callback_);
+    subscriber_ = node_handle_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(
+        ros::names::resolve(params_.topic), params_.queue_size, &TwistThrottledCallback::callback,
+        &throttled_callback_);
   }
 }
 


### PR DESCRIPTION
Backport Noetic version of ThrottledCallback into fuse_core
Update all fuse classes to use the fuse_core version
Add a compile-time message that the fuse_models version will be deprecated