### PR TITLE
Fixed compile error when using the latest version of rviz

### DIFF
--- a/fuse_viz/include/fuse_viz/serialized_graph_display.h
+++ b/fuse_viz/include/fuse_viz/serialized_graph_display.h
@@ -41,20 +41,15 @@
 #include <fuse_msgs/SerializedGraph.h>
 
 #include <rviz/message_filter_display.h>
+
+#include <OgreColourValue.h>
+#include <OgreSceneNode.h>
 #endif  // Q_MOC_RUN
 
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
-
-namespace Ogre
-{
-
-class SceneNode;
-class ColourValue;
-
-}  // namespace Ogre
 
 namespace rviz
 {


### PR DESCRIPTION
Backport of #220 into kinetic-devel
Fixed compile error when using the latest version of rviz