### PR TITLE
Add imu 2d rostest

### DIFF
--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -149,6 +149,7 @@ install(
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+  find_package(catkin REQUIRED COMPONENTS angles)
 
   # Lint tests
   roslint_add_test()

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -227,6 +227,22 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Imu2D tests
+  add_rostest_gtest(
+    test_imu_2d
+    test/imu_2d.test
+    test/test_imu_2d.cpp
+  )
+  target_link_libraries(test_imu_2d
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_imu_2d
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Unicycle2D Ignition tests
   add_rostest_gtest(
     test_unicycle_2d_ignition

--- a/fuse_models/package.xml
+++ b/fuse_models/package.xml
@@ -39,6 +39,7 @@
 
   <exec_depend>message_runtime</exec_depend>
 
+  <test_depend>angles</test_depend>
   <!-- The official rosdep has an entry for Google's benchmark deb
        (https://github.com/ros/rosdistro/blob/2cbcebdedcc1e827501acfecaf2386cd33f26809/rosdep/base.yaml#L232-L239)
        since https://github.com/ros/rosdistro/pull/23163 got merged.
@@ -52,6 +53,11 @@
        For this reason we conditionally test_depend on benchmark only if the $ROS_DISTRO is ROS Melodic or newer.
   -->
   <test_depend condition="$ROS_DISTRO >= melodic">benchmark</test_depend>
+  <test_depend>controller_manager</test_depend>
+  <test_depend>diff_drive_controller</test_depend>
+  <test_depend>gazebo_ros</test_depend>
+  <test_depend>joint_state_controller</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>

--- a/fuse_models/test/diffbot.launch
+++ b/fuse_models/test/diffbot.launch
@@ -22,5 +22,9 @@
 
   <!-- Spawn controller -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
-        args="diffbot_controller"/>
+        args="joint_state_controller
+              diffbot_controller"/>
+
+  <!-- Convert joint states to TF transforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 </launch>

--- a/fuse_models/test/diffbot.launch
+++ b/fuse_models/test/diffbot.launch
@@ -1,0 +1,26 @@
+<launch>
+  <arg name="gui" default="false"/>
+
+  <!-- Start world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="gui" value="$(arg gui)"/>
+  </include>
+
+  <!-- Load diffbot model -->
+  <param name="robot_description"
+         command="$(find xacro)/xacro '$(find fuse_models)/test/diffbot.xacro'"/>
+
+  <!-- Load diffbot config, e.g. PID gains -->
+  <rosparam command="load" file="$(find fuse_models)/test/diffbot.yaml"/>
+
+  <!-- Spawn diffbot robot in gazebo -->
+  <node name="spawn_diffbot" pkg="gazebo_ros" type="spawn_model"
+        args="-urdf -param robot_description -model diffbot -z 0.5"/>
+
+  <!-- Load controller config -->
+  <rosparam command="load" file="$(find fuse_models)/test/diffbot_controllers.yaml"/>
+
+  <!-- Spawn controller -->
+  <node name="controller_spawner" pkg="controller_manager" type="spawner"
+        args="diffbot_controller"/>
+</launch>

--- a/fuse_models/test/diffbot.xacro
+++ b/fuse_models/test/diffbot.xacro
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="$(find fuse_models)/test/wheel.xacro"/>
+
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+  <!-- Wheels -->
+  <xacro:wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${(width+thickness)/2} 0 0" rpy="0 ${90.0 * deg_to_rad} 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-(width+thickness)/2} 0 0" rpy="0 ${90.0 * deg_to_rad} 0"/>
+  </xacro:wheel>
+
+  <!-- IMU -->
+  <link name="imu_link"/>
+  <joint name="imu_joint" type="fixed">
+    <parent link="base_link" />
+    <child link="imu_link" />
+    <origin xyz="0.1 -0.2 0.3" rpy="0.0 ${-90.0 * deg_to_rad} ${90.0 * deg_to_rad}"/>
+  </joint>
+
+  <gazebo reference="imu_link">
+    <gravity>true</gravity>
+    <sensor name="imu_sensor" type="imu">
+      <always_on>true</always_on>
+      <update_rate>50.0</update_rate>
+      <visualize>true</visualize>
+      <plugin name="imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+        <topicName>imu</topicName>
+        <bodyName>imu_link</bodyName>
+        <updateRateHZ>50.0</updateRateHZ>
+        <frameName>imu_link</frameName>
+        <gaussianNoise>0.001</gaussianNoise>
+        <xyzOffset>0 0 0</xyzOffset>
+        <rpyOffset>0 0 0</rpyOffset>
+        <initialOrientationAsReference>false</initialOrientationAsReference>
+      </plugin>
+    </sensor>
+  </gazebo>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+</robot>

--- a/fuse_models/test/diffbot.xacro
+++ b/fuse_models/test/diffbot.xacro
@@ -77,7 +77,7 @@
         <bodyName>imu_link</bodyName>
         <updateRateHZ>50.0</updateRateHZ>
         <frameName>imu_link</frameName>
-        <gaussianNoise>0.001</gaussianNoise>
+        <gaussianNoise>1.0e-6</gaussianNoise>
         <xyzOffset>0 0 0</xyzOffset>
         <rpyOffset>0 0 0</rpyOffset>
         <initialOrientationAsReference>false</initialOrientationAsReference>
@@ -90,6 +90,16 @@
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
       <robotNamespace>/</robotNamespace>
       <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
+
+  <!-- ground truth plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
+      <bodyName>base_link</bodyName>
+      <topicName>ground_truth_odom</topicName>
+      <alwaysOn>true</alwaysOn>
+      <updateRate>50.0</updateRate>
     </plugin>
   </gazebo>
 

--- a/fuse_models/test/diffbot.yaml
+++ b/fuse_models/test/diffbot.yaml
@@ -1,0 +1,6 @@
+gazebo_ros_control:
+  pid_gains:
+    wheel_0_joint:
+      p: &p 100.0
+    wheel_1_joint:
+      p: *p

--- a/fuse_models/test/diffbot_controllers.yaml
+++ b/fuse_models/test/diffbot_controllers.yaml
@@ -1,3 +1,9 @@
+# Publish all joint states
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50
+
+# Diff drive controller
 diffbot_controller:
   type: "diff_drive_controller/DiffDriveController"
   left_wheel: 'wheel_0_joint'

--- a/fuse_models/test/diffbot_controllers.yaml
+++ b/fuse_models/test/diffbot_controllers.yaml
@@ -1,0 +1,10 @@
+diffbot_controller:
+  type: "diff_drive_controller/DiffDriveController"
+  left_wheel: 'wheel_0_joint'
+  right_wheel: 'wheel_1_joint'
+  publish_rate: 50.0 # defaults to 50
+  initial_pose_covariance_diagonal:  [0.001, 0.001, 0.01]
+  cmd_vel_timeout: 20.0 # we test this separately, give plenty for the other tests
+  k_l: 0.01
+  k_r: 0.01
+  wheel_resolution: 0.001

--- a/fuse_models/test/imu.yaml
+++ b/fuse_models/test/imu.yaml
@@ -1,0 +1,7 @@
+imu:
+  topic: /imu
+  angular_velocity_dimensions: ['yaw']
+  differential: true
+  orientation_dimensions: ['yaw']
+  orientation_target_frame: &target_frame base_link
+  twist_target_frame: *target_frame

--- a/fuse_models/test/imu_2d.test
+++ b/fuse_models/test/imu_2d.test
@@ -1,0 +1,12 @@
+<launch>
+  <!-- Simulat robot -->
+  <include file="$(find fuse_models)/test/diffbot.launch"/>
+
+  <!-- Load IMU sensor configuration -->
+  <rosparam file="$(find fuse_models)/test/imu.yaml" command="load" ns="imu_2d_test"/>
+
+  <!-- Run test -->
+  <test test-name="imu_2d_test" pkg="fuse_models" type="test_imu_2d" time-limit="120">
+    <remap from="odom" to="/ground_truth_odom"/>
+  </test>
+</launch>

--- a/fuse_models/test/test_imu_2d.cpp
+++ b/fuse_models/test/test_imu_2d.cpp
@@ -1,0 +1,320 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <angles/angles.h>
+#include <fuse_constraints/absolute_constraint.h>
+#include <fuse_constraints/relative_pose_2d_stamped_constraint.h>
+#include <fuse_core/transaction.h>
+#include <fuse_models/imu_2d.h>
+#include <fuse_variables/position_2d_stamped.h>
+#include <fuse_variables/velocity_angular_2d_stamped.h>
+#include <geometry_msgs/Twist.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <utility>
+
+/**
+ * @brief Imu2D test fixture
+ */
+class Imu2DTestFixture : public ::testing::Test
+{
+public:
+  Imu2DTestFixture()
+  {
+    cmd_vel_publisher_ = node_handle_.advertise<geometry_msgs::Twist>("/diffbot_controller/cmd_vel", 10);
+    odom_subscriber_ = node_handle_.subscribe("odom", 10, &Imu2DTestFixture::odomCallback, this);
+
+    cmd_vel_timer_ = node_handle_.createTimer(ros::Duration(0.1), &Imu2DTestFixture::cmdVelTimerCallback, this);
+  }
+
+  void transactionCallback(const fuse_core::Transaction::SharedPtr& transaction)
+  {
+    std::lock_guard<std::mutex> lock(last_transaction_mutex_);
+    last_transaction_ = *transaction;
+  }
+
+  void setCmdVel(const geometry_msgs::Twist& cmd_vel)
+  {
+    cmd_vel_ = cmd_vel;
+  }
+
+  nav_msgs::Odometry getLastOdom() const
+  {
+    std::lock_guard<std::mutex> lock(last_odom_mutex_);
+    return last_odom_;
+  }
+
+  fuse_core::Transaction getLastTransaction() const
+  {
+    std::lock_guard<std::mutex> lock(last_transaction_mutex_);
+    return last_transaction_;
+  }
+
+private:
+  void odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
+  {
+    std::lock_guard<std::mutex> lock(last_odom_mutex_);
+    last_odom_ = *msg;
+  }
+
+  void cmdVelTimerCallback(const ros::TimerEvent&)
+  {
+    cmd_vel_publisher_.publish(cmd_vel_);
+  }
+
+  ros::NodeHandle node_handle_;       //!< A node handle
+  ros::Publisher cmd_vel_publisher_;  //!< The command velocity publisher
+  ros::Subscriber odom_subscriber_;   //!< The wheel odometry subscriber
+  ros::Timer cmd_vel_timer_;  //!< A timer to send the command velocity to the robot continuously; if the command
+                              //!< velocity is only sent once, after some time the controller considers the command
+                              //!< velocity publisher hang up and resets the command velocity it uses to zero
+
+  geometry_msgs::Twist cmd_vel_;  //!< The command velocity to send to the robot
+  nav_msgs::Odometry last_odom_;  //!< The last odometry measurement received
+
+  fuse_core::Transaction last_transaction_;  //!< The last transaction generated
+
+  mutable std::mutex last_odom_mutex_;         //!< A mutex to protect last_odom_ access
+  mutable std::mutex last_transaction_mutex_;  //!< A mutex to protect last_transaction_ access
+};
+
+TEST_F(Imu2DTestFixture, BaseFrameYawAngularVelocity)
+{
+  // Create an IMU sensor and register the transaction callback
+  const std::string imu_2d_name{ "imu" };
+
+  fuse_models::Imu2D imu_2d;
+  imu_2d.initialize(imu_2d_name, std::bind(&Imu2DTestFixture::transactionCallback, this, std::placeholders::_1));
+  imu_2d.start();
+
+  // Make the robot turn in place for a few seconds
+  geometry_msgs::Twist twist;
+  twist.angular.z = 0.5;
+
+  setCmdVel(twist);
+
+  using namespace std::chrono_literals;
+  std::this_thread::sleep_for(3s);
+
+  // Confirm the last transaction has the expect number of variables and constraints generated by the imu sensor model
+  // source
+  const auto last_transaction = getLastTransaction();
+
+  // That is:
+  // * 5 variables:
+  //   * 1 variable for the angular velocity
+  //   * 4 variables for the current and previous position and orientation
+  // * 2 constraints:
+  //   * 1 constraints for the absolute angular velocity
+  //   * 1 constraints for the relative pose between the current and previous position and orientation
+  //
+  const auto added_variables = last_transaction.addedVariables();
+  const auto added_constraints = last_transaction.addedConstraints();
+
+  ASSERT_EQ(5, boost::size(added_variables));
+  ASSERT_EQ(2, boost::size(added_constraints));
+
+  // With all constraints generated by the imu sensor model source
+  for (const auto& constraint : added_constraints)
+  {
+    ASSERT_EQ(imu_2d_name, constraint.source());
+  }
+
+  // And no variables or constraints are removed
+  ASSERT_TRUE(boost::empty(last_transaction.removedVariables()));
+  ASSERT_TRUE(boost::empty(last_transaction.removedConstraints()));
+
+  // Confirm the last transaction generated matches the last wheel odometry received
+  //
+  // Note that we are not synchronizing the odometry measurements with the last transaction stamp or involved stamps,
+  // under the assumption the velocity is steady at the time it is being sampled. However, this is likely the reason the
+  // tolerance in the checks below is too high. With 1.0e-3 most of the checks fail even when things are working
+  // properly.
+  const auto last_odom = getLastOdom();
+
+  // First, confirm the fuse_variables::VelocityAngular2DStamped variable yaw is the same as the wheel odometry twist
+  // angular velocity along the z axis
+  const auto& w = last_odom.twist.twist.angular.z;
+
+  // That is, ensure there is one fuse_variables::VelocityAngular2DStamped variable
+  EXPECT_EQ(1, std::count_if(added_variables.begin(), added_variables.end(), [](const auto& variable) -> bool {
+              return dynamic_cast<const fuse_variables::VelocityAngular2DStamped*>(&variable);
+            }));
+
+  // And iterate over all added variables to process it
+  for (const auto& variable : added_variables)
+  {
+    // Skip if not a fuse_variables::VelocityAngular2DStamped variable
+    const auto velocity_angular = dynamic_cast<const fuse_variables::VelocityAngular2DStamped*>(&variable);
+    if (!velocity_angular)
+    {
+      continue;
+    }
+
+    // Check the angular velocity yaw is the same as the wheel odometry one
+    EXPECT_NEAR(w, velocity_angular->yaw(), 1.0e-2);
+  }
+
+  // Second, confirm the fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint constraint mean is the same as the
+  // wheel odometry twist angular velocity along the z axis
+
+  // That is, ensure there is one fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint constraint
+  EXPECT_EQ(1, std::count_if(added_constraints.begin(), added_constraints.end(), [](const auto& constraint) -> bool {
+              return dynamic_cast<const fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint*>(&constraint);
+            }));
+
+  // And iterate over all added constraints to process it
+  for (const auto& constraint : added_constraints)
+  {
+    // Skip if not a fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint constraint
+    const auto velocity_angular =
+        dynamic_cast<const fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint*>(&constraint);
+    if (!velocity_angular)
+    {
+      continue;
+    }
+
+    // Check the angular velocity mean has a single value and it is the same as the wheel odometry one
+    const auto& mean = velocity_angular->mean();
+    ASSERT_EQ(1, mean.size());
+    EXPECT_NEAR(w, mean[0], 1.0e-2);
+  }
+
+  // Third, confirm the relative yaw orientation velocity between the current and the previous
+  // fuse_variables::Orientation2DStamped variables is the same as the wheel odometry twist angular velocity along the z
+  // axis
+
+  // That is, ensure there are two fuse_variables::Orientation2DStamped variables
+  EXPECT_EQ(2, std::count_if(added_variables.begin(), added_variables.end(), [](const auto& variable) -> bool {
+              return dynamic_cast<const fuse_variables::Orientation2DStamped*>(&variable);
+            }));
+
+  // Iterate over all added variables to process retrieve the fuse_variables::Orientation2DStamped variables
+  std::vector<const fuse_variables::Orientation2DStamped*> orientations;
+  for (const auto& variable : added_variables)
+  {
+    // Skip if not a fuse_variables::VelocityAngular2DStamped variable
+    const auto orientation = dynamic_cast<const fuse_variables::Orientation2DStamped*>(&variable);
+    if (!orientation)
+    {
+      continue;
+    }
+
+    orientations.push_back(orientation);
+  }
+
+  // Sort them by stamp
+  std::sort(orientations.begin(), orientations.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs->stamp() < rhs->stamp(); });
+
+  // And check the angular velocity is the same as the wheel odometry one
+  //
+  // We need the time and orientation deltas in order to compute the angular velocity
+  const auto dt = (orientations[1]->stamp() - orientations[0]->stamp()).toSec();
+  ASSERT_LT(0.0, dt);
+
+  const auto orientation_delta = angles::shortest_angular_distance(orientations[0]->yaw(), orientations[1]->yaw());
+
+  EXPECT_NEAR(w, orientation_delta / dt, 1.0e-2);
+
+  // Finally, confirm the fuse_constraints::RelativePose2DStampedConstraint constraint mean is the same as the wheel
+  // odometry twist angular velocity along the z axis
+
+  // That is, ensure there is one fuse_constraints::RelativePose2DStampedConstraint constraint
+  EXPECT_EQ(1, std::count_if(added_constraints.begin(), added_constraints.end(), [](const auto& constraint) -> bool {
+              return dynamic_cast<const fuse_constraints::RelativePose2DStampedConstraint*>(&constraint);
+            }));
+
+  // And iterate over all added constraints to process it
+  for (const auto& constraint : added_constraints)
+  {
+    // Skip if not a fuse_constraints::RelativePose2DStampedConstraint constraint
+    const auto relative_pose = dynamic_cast<const fuse_constraints::RelativePose2DStampedConstraint*>(&constraint);
+    if (!relative_pose)
+    {
+      continue;
+    }
+
+    // Check the relative pose mean orientation (3rd component) is the same as the wheel odometry one, when multiplied
+    // by the time delta between the current and previous position and orientation variables
+    //
+    // We retrieve the current and previous positions, i.e. position2 and position1, and compute the time delta between
+    // them. Alternatively, we could use the time delta previously computed for the orientation variables.
+    const auto& delta = relative_pose->delta();
+
+    const auto& variables = relative_pose->variables();
+    const auto& position1_uuid = variables[0];
+    const auto& position2_uuid = variables[2];
+
+    const auto position1_iter =
+        std::find_if(added_variables.begin(), added_variables.end(),
+                     [&position1_uuid](const auto& variable) { return variable.uuid() == position1_uuid; });
+    ASSERT_NE(added_variables.end(), position1_iter);
+
+    const auto position1 = dynamic_cast<const fuse_variables::Position2DStamped*>(&*position1_iter);
+    ASSERT_TRUE(position1);
+
+    const auto position2_iter =
+        std::find_if(added_variables.begin(), added_variables.end(),
+                     [&position2_uuid](const auto& variable) { return variable.uuid() == position2_uuid; });
+    ASSERT_NE(added_variables.end(), position2_iter);
+
+    const auto position2 = dynamic_cast<const fuse_variables::Position2DStamped*>(&*position2_iter);
+    ASSERT_TRUE(position2);
+
+    const auto dt = position2->stamp().toSec() - position1->stamp().toSec();
+    ASSERT_LT(0.0, dt);
+
+    ASSERT_EQ(3, delta.size());
+    EXPECT_NEAR(w, delta[2] / dt, 1.0e-2);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "imu_2d_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/fuse_models/test/wheel.xacro
+++ b/fuse_models/test/wheel.xacro
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="wheel" params="name parent radius thickness *origin">
+    <link name="${name}_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_joint" type="continuous">
+      <parent link="${parent}_link"/>
+      <child link="${name}_link"/>
+      <xacro:insert_block name="origin"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_joint_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${name}_joint">
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${name}_joint_motor">
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <mechanicalReduction>1</mechanicalReduction>
+        <motorTorqueConstant>1</motorTorqueConstant>
+      </actuator>
+    </transmission>
+
+    <gazebo reference="${name}_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
* Add _diffbot_, similar to the one in https://github.com/ros-controls/ros_controllers/blob/noetic-devel/diff_drive_controller/test/diffbot.xacro, but a bit simpler and with an IMU
* Add IMU test that shows the relative constraints created don't match the ground truth when `differential: true`

```bash
$ make run_tests_fuse_models_rostest_test_imu_2d.test
[ROSTEST]-----------------------------------------------------------------------

[fuse_models.rosunit-imu_2d_test/BaseFrameYawAngularVelocity][FAILURE]----------
/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/test/test_imu_2d.cpp:255
The difference between w and orientation_delta / dt is 0.96695215295635117, which exceeds 1.0e-2, where
w evaluates to 0.48358168580225275,
orientation_delta / dt evaluates to -0.48337046715409837, and
1.0e-2 evaluates to 0.01.
--------------------------------------------------------------------------------


[fuse_models.rosunit-imu_2d_test/BaseFrameYawAngularVelocity][FAILURE]----------
/home/efernandez/dev/ws/cpr_ws/src/fuse/fuse_models/test/test_imu_2d.cpp:306
The difference between w and delta[2] / dt is 0.96695215295635073, which exceeds 1.0e-2, where
w evaluates to 0.48358168580225275,
delta[2] / dt evaluates to -0.48337046715409793, and
1.0e-2 evaluates to 0.01.
--------------------------------------------------------------------------------


SUMMARY
 * RESULT: FAIL
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 1
```

Some tolerances in the test are a bit too large. I believe that's due to the fact I didn't synchronize the transactions generated by the `Imu2D` sensor model and the ground truth. However, I don't think that's really important, because the error is quite large with the current implementation.

I've fixed this in https://github.com/locusrobotics/fuse/pull/268

This is on top of https://github.com/locusrobotics/fuse/pull/266, which was required for the rostest to compile because a header was missing in the `Imu2D` sensor model header file.