### PR TITLE
Add missed geometry_msgs package

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -126,6 +126,7 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(geometry_msgs REQUIRED)
 
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
@@ -436,6 +437,12 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_throttled_callback
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
+  )
+  target_include_directories(test_throttled_callback
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${geometry_msgs_INCLUDE_DIRS}
   )
   set_target_properties(test_throttled_callback
     PROPERTIES

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -20,6 +20,7 @@
   <depend version_gte="1.13.8">rosconsole</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>geometry_msgs</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml" />


### PR DESCRIPTION
Fixes this compilation error:
```bash
/build/source/test/test_throttled_callback.cpp:35:10: fatal error: geometry_msgs/Point.h: No such file or directory
   35 | #include <geometry_msgs/Point.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```