### PR TITLE
Minor header fixes

### DIFF
--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -38,7 +38,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/eigen_gtest.h>
-#include <fuse_core/macros.h>
+#include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -41,6 +41,7 @@
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/TwistWithCovarianceStamped.h>
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 #include <tf2_ros/buffer.h>

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_MODELS_IMU_2D_H
 #define FUSE_MODELS_IMU_2D_H
 
-#include <fuse_models/parameters/imu_2d_params.h>
 #include <fuse_core/throttled_callback.h>
+#include <fuse_models/parameters/imu_2d_params.h>
 
 #include <fuse_core/async_sensor_model.h>
 #include <fuse_core/uuid.h>


### PR DESCRIPTION
* Add missed header
* Use `fuse_macros.h` instead of deprecated `macros.h`
* Sort headers