### PR TITLE
Fix Ceres 2.0.0 API support

### DIFF
--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -217,7 +217,8 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
+  using StaticParameters = ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>;
+  return ceres::internal::AutoDifferentiate<kLocalSize, StaticParameters>(
       *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #endif
 }

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -190,7 +190,7 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<PlusFunctor, double, kGlobalSize, kLocalSize>
     ::Differentiate(*plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
+  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
       *plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
 #endif
 }
@@ -217,7 +217,7 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
+  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
       *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #endif
 }


### PR DESCRIPTION
This fixes the following compilation error when building with Ceres Solver 2.0.0 or newer:
```bash
In file included from /build/source/test/test_orientation_3d_stamped.cpp:35:
include/fuse_core/autodiff_local_parameterization.h: In instantiation of bool fuse_core::AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>::ComputeJacobian(const double*, double*) const [with PlusFunctor = Orientation3DPlus; MinusFunctor = Orientation3DMinus; int kGlobalSize = 4; int kLocalSize = 3]:
/build/source/test/test_orientation_3d_stamped.cpp:203:53:   required from here
include/fuse_core/autodiff_local_parameterization.h:193:107: error: no matching function for call to AutoDifferentiate<ceres::internal::StaticParameterDims<4, 3> >(Orientation3DPlus&, const double* [2], int, double [4], double* [2])
  193 |   return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  194 |       *plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                            
In file included from include/fuse_core/autodiff_local_parameterization.h:41,
                 from /build/source/test/test_orientation_3d_stamped.cpp:35:
include/ceres/internal/autodiff.h:309:13: note: candidate: template<int kNumResiduals, class ParameterDims, class Functor, class T> bool ceres::internal::AutoDifferentiate(const Functor&, const T* const*, int, T*, T**)
  309 | inline bool AutoDifferentiate(const Functor& functor,
      |             ^~~~~~~~~~~~~~~~~
include/ceres/internal/autodiff.h:309:13: note:   template argument deduction/substitution failed:
In file included from /build/source/test/test_orientation_3d_stamped.cpp:35:
include/fuse_core/autodiff_local_parameterization.h: In instantiation of bool fuse_core::AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>::ComputeMinusJacobian(const double*, double*) const [with PlusFunctor = Orientation3DPlus; MinusFunctor = Orientation3DMinus; int kGlobalSize = 4; int kLocalSize = 3]:
/build/source/test/test_orientation_3d_stamped.cpp:242:58:   required from here
include/fuse_core/autodiff_local_parameterization.h:220:108: error: no matching function for call to AutoDifferentiate<ceres::internal::StaticParameterDims<4, 4> >(Orientation3DMinus&, const double* [2], int, double [3], double* [2])
  220 |   return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  221 |       *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    
In file included from include/fuse_core/autodiff_local_parameterization.h:41,
                 from /build/source/test/test_orientation_3d_stamped.cpp:35:
include/ceres/internal/autodiff.h:309:13: note: candidate: template<int kNumResiduals, class ParameterDims, class Functor, class T> bool ceres::internal::AutoDifferentiate(const Functor&, const T* const*, int, T*, T**)
  309 | inline bool AutoDifferentiate(const Functor& functor,
      |             ^~~~~~~~~~~~~~~~~
include/ceres/internal/autodiff.h:309:13: note:   template argument deduction/substitution failed:
```

The `internal::AutoDifferentiate` API was changed in https://github.com/ceres-solver/ceres-solver/commit/e7a30359ee754057f9bd7b349c98c291138d91f4, first released in 2.0.0

It's actually an `internal` API, so technically we shouldn't be using it. Either way, this fixes the compilation error.

@iwanders found and fixed this. He's also pointed out that this code is only used in unit tests, but I believe that's indeed intended, since it looks like `fuse_core::AutoDiffLocalParameterization` is used to compute the expected values to compared the actual ones against them, as it's done in https://github.com/locusrobotics/fuse/blob/3825e489ceaba394fb07c87e0e52dce9485da19b/fuse_variables/test/test_orientation_2d_stamped.cpp#L170.