### PR TITLE
[RST-4186] Fix fuse macro names

### DIFF
--- a/fuse_constraints/include/fuse_constraints/absolute_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -37,7 +37,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 

--- a/fuse_constraints/include/fuse_constraints/marginalize_variables.h
+++ b/fuse_constraints/include/fuse_constraints/marginalize_variables.h
@@ -40,7 +40,7 @@
 #include <fuse_core/eigen.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>
 

--- a/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
@@ -35,7 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_ORIENTATION_3D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_2d_cost_functor.h
@@ -35,7 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_DELTA_POSE_2D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
@@ -36,7 +36,7 @@
 
 #include <fuse_constraints/normal_delta_orientation_3d_cost_functor.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 #include <ceres/rotation.h>

--- a/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
@@ -35,7 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_ORIENTATION_3D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 #include <fuse_variables/orientation_3d_stamped.h>
 

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_2d_cost_functor.h
@@ -35,7 +35,7 @@
 #define FUSE_CONSTRAINTS_NORMAL_PRIOR_POSE_2D_COST_FUNCTOR_H
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
@@ -36,7 +36,7 @@
 
 #include <fuse_constraints/normal_prior_orientation_3d_cost_functor.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 #include <Eigen/Core>

--- a/fuse_constraints/include/fuse_constraints/relative_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_angular_2d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>

--- a/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_3d_stamped.h>

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_ASYNC_MOTION_MODEL_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
 #include <fuse_core/transaction.h>
 #include <ros/callback_queue.h>
@@ -85,7 +85,7 @@ namespace fuse_core
 class AsyncMotionModel : public MotionModel
 {
 public:
-  SMART_PTR_ALIASES_ONLY(AsyncMotionModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncMotionModel);
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_ASYNC_PUBLISHER_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/publisher.h>
 #include <fuse_core/transaction.h>
 #include <ros/callback_queue.h>
@@ -63,7 +63,7 @@ namespace fuse_core
 class AsyncPublisher : public Publisher
 {
 public:
-  SMART_PTR_ALIASES_ONLY(AsyncPublisher);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncPublisher);
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_ASYNC_SENSOR_MODEL_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/sensor_model.h>
 #include <fuse_core/transaction.h>
 #include <ros/callback_queue.h>
@@ -87,7 +87,7 @@ namespace fuse_core
 class AsyncSensorModel : public SensorModel
 {
 public:
-  SMART_PTR_ALIASES_ONLY(AsyncSensorModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncSensorModel);
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/ceres_options.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 
 #include <ceres/internal/autodiff.h>
 
@@ -77,7 +77,7 @@ template <typename PlusFunctor, typename MinusFunctor, int kGlobalSize, int kLoc
 class AutoDiffLocalParameterization : public LocalParameterization
 {
 public:
-  SMART_PTR_DEFINITIONS(AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>);
+  FUSE_SMART_PTR_DEFINITIONS(AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>);
 
   /**
    * @brief Constructs new PlusFunctor and MinusFunctor instances

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_CONSTRAINT_H
 
 #include <fuse_core/loss.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
@@ -145,7 +145,7 @@
  * @endcode
  */
 #define FUSE_CONSTRAINT_DEFINITIONS(...) \
-  SMART_PTR_DEFINITIONS(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_CONSTRAINT_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_CONSTRAINT_SERIALIZE_DEFINITION(__VA_ARGS__)
@@ -165,7 +165,7 @@
  * @endcode
  */
 #define FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(...) \
-  SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
   FUSE_CONSTRAINT_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_CONSTRAINT_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_CONSTRAINT_SERIALIZE_DEFINITION(__VA_ARGS__)
@@ -193,7 +193,7 @@ namespace fuse_core
 class Constraint
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Constraint);
+  FUSE_SMART_PTR_ALIASES_ONLY(Constraint);
 
   /**
    * @brief Default constructor

--- a/fuse_core/include/fuse_core/fuse_macros.h
+++ b/fuse_core/include/fuse_core/fuse_macros.h
@@ -52,10 +52,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef FUSE_CORE_MACROS_H
-#define FUSE_CORE_MACROS_H
-
-#pragma message("Including header <fuse_core/macros.h> is deprecated, include <fuse_core/fuse_macros.h> instead.")
+#ifndef FUSE_CORE_FUSE_MACROS_H
+#define FUSE_CORE_FUSE_MACROS_H
 
 #include <memory>
 #include <utility>
@@ -84,12 +82,12 @@
  *
  * Use in the public section of the class.
  */
-#define SMART_PTR_DEFINITIONS(...) \
-  __SHARED_PTR_ALIAS(__VA_ARGS__) \
-  __MAKE_SHARED_DEFINITION(__VA_ARGS__) \
-  __WEAK_PTR_ALIAS(__VA_ARGS__) \
-  __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
-  __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
+#define FUSE_SMART_PTR_DEFINITIONS(...) \
+  __FUSE_SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __FUSE_MAKE_SHARED_DEFINITION(__VA_ARGS__) \
+  __FUSE_WEAK_PTR_ALIAS(__VA_ARGS__) \
+  __FUSE_UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+  __FUSE_MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 
 /**
  * Defines smart pointer aliases and static functions for a class that contains fixed-sized vectorable Eigen member
@@ -101,16 +99,16 @@
  * Use in the public section of the class.
  */
 #if __cpp_aligned_new
-  #define SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
-    SMART_PTR_DEFINITIONS(__VA_ARGS__)
+  #define FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
+    FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__)
 #else
-  #define SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
+  #define FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(...) \
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
-    __SHARED_PTR_ALIAS(__VA_ARGS__) \
-    __MAKE_SHARED_ALIGNED_DEFINITION(__VA_ARGS__) \
-    __WEAK_PTR_ALIAS(__VA_ARGS__) \
-    __UNIQUE_PTR_ALIAS(__VA_ARGS__) \
-    __MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
+    __FUSE_SHARED_PTR_ALIAS(__VA_ARGS__) \
+    __FUSE_MAKE_SHARED_ALIGNED_DEFINITION(__VA_ARGS__) \
+    __FUSE_WEAK_PTR_ALIAS(__VA_ARGS__) \
+    __FUSE_UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+    __FUSE_MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 #endif
 
 /**
@@ -122,16 +120,16 @@
  *
  * Use in the public section of the class.
  */
-#define SMART_PTR_ALIASES_ONLY(...) \
-  __SHARED_PTR_ALIAS(__VA_ARGS__) \
-  __WEAK_PTR_ALIAS(__VA_ARGS__) \
-  __UNIQUE_PTR_ALIAS(__VA_ARGS__)
+#define FUSE_SMART_PTR_ALIASES_ONLY(...) \
+  __FUSE_SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __FUSE_WEAK_PTR_ALIAS(__VA_ARGS__) \
+  __FUSE_UNIQUE_PTR_ALIAS(__VA_ARGS__)
 
-#define __SHARED_PTR_ALIAS(...) \
+#define __FUSE_SHARED_PTR_ALIAS(...) \
   using SharedPtr = std::shared_ptr<__VA_ARGS__>; \
   using ConstSharedPtr = std::shared_ptr<const __VA_ARGS__>;
 
-#define __MAKE_SHARED_DEFINITION(...) \
+#define __FUSE_MAKE_SHARED_DEFINITION(...) \
   template<typename ... Args> \
   static std::shared_ptr<__VA_ARGS__> \
   make_shared(Args && ... args) \
@@ -139,7 +137,7 @@
     return std::make_shared<__VA_ARGS__>(std::forward<Args>(args) ...); \
   }
 
-#define __MAKE_SHARED_ALIGNED_DEFINITION(...) \
+#define __FUSE_MAKE_SHARED_ALIGNED_DEFINITION(...) \
   template<typename ... Args> \
   static std::shared_ptr<__VA_ARGS__> \
   make_shared(Args && ... args) \
@@ -147,15 +145,15 @@
     return std::allocate_shared<__VA_ARGS__>(Eigen::aligned_allocator<__VA_ARGS__>(), std::forward<Args>(args) ...); \
   }
 
-#define __WEAK_PTR_ALIAS(...) \
+#define __FUSE_WEAK_PTR_ALIAS(...) \
   using WeakPtr = std::weak_ptr<__VA_ARGS__>; \
   using ConstWeakPtr = std::weak_ptr<const __VA_ARGS__>;
 
-#define __UNIQUE_PTR_ALIAS(...) \
+#define __FUSE_UNIQUE_PTR_ALIAS(...) \
   using UniquePtr = std::unique_ptr<__VA_ARGS__>;
 
 #if __cplusplus >= 201402L
-  #define __MAKE_UNIQUE_DEFINITION(...) \
+  #define __FUSE_MAKE_UNIQUE_DEFINITION(...) \
   template<typename ... Args> \
   static std::unique_ptr<__VA_ARGS__> \
   make_unique(Args && ... args) \
@@ -163,7 +161,7 @@
     return std::make_unique<__VA_ARGS__>(std::forward<Args>(args) ...); \
   }
 #else
-  #define __MAKE_UNIQUE_DEFINITION(...) \
+  #define __FUSE_MAKE_UNIQUE_DEFINITION(...) \
   template<typename ... Args> \
   static std::unique_ptr<__VA_ARGS__> \
   make_unique(Args && ... args) \
@@ -172,4 +170,4 @@
   }
 #endif
 
-#endif  // FUSE_CORE_MACROS_H
+#endif  // FUSE_CORE_FUSE_MACROS_H

--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_GRAPH_H
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
@@ -130,7 +130,7 @@
 * @endcode
 */
 #define FUSE_GRAPH_DEFINITIONS(...) \
-  SMART_PTR_DEFINITIONS(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_GRAPH_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_GRAPH_SERIALIZE_DEFINITION(__VA_ARGS__)
 
@@ -149,7 +149,7 @@ namespace fuse_core
 class Graph
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Graph);
+  FUSE_SMART_PTR_ALIASES_ONLY(Graph);
 
   /**
    * @brief A range of fuse_ros::Constraint objects

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_CORE_LOCAL_PARAMETERIZATION_H
 #define FUSE_CORE_LOCAL_PARAMETERIZATION_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>
@@ -57,7 +57,7 @@ namespace fuse_core
 class LocalParameterization : public ceres::LocalParameterization
 {
 public:
-  SMART_PTR_ALIASES_ONLY(LocalParameterization);
+  FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
 
   /**
    * @brief Generalization of the subtraction operation

--- a/fuse_core/include/fuse_core/loss.h
+++ b/fuse_core/include/fuse_core/loss.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_CORE_LOSS_H
 #define FUSE_CORE_LOSS_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>
@@ -137,7 +137,7 @@
  * @endcode
  */
 #define FUSE_LOSS_DEFINITIONS(...) \
-  SMART_PTR_DEFINITIONS(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_LOSS_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_LOSS_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_LOSS_SERIALIZE_DEFINITION(__VA_ARGS__)
@@ -169,7 +169,7 @@ namespace fuse_core
 class Loss
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Loss);
+  FUSE_SMART_PTR_ALIASES_ONLY(Loss);
 
   static constexpr ceres::Ownership Ownership =
       ceres::Ownership::TAKE_OWNERSHIP;  //!< The ownership of the ceres::LossFunction* returned by lossFunction()

--- a/fuse_core/include/fuse_core/message_buffer.h
+++ b/fuse_core/include/fuse_core/message_buffer.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_CORE_MESSAGE_BUFFER_H
 #define FUSE_CORE_MESSAGE_BUFFER_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <ros/duration.h>
 #include <ros/time.h>
 
@@ -61,7 +61,7 @@ template <typename Message>
 class MessageBuffer
 {
 public:
-  SMART_PTR_DEFINITIONS(MessageBuffer<Message>);
+  FUSE_SMART_PTR_DEFINITIONS(MessageBuffer<Message>);
 
   /**
    * @brief A range of messages

--- a/fuse_core/include/fuse_core/motion_model.h
+++ b/fuse_core/include/fuse_core/motion_model.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_MOTION_MODEL_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 
 #include <string>
@@ -53,7 +53,7 @@ namespace fuse_core
 class MotionModel
 {
 public:
-  SMART_PTR_ALIASES_ONLY(MotionModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(MotionModel);
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/publisher.h
+++ b/fuse_core/include/fuse_core/publisher.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_PUBLISHER_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 
 #include <string>
@@ -57,7 +57,7 @@ namespace fuse_core
 class Publisher
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Publisher);
+  FUSE_SMART_PTR_ALIASES_ONLY(Publisher);
 
   /**
    * @brief Constructor

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_SENSOR_MODEL_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 
 #include <functional>
@@ -68,7 +68,7 @@ using TransactionCallback = std::function<void(Transaction::SharedPtr transactio
 class SensorModel
 {
 public:
-  SMART_PTR_ALIASES_ONLY(SensorModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(SensorModel);
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/timestamp_manager.h
+++ b/fuse_core/include/fuse_core/timestamp_manager.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_TIMESTAMP_MANAGER_H
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>
 #include <ros/duration.h>
@@ -65,7 +65,7 @@ namespace fuse_core
 class TimestampManager
 {
 public:
-  SMART_PTR_DEFINITIONS(TimestampManager);
+  FUSE_SMART_PTR_DEFINITIONS(TimestampManager);
 
   /**
    * @brief Function that generates motion model constraints between the requested timestamps

--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_TRANSACTION_H
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
@@ -66,7 +66,7 @@ namespace fuse_core
 class Transaction
 {
 public:
-  SMART_PTR_DEFINITIONS(Transaction);
+  FUSE_SMART_PTR_DEFINITIONS(Transaction);
 
   /**
    * @brief A range of Constraint::SharedPtr objects

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_VARIABLE_H
 
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
@@ -139,7 +139,7 @@
  * @endcode
  */
 #define FUSE_VARIABLE_DEFINITIONS(...) \
-  SMART_PTR_DEFINITIONS(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
   FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
@@ -159,7 +159,7 @@
  * @endcode
  */
 #define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...) \
-  SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
   FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
   FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
@@ -188,7 +188,7 @@ namespace fuse_core
 class Variable
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Variable);
+  FUSE_SMART_PTR_ALIASES_ONLY(Variable);
 
   /**
    * @brief Default constructor

--- a/fuse_core/test/example_constraint.h
+++ b/fuse_core/test/example_constraint.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 

--- a/fuse_core/test/example_loss.h
+++ b/fuse_core/test/example_loss.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_TEST_EXAMPLE_LOSS_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/loss.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>

--- a/fuse_core/test/example_variable.h
+++ b/fuse_core/test/example_variable.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_CORE_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 #define FUSE_CORE_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>

--- a/fuse_graphs/benchmark/benchmark_create_problem.cpp
+++ b/fuse_graphs/benchmark/benchmark_create_problem.cpp
@@ -32,7 +32,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_graphs/hash_graph.h>

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>

--- a/fuse_graphs/test/covariance_constraint.h
+++ b/fuse_graphs/test/covariance_constraint.h
@@ -35,7 +35,7 @@
 #define FUSE_GRAPHS_TEST_COVARIANCE_CONSTRAINT_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 

--- a/fuse_graphs/test/example_constraint.h
+++ b/fuse_graphs/test/example_constraint.h
@@ -35,7 +35,7 @@
 #define FUSE_GRAPHS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 

--- a/fuse_graphs/test/example_loss.h
+++ b/fuse_graphs/test/example_loss.h
@@ -35,7 +35,7 @@
 #define FUSE_GRAPHS_TEST_EXAMPLE_LOSS_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/loss.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -68,7 +68,7 @@ namespace fuse_models
 class Acceleration2D : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Acceleration2D);
+  FUSE_SMART_PTR_DEFINITIONS(Acceleration2D);
   using ParameterType = parameters::Acceleration2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/graph_ignition.h
+++ b/fuse_models/include/fuse_models/graph_ignition.h
@@ -71,7 +71,7 @@ namespace fuse_models
 class GraphIgnition : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(GraphIgnition);
+  FUSE_SMART_PTR_DEFINITIONS(GraphIgnition);
   using ParameterType = parameters::GraphIgnitionParams;
 
   /**

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -86,7 +86,7 @@ namespace fuse_models
 class Imu2D : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Imu2D);
+  FUSE_SMART_PTR_DEFINITIONS(Imu2D);
   using ParameterType = parameters::Imu2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -82,7 +82,7 @@ namespace fuse_models
 class Odometry2D : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Odometry2D);
+  FUSE_SMART_PTR_DEFINITIONS(Odometry2D);
   using ParameterType = parameters::Odometry2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -96,7 +96,7 @@ namespace fuse_models
 class Odometry2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher);
   using ParameterType = parameters::Odometry2DPublisherParams;
 
   /**

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -71,7 +71,7 @@ namespace fuse_models
 class Pose2D : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Pose2D);
+  FUSE_SMART_PTR_DEFINITIONS(Pose2D);
   using ParameterType = parameters::Pose2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/transaction.h
+++ b/fuse_models/include/fuse_models/transaction.h
@@ -63,7 +63,7 @@ namespace fuse_models
 class Transaction : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Transaction);
+  FUSE_SMART_PTR_DEFINITIONS(Transaction);
   using ParameterType = parameters::TransactionParams;
 
   /**

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -66,7 +66,7 @@ namespace fuse_models
 class Twist2D : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Twist2D);
+  FUSE_SMART_PTR_DEFINITIONS(Twist2D);
   using ParameterType = parameters::Twist2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -38,7 +38,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/timestamp_manager.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>
@@ -72,7 +72,7 @@ namespace fuse_models
 class Unicycle2D : public fuse_core::AsyncMotionModel
 {
 public:
-  SMART_PTR_DEFINITIONS_WITH_EIGEN(Unicycle2D);
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Unicycle2D);
 
   /**
    * @brief Default constructor

--- a/fuse_models/include/fuse_models/unicycle_2d_ignition.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_ignition.h
@@ -35,7 +35,7 @@
 #define FUSE_MODELS_UNICYCLE_2D_IGNITION_H
 
 #include <fuse_core/async_sensor_model.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/uuid.h>
 #include <fuse_models/parameters/unicycle_2d_ignition_params.h>
 #include <fuse_models/SetPose.h>
@@ -78,7 +78,7 @@ namespace fuse_models
 class Unicycle2DIgnition : public fuse_core::AsyncSensorModel
 {
 public:
-  SMART_PTR_DEFINITIONS(Unicycle2DIgnition);
+  FUSE_SMART_PTR_DEFINITIONS(Unicycle2DIgnition);
   using ParameterType = parameters::Unicycle2DIgnitionParams;
 
   /**

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
@@ -37,7 +37,7 @@
 #include <fuse_models/unicycle_2d_predict.h>
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 #include <ceres/sized_cost_function.h>

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
@@ -37,7 +37,7 @@
 #include <fuse_models/unicycle_2d_predict.h>
 
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/util.h>
 
 

--- a/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/acceleration_linear_2d_stamped.h>

--- a/fuse_models/test/example_constraint.h
+++ b/fuse_models/test/example_constraint.h
@@ -36,7 +36,7 @@
 #define FUSE_MODELS_TEST_EXAMPLE_CONSTRAINT_H  // NOLINT{build/header_guard}
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 

--- a/fuse_models/test/example_variable.h
+++ b/fuse_models/test/example_variable.h
@@ -35,7 +35,7 @@
 #ifndef FUSE_MODELS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 #define FUSE_MODELS_TEST_EXAMPLE_VARIABLE_H  // NOLINT{build/header_guard}
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>

--- a/fuse_models/test/example_variable_stamped.h
+++ b/fuse_models/test/example_variable_stamped.h
@@ -35,7 +35,7 @@
 #ifndef FUSE_MODELS_TEST_EXAMPLE_VARIABLE_STAMPED_H  // NOLINT{build/header_guard}
 #define FUSE_MODELS_TEST_EXAMPLE_VARIABLE_STAMPED_H  // NOLINT{build/header_guard}
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -35,7 +35,7 @@
 #define FUSE_OPTIMIZERS_BATCH_OPTIMIZER_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_optimizers/batch_optimizer_params.h>
 #include <fuse_optimizers/optimizer.h>
@@ -96,7 +96,7 @@ namespace fuse_optimizers
 class BatchOptimizer : public Optimizer
 {
 public:
-  SMART_PTR_DEFINITIONS(BatchOptimizer);
+  FUSE_SMART_PTR_DEFINITIONS(BatchOptimizer);
   using ParameterType = BatchOptimizerParams;
 
   /**

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -105,7 +105,7 @@ namespace fuse_optimizers
 class FixedLagSmoother : public Optimizer
 {
 public:
-  SMART_PTR_DEFINITIONS(FixedLagSmoother);
+  FUSE_SMART_PTR_DEFINITIONS(FixedLagSmoother);
   using ParameterType = FixedLagSmootherParams;
 
   /**

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -36,7 +36,7 @@
 
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
 #include <fuse_core/publisher.h>
 #include <fuse_core/sensor_model.h>
@@ -93,7 +93,7 @@ namespace fuse_optimizers
 class Optimizer
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Optimizer);
+  FUSE_SMART_PTR_ALIASES_ONLY(Optimizer);
 
   /**
    * @brief Constructor

--- a/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
+++ b/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_OPTIMIZERS_VARIABLE_STAMP_INDEX_H
 #define FUSE_OPTIMIZERS_VARIABLE_STAMP_INDEX_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 
@@ -56,7 +56,7 @@ namespace fuse_optimizers
 class VariableStampIndex
 {
 public:
-  SMART_PTR_DEFINITIONS(VariableStampIndex);
+  FUSE_SMART_PTR_DEFINITIONS(VariableStampIndex);
 
   /**
    * @brief Constructor

--- a/fuse_optimizers/test/example_optimizer.h
+++ b/fuse_optimizers/test/example_optimizer.h
@@ -47,7 +47,7 @@
 class ExampleOptimizer : public fuse_optimizers::Optimizer
 {
 public:
-  SMART_PTR_DEFINITIONS(ExampleOptimizer);
+  FUSE_SMART_PTR_DEFINITIONS(ExampleOptimizer);
 
   ExampleOptimizer(fuse_core::Graph::UniquePtr graph, const ros::NodeHandle& node_handle = ros::NodeHandle(),
                  const ros::NodeHandle& private_node_handle = ros::NodeHandle("~"))

--- a/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <ros/ros.h>
 
@@ -57,7 +57,7 @@ namespace fuse_publishers
 class Path2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS(Path2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(Path2DPublisher);
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -38,7 +38,7 @@
 
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 #include <fuse_variables/orientation_2d_stamped.h>
@@ -97,7 +97,7 @@ namespace fuse_publishers
 class Pose2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS(Pose2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(Pose2DPublisher);
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/throttled_callback.h>
 #include <fuse_core/transaction.h>
 #include <ros/ros.h>
@@ -53,7 +53,7 @@ namespace fuse_publishers
 class SerializedPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS(SerializedPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(SerializedPublisher);
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
+++ b/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
@@ -35,7 +35,7 @@
 #define FUSE_PUBLISHERS_STAMPED_VARIABLE_SYNCHRONIZER_H
 
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
@@ -67,7 +67,7 @@ template <typename ...Ts>
 class StampedVariableSynchronizer
 {
 public:
-  SMART_PTR_DEFINITIONS(StampedVariableSynchronizer);
+  FUSE_SMART_PTR_DEFINITIONS(StampedVariableSynchronizer);
   static const ros::Time TIME_ZERO;  //!< Constant representing a zero timestamp
 
   /**

--- a/fuse_tutorials/include/fuse_tutorials/beacon_publisher.h
+++ b/fuse_tutorials/include/fuse_tutorials/beacon_publisher.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <ros/ros.h>
 
@@ -101,7 +101,7 @@ class BeaconPublisher : public fuse_core::AsyncPublisher
 public:
   // It is convenient to have some typedefs for various smart pointer types (shared, unique, etc.). A macro is provided
   // to make it easy to define these typedefs and ensures that the naming is consistent throughout all fuse packages.
-  SMART_PTR_DEFINITIONS(BeaconPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(BeaconPublisher);
 
   /**
    * @brief Default constructor

--- a/fuse_tutorials/include/fuse_tutorials/range_constraint.h
+++ b/fuse_tutorials/include/fuse_tutorials/range_constraint.h
@@ -35,7 +35,7 @@
 #define FUSE_TUTORIALS_RANGE_CONSTRAINT_H
 
 #include <fuse_core/constraint.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_variables/point_2d_landmark.h>
 #include <fuse_variables/position_2d_stamped.h>
 

--- a/fuse_tutorials/include/fuse_tutorials/range_sensor_model.h
+++ b/fuse_tutorials/include/fuse_tutorials/range_sensor_model.h
@@ -106,7 +106,7 @@ class RangeSensorModel : public fuse_core::AsyncSensorModel
 public:
   // It is convenient to have some typedefs for various smart pointer types (shared, unique, etc.). A macro is provided
   // to make it easy to define these typedefs and ensures that the naming is consistent throughout all fuse packages.
-  SMART_PTR_DEFINITIONS(RangeSensorModel);
+  FUSE_SMART_PTR_DEFINITIONS(RangeSensorModel);
 
   /**
    * @brief Default constructor

--- a/fuse_variables/include/fuse_variables/fixed_size_variable.h
+++ b/fuse_variables/include/fuse_variables/fixed_size_variable.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_VARIABLES_FIXED_SIZE_VARIABLE_H
 #define FUSE_VARIABLES_FIXED_SIZE_VARIABLE_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/variable.h>
 
@@ -62,7 +62,7 @@ template <size_t N>
 class FixedSizeVariable : public fuse_core::Variable
 {
 public:
-  SMART_PTR_ALIASES_ONLY(FixedSizeVariable<N>);
+  FUSE_SMART_PTR_ALIASES_ONLY(FixedSizeVariable<N>);
 
   /**
    * @brief A static version of the variable size

--- a/fuse_variables/include/fuse_variables/point_2d_fixed_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_2d_fixed_landmark.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_VARIABLES_POINT_2D_FIXED_LANDMARK_H
 #define FUSE_VARIABLES_POINT_2D_FIXED_LANDMARK_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_variables/fixed_size_variable.h>
 

--- a/fuse_variables/include/fuse_variables/point_2d_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_2d_landmark.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_VARIABLES_POINT_2D_LANDMARK_H
 #define FUSE_VARIABLES_POINT_2D_LANDMARK_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_variables/fixed_size_variable.h>
 

--- a/fuse_variables/include/fuse_variables/point_3d_fixed_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_3d_fixed_landmark.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_VARIABLES_POINT_3D_FIXED_LANDMARK_H
 #define FUSE_VARIABLES_POINT_3D_FIXED_LANDMARK_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_variables/fixed_size_variable.h>
 

--- a/fuse_variables/include/fuse_variables/point_3d_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_3d_landmark.h
@@ -37,7 +37,7 @@
 #ifndef FUSE_VARIABLES_POINT_3D_LANDMARK_H
 #define FUSE_VARIABLES_POINT_3D_LANDMARK_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_variables/fixed_size_variable.h>
 

--- a/fuse_variables/include/fuse_variables/stamped.h
+++ b/fuse_variables/include/fuse_variables/stamped.h
@@ -34,7 +34,7 @@
 #ifndef FUSE_VARIABLES_STAMPED_H
 #define FUSE_VARIABLES_STAMPED_H
 
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <ros/node_handle.h>
@@ -57,7 +57,7 @@ namespace fuse_variables
 class Stamped
 {
 public:
-  SMART_PTR_ALIASES_ONLY(Stamped);
+  FUSE_SMART_PTR_ALIASES_ONLY(Stamped);
 
   /**
    * @brief Default constructor


### PR DESCRIPTION
Several of the macros defined in fuse use the same name as macros defined in ROS2. To prevent conflicts, the fuse macros were "namespaced" by adding a `FUSE_` prefix to anything that didn't have one already. To prevent breaking any external packages, the original macro header and names are maintained, with a compile-time message saying this file is deprecated.