### PR TITLE
fuse -> ROS 2 : Port Logging

### DIFF
--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -38,6 +38,7 @@
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
 #include <fuse_core/transaction.h>
+// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
 #include <ros/callback_queue.h>
 #include <ros/node_handle.h>
 #include <ros/spinner.h>
@@ -67,7 +68,7 @@ namespace fuse_core
  * together (along with any previously existing timestamps). In lieu of a ROS service callback function, the
  * AsyncMotionModel class requires the applyCallback() function to be implemented. This callback will be executed
  * from the same callback queue as any other subscriptions or service callbacks.
- * 
+ *
  * Derived classes:
  * - _probably_ need to implement the onInit() method. This method is used to configure the motion model for operation.
  *   This includes things like accessing the parameter server and subscribing to sensor topics.
@@ -172,13 +173,14 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this motion model instance
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this motion model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
 
   /**
    * @brief Constructor
-   * 
+   *
    * Construct a new motion model and create a local callback queue and thread spinner.
    *
    * @param[in] thread_count The number of threads used to service the local callback queue
@@ -202,16 +204,16 @@ protected:
 
   /**
    * @brief Callback fired in the local callback queue thread(s) whenever a new Graph is received from the optimizer
-   * 
+   *
    * Receiving a new Graph object generally means that new variables have been inserted into the Graph, and new
    * optimized values are available. To simplify synchronization between the sensor models and other consumers of
    * Graph data, the provided Graph object will never be updated be updated by anyone. Thus, only read access to the
    * Graph is provided. Information may be accessed or computed, but it cannot be changed. The optimizer provides
    * the sensors with Graph updates by sending a new Graph object, not by modifying the Graph object.
-   * 
+   *
    * If the derived sensor model does not need access to the Graph object, there is not reason to overload this
    * empty implementation.
-   * 
+   *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
   virtual void onGraphUpdate(Graph::ConstSharedPtr /*graph*/) {}

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -173,7 +173,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this motion model instance
-  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this motion model (TODO(CH3): Uncomment when it's time)
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this motion model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -173,7 +173,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this motion model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this motion model (TODO(CH3): Uncomment when it's time)
+  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this motion model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -38,6 +38,7 @@
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/publisher.h>
 #include <fuse_core/transaction.h>
+// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
 #include <ros/callback_queue.h>
 #include <ros/node_handle.h>
 #include <ros/spinner.h>
@@ -135,6 +136,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this publisher instance
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this publisher (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -136,7 +136,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this publisher instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this publisher (TODO(CH3): Uncomment when it's time)
+  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this publisher (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -136,7 +136,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this publisher instance
-  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this publisher (TODO(CH3): Uncomment when it's time)
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this publisher (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -38,6 +38,7 @@
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/sensor_model.h>
 #include <fuse_core/transaction.h>
+// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
 #include <ros/callback_queue.h>
 #include <ros/node_handle.h>
 #include <ros/spinner.h>
@@ -62,12 +63,12 @@ namespace fuse_core
  * AsyncSensorModel class provides a global and private node handle, both hooked to a local callback queue and local
  * spinner. This makes it act like a full ROS node -- subscriptions trigger message callbacks, callbacks will fire
  * sequentially, etc. However, authors of derived sensor models should be aware of this fact and avoid creating
- * additional node handles, or at least take care when creating new node handles and additional callback queues. 
+ * additional node handles, or at least take care when creating new node handles and additional callback queues.
  * Finally, instead of publishing the generated constraints using a ROS publisher, the asynchronous sensor model
  * provides a "sendTransaction()" method that should be called whenever the sensor is ready to send a
  * fuse_core::Transaction object to the Optimizer. Under the hood, this executes the TransactionCallback that was
  * provided during plugin construction.
- * 
+ *
  * Derived classes:
  * - _must_ implement the onInit() method. This method is used to configure the sensor model for operation.
  *   This includes things like accessing the parameter server and subscribing to sensor topics.
@@ -129,7 +130,7 @@ public:
    * of received sensor data. Instead of the Optimizer periodically checking for new transactions, we provide a
    * "push" mechanism for the sensor model to send the transaction to the Optimizer immediately by calling the callback
    * function provided by the Optimizer. This function will be executed by the SensorModel's thread.
-   * 
+   *
    * This should be called by derived classes whenever a new Transaction is generated, probably from within the sensor
    * message callback function.
    *
@@ -176,6 +177,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this sensor model instance
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
@@ -192,16 +194,16 @@ protected:
 
   /**
    * @brief Callback fired in the local callback queue thread(s) whenever a new Graph is received from the optimizer
-   * 
+   *
    * Receiving a new Graph object generally means that new variables have been inserted into the Graph, and new
    * optimized values are available. To simplify synchronization between the sensor models and other consumers of
    * Graph data, the provided Graph object will never be updated be updated by anyone. Thus, only read access to the
    * Graph is provided. Information may be accessed or computed, but it cannot be changed. The optimizer provides
    * the sensors with Graph updates by sending a new Graph object, not by modifying the Graph object.
-   * 
+   *
    * If the derived sensor model does not need access to the Graph object, there is not reason to overload this
    * empty implementation.
-   * 
+   *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed whenever needed.
    */
   virtual void onGraphUpdate(Graph::ConstSharedPtr /*graph*/) {}
@@ -212,7 +214,7 @@ protected:
    * This could include things like reading from the parameter server or subscribing to topics. The class's node
    * handles will be properly initialized before onInit() is called. Spinning of the callback queue will not begin
    * until after the call to onInit() completes.
-   * 
+   *
    * Derived sensor models classes must implement this function, because otherwise I'm not sure how the derived
    * sensor model would actually do anything.
    */

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -177,7 +177,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this sensor model instance
-  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this sensor model (TODO(CH3): Uncomment when it's time)
+  // rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -177,7 +177,7 @@ public:
 protected:
   ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this sensor model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model (TODO(CH3): Uncomment when it's time)
+  // rclcpp::NodeHandle<???>::SharedPtr nh_;  //!< The node handle for this sensor model (TODO(CH3): Uncomment when it's time)
   ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
   ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
   ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -83,7 +83,7 @@ namespace fuse_core
  * std::future<double> result = callback->getFuture();
  * ros::getGlobalCallbackQueue()->addCallback(callback);
  * result.wait();
- * ROS_INFO_STREAM("The result is: " << result.get());
+ * RCLCPP_INFO_STREAM(rclcpp::get_logger("callback_wrapper"), "The result is: " << result.get());
  * @endcode
  */
 template <typename T>

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -83,7 +83,7 @@ namespace fuse_core
  * std::future<double> result = callback->getFuture();
  * ros::getGlobalCallbackQueue()->addCallback(callback);
  * result.wait();
- * RCLCPP_INFO_STREAM(rclcpp::get_logger("callback_wrapper"), "The result is: " << result.get());
+ * RCLCPP_INFO_STREAM(rclcpp::get_logger("fuse"), "The result is: " << result.get());
  * @endcode
  */
 template <typename T>

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -190,7 +190,7 @@ CERES_OPTION_STRING_DEFINITIONS(VisibilityClusteringType)
  * @param[in] default_value - A default value to use if the provided parameter name does not exist
  * @return The loaded (or default) value
  */
-template <class T>  // TODO(CH3): Replace nh with a node
+template <class T>  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, const T& default_value)
 {
   const std::string default_string_value{ ToString(default_value) };
@@ -217,6 +217,7 @@ T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name
  * @param[in] nh - A node handle in a namespace containing ceres::Covariance::Options settings
  * @param[out] covariance_options - The ceres::Covariance::Options object to update
  */
+// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::Options& covariance_options);
 
 /**
@@ -225,6 +226,7 @@ void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::
  * @param[in] nh - A node handle in a namespace containing ceres::Problem::Options settings
  * @param[out] problem_options - The ceres::Problem::Options object to update
  */
+// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Options& problem_options);
 
 /**
@@ -233,6 +235,7 @@ void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Option
  * @param[in] nh - A node handle in a namespace containing ceres::Solver::Options settings
  * @param[out] solver_options - The ceres::Solver::Options object to update
  */
+// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadSolverOptionsFromROS(const ros::NodeHandle& nh, ceres::Solver::Options& solver_options);
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -190,7 +190,7 @@ CERES_OPTION_STRING_DEFINITIONS(VisibilityClusteringType)
  * @param[in] default_value - A default value to use if the provided parameter name does not exist
  * @return The loaded (or default) value
  */
-template <class T>  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
+template <class T>  // TODO(CH3): Replace nh with a node
 T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, const T& default_value)
 {
   const std::string default_string_value{ ToString(default_value) };
@@ -217,7 +217,6 @@ T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name
  * @param[in] nh - A node handle in a namespace containing ceres::Covariance::Options settings
  * @param[out] covariance_options - The ceres::Covariance::Options object to update
  */
-// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::Options& covariance_options);
 
 /**
@@ -226,7 +225,6 @@ void loadCovarianceOptionsFromROS(const ros::NodeHandle& nh, ceres::Covariance::
  * @param[in] nh - A node handle in a namespace containing ceres::Problem::Options settings
  * @param[out] problem_options - The ceres::Problem::Options object to update
  */
-// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Options& problem_options);
 
 /**
@@ -235,7 +233,6 @@ void loadProblemOptionsFromROS(const ros::NodeHandle& nh, ceres::Problem::Option
  * @param[in] nh - A node handle in a namespace containing ceres::Solver::Options settings
  * @param[out] solver_options - The ceres::Solver::Options object to update
  */
-// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (logging and params probably)
 void loadSolverOptionsFromROS(const ros::NodeHandle& nh, ceres::Solver::Options& solver_options);
 
 }  // namespace fuse_core

--- a/fuse_core/include/fuse_core/ceres_options.h
+++ b/fuse_core/include/fuse_core/ceres_options.h
@@ -36,7 +36,7 @@
 
 #include <fuse_core/ceres_macros.h>
 
-#include <ros/console.h>
+#include <rclcpp/logging.hpp>
 #include <ros/node_handle.h>
 
 #include <ceres/version.h>
@@ -190,7 +190,7 @@ CERES_OPTION_STRING_DEFINITIONS(VisibilityClusteringType)
  * @param[in] default_value - A default value to use if the provided parameter name does not exist
  * @return The loaded (or default) value
  */
-template <class T>
+template <class T>  // TODO(CH3): Replace nh with a node
 T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, const T& default_value)
 {
   const std::string default_string_value{ ToString(default_value) };
@@ -201,9 +201,10 @@ T getParam(const ros::NodeHandle& node_handle, const std::string& parameter_name
   T value;
   if (!FromString(string_value, &value))
   {
-    ROS_WARN_STREAM("The requested " << parameter_name << " (" << string_value
-                                     << ") is not supported. Using the default value (" << default_string_value
-                                     << ") instead.");
+    RCLCPP_WARN_STREAM(node->get_logger(),
+                       "The requested " << parameter_name << " (" << string_value
+                       << ") is not supported. Using the default value (" << default_string_value
+                       << ") instead.");
     value = default_value;
   }
 

--- a/fuse_core/include/fuse_core/console.h
+++ b/fuse_core/include/fuse_core/console.h
@@ -34,11 +34,22 @@
 #ifndef FUSE_CORE_CONSOLE_H
 #define FUSE_CORE_CONSOLE_H
 
-#include <rclcpp/clock.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/time.h>
 
 
 namespace fuse_core
 {
+
+// To replicate ROS 1 behavior, the throttle checking conditions were adapted from the logic here:
+// https://github.com/ros/rosconsole/blob/c9503279e932a04b3d2667cca3d28a8133cacc22/include/ros/console.h
+#if defined(_MSC_VER)
+  #define FUSE_LIKELY(x)       (x)
+  #define FUSE_UNLIKELY(x)     (x)
+#else
+  #define FUSE_LIKELY(x)       __builtin_expect((x),1)
+  #define FUSE_UNLIKELY(x)     __builtin_expect((x),0)
+#endif
 
 /**
  * @brief a log filter that provides a condition to RCLCPP_*_STREAM_EXPRESSION and allows to reset the last time the
@@ -60,23 +71,22 @@ public:
    * @brief Returns whether or not the log statement should be printed. Called before the log arguments are evaluated
    * and the message is formatted.
    *
-   * This works as ROS_*_DELAYED_THROTTLE but the last time the filter condition was hit is handled by this filter, so
+   * This borrows logic from ROS 1's delayed throttle logging, but the last time the filter condition was hit is handled by this filter, so
    * it can be reset.
+   *
+   * @param[in] now - The current ROS time at which to check if logging should fire
    *
    * @return True if the filter condition is hit, false otherwise
    */
-  bool isEnabled() override
+  bool isEnabled(const rclcpp::Time& now)
   {
-    #warn "migrated from ros1, using default clock"
-    const auto now = rclcpp::Clock().now().seconds();
-
     if (last_hit_ < 0.0)
     {
       last_hit_ = now;
       return true;
     }
 
-    if (now > (last_hit_ + period_))
+    if (FUSE_UNLIKELY(last_hit_ + period_ <= now) || FUSE_UNLIKELY(now < last_hit_))
     {
       last_hit_ = now;
       return true;

--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -55,12 +55,12 @@ namespace fuse_core
  * @throws std::runtime_error if the parameter does not exist
  */
 template <typename T>
-void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)
+void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)  // TODO(CH3): Replace nh with a node
 {
   if (!nh.getParam(key, value))
   {
     const std::string error = "Could not find required parameter " + key + " in namespace " + nh.getNamespace();
-    ROS_FATAL_STREAM(error);
+    RCLCPP_FATAL_STREAM(node->get_logger(), error);
     throw std::runtime_error(error);
   }
 }
@@ -77,14 +77,15 @@ void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& valu
 template <typename T,
           typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
 void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T& default_value,
-                      const bool strict = true)
+                      const bool strict = true)  // TODO(CH3): Replace nh with a node
 {
   T value;
   node_handle.param(parameter_name, value, default_value);
   if (value < 0 || (strict && value == 0))
   {
-    ROS_WARN_STREAM("The requested " << parameter_name << " is <" << (strict ? "=" : "") <<
-                    " 0. Using the default value (" << default_value << ") instead.");
+    RCLCPP_WARN_STREAM(node->get_logger(),
+                       "The requested " << parameter_name << " is <" << (strict ? "=" : "")
+                       << " 0. Using the default value (" << default_value << ") instead.");
   }
   else
   {

--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -55,7 +55,7 @@ namespace fuse_core
  * @throws std::runtime_error if the parameter does not exist
  */
 template <typename T>
-void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)  // TODO(CH3): Replace nh with a node
+void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 {
   if (!nh.getParam(key, value))
   {
@@ -77,7 +77,7 @@ void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& valu
 template <typename T,
           typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
 void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T& default_value,
-                      const bool strict = true)  // TODO(CH3): Replace nh with a node
+                      const bool strict = true)  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 {
   T value;
   node_handle.param(parameter_name, value, default_value);
@@ -124,6 +124,7 @@ inline void getPositiveParam(const ros::NodeHandle& node_handle, const std::stri
  * @return The loaded (or default) covariance matrix, generated from the diagonal vector
  */
 template <int Size, typename Scalar = double>
+// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::NodeHandle& node_handle,
                                                                  const std::string& parameter_name,
                                                                  Scalar default_value)
@@ -156,6 +157,7 @@ fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::Node
  * @param[in] name - The ROS parameter name for the loss configuration parameter
  * @return Loss function or nullptr if the parameter does not exist
  */
+// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 inline fuse_core::Loss::SharedPtr loadLossConfig(const ros::NodeHandle& nh, const std::string& name)
 {
   if (!nh.hasParam(name))

--- a/fuse_core/include/fuse_core/parameter.h
+++ b/fuse_core/include/fuse_core/parameter.h
@@ -55,7 +55,7 @@ namespace fuse_core
  * @throws std::runtime_error if the parameter does not exist
  */
 template <typename T>
-void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
+void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& value)  // TODO(CH3): Replace nh with a node
 {
   if (!nh.getParam(key, value))
   {
@@ -77,7 +77,7 @@ void getParamRequired(const ros::NodeHandle& nh, const std::string& key, T& valu
 template <typename T,
           typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
 void getPositiveParam(const ros::NodeHandle& node_handle, const std::string& parameter_name, T& default_value,
-                      const bool strict = true)  // TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
+                      const bool strict = true)  // TODO(CH3): Replace nh with a node
 {
   T value;
   node_handle.param(parameter_name, value, default_value);
@@ -124,7 +124,6 @@ inline void getPositiveParam(const ros::NodeHandle& node_handle, const std::stri
  * @return The loaded (or default) covariance matrix, generated from the diagonal vector
  */
 template <int Size, typename Scalar = double>
-// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::NodeHandle& node_handle,
                                                                  const std::string& parameter_name,
                                                                  Scalar default_value)
@@ -157,7 +156,6 @@ fuse_core::Matrix<Scalar, Size, Size> getCovarianceDiagonalParam(const ros::Node
  * @param[in] name - The ROS parameter name for the loss configuration parameter
  * @return Loss function or nullptr if the parameter does not exist
  */
-// TODO(CH3): Replace nh with an rclcpp NodeHandle<???> (params probably)
 inline fuse_core::Loss::SharedPtr loadLossConfig(const ros::NodeHandle& nh, const std::string& name)
 {
   if (!nh.hasParam(name))

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -34,8 +34,8 @@
 #ifndef FUSE_CORE_UTIL_H
 #define FUSE_CORE_UTIL_H
 
-//#include <ros/console.h>
-//#include <ros/node_handle.h>
+#include <rclcpp/logging.hpp>
+#include <ros/node_handle.h>
 
 #include <ceres/jet.h>
 #include <Eigen/Core>

--- a/fuse_models/include/fuse_models/common/sensor_config.h
+++ b/fuse_models/include/fuse_models/common/sensor_config.h
@@ -42,7 +42,7 @@
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
-#include <ros/console.h>
+#include <rclcpp/logging.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -65,7 +65,7 @@ namespace common
 inline void throwDimensionError(const std::string& dimension)
 {
   std::string error = "Dimension " + dimension + " is not valid for this type.";
-  ROS_ERROR_STREAM(error);
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("sensor_config"), error);
   throw std::runtime_error(error);
 }
 

--- a/fuse_models/include/fuse_models/common/sensor_config.h
+++ b/fuse_models/include/fuse_models/common/sensor_config.h
@@ -65,7 +65,7 @@ namespace common
 inline void throwDimensionError(const std::string& dimension)
 {
   std::string error = "Dimension " + dimension + " is not valid for this type.";
-  RCLCPP_ERROR_STREAM(rclcpp::get_logger("sensor_config"), error);
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("fuse"), error);
   throw std::runtime_error(error);
 }
 

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -245,7 +245,7 @@ bool transformMessage(
   }
   catch (const tf2::TransformException& ex)
   {
-    RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 5.0 * 1000,
+    RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 5.0 * 1000,
                                           "Could not transform message from " << input.header.frame_id << " to "
                                           << output.header.frame_id << ". Error was " << ex.what());
   }
@@ -300,7 +300,7 @@ inline bool processAbsolutePoseWithCovariance(
     if (!transformMessage(tf_buffer, pose, transformed_message, tf_timeout))
     {
       RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
-        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+        rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
         "Failed to transform pose message with stamp " << pose.header.stamp << ". Cannot create constraint.");
       return false;
     }
@@ -350,7 +350,7 @@ inline bool processAbsolutePoseWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                    "Invalid partial absolute pose measurement from '" << source
                                    << "' source: " << ex.what());
       return false;
@@ -693,7 +693,7 @@ inline bool processDifferentialPoseWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                    "Invalid partial differential pose measurement from '"
                                    << source << "' source: " << ex.what());
       return false;
@@ -849,7 +849,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
 
   if (dt < 1e-6)
   {
-    RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+    RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                  "Very small time difference " << dt << "s from '" << source << "' source.");
     return false;
   }
@@ -883,7 +883,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                    "Invalid partial differential pose measurement using the twist covariance from '"
                                    << source << "' source: " << ex.what());
       return false;
@@ -965,7 +965,7 @@ inline bool processTwistWithCovariance(
     if (!transformMessage(tf_buffer, twist, transformed_message, tf_timeout))
     {
       RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
-        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+        rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
         "Failed to transform twist message with stamp " << twist.header.stamp << ". Cannot create constraint.");
       return false;
     }
@@ -1014,7 +1014,7 @@ inline bool processTwistWithCovariance(
       }
       catch (const std::runtime_error& ex)
       {
-        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                      "Invalid partial linear velocity measurement from '"
                                      << source << "' source: " << ex.what());
         add_constraint = false;
@@ -1057,7 +1057,7 @@ inline bool processTwistWithCovariance(
       }
       catch (const std::runtime_error& ex)
       {
-        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0,
+        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0,
                                      "Invalid partial angular velocity measurement from '"
                                      << source << "' source: " << ex.what());
         add_constraint = false;
@@ -1132,7 +1132,7 @@ inline bool processAccelWithCovariance(
     if (!transformMessage(tf_buffer, acceleration, transformed_message, tf_timeout))
     {
       RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
-        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0,
+        rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0,
         "Failed to transform acceleration message with stamp " << acceleration.header.stamp
                                                                << ". Cannot create constraint.");
       return false;
@@ -1170,7 +1170,7 @@ inline bool processAccelWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                    "Invalid partial linear acceleration measurement from '"
                                    << source << "' source: " << ex.what());
       return false;

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -52,6 +52,7 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
+#include <rclcpp/clock.hpp>
 #include <ros/ros.h>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/LinearMath/Vector3.h>
@@ -244,8 +245,9 @@ bool transformMessage(
   }
   catch (const tf2::TransformException& ex)
   {
-    ROS_WARN_STREAM_DELAYED_THROTTLE(5.0, "Could not transform message from " << input.header.frame_id << " to " <<
-      output.header.frame_id << ". Error was " << ex.what());
+    RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 5.0 * 1000,
+                                          "Could not transform message from " << input.header.frame_id << " to "
+                                          << output.header.frame_id << ". Error was " << ex.what());
   }
 
   return false;
@@ -297,8 +299,8 @@ inline bool processAbsolutePoseWithCovariance(
 
     if (!transformMessage(tf_buffer, pose, transformed_message, tf_timeout))
     {
-      ROS_WARN_STREAM_DELAYED_THROTTLE(
-        10.0,
+      RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
+        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
         "Failed to transform pose message with stamp " << pose.header.stamp << ". Cannot create constraint.");
       return false;
     }
@@ -348,8 +350,9 @@ inline bool processAbsolutePoseWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial absolute pose measurement from '" << source
-                                                                                         << "' source: " << ex.what());
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                   "Invalid partial absolute pose measurement from '" << source
+                                   << "' source: " << ex.what());
       return false;
     }
   }
@@ -690,8 +693,9 @@ inline bool processDifferentialPoseWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial differential pose measurement from '"
-                                          << source << "' source: " << ex.what());
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                   "Invalid partial differential pose measurement from '"
+                                   << source << "' source: " << ex.what());
       return false;
     }
   }
@@ -845,7 +849,8 @@ inline bool processDifferentialPoseWithTwistCovariance(
 
   if (dt < 1e-6)
   {
-    ROS_ERROR_STREAM_THROTTLE(10.0, "Very small time difference " << dt << "s from '" << source << "' source.");
+    RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                 "Very small time difference " << dt << "s from '" << source << "' source.");
     return false;
   }
 
@@ -878,8 +883,9 @@ inline bool processDifferentialPoseWithTwistCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial differential pose measurement using the twist covariance from '"
-                                          << source << "' source: " << ex.what());
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                   "Invalid partial differential pose measurement using the twist covariance from '"
+                                   << source << "' source: " << ex.what());
       return false;
     }
   }
@@ -958,8 +964,8 @@ inline bool processTwistWithCovariance(
 
     if (!transformMessage(tf_buffer, twist, transformed_message, tf_timeout))
     {
-      ROS_WARN_STREAM_DELAYED_THROTTLE(
-        10.0,
+      RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
+        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
         "Failed to transform twist message with stamp " << twist.header.stamp << ". Cannot create constraint.");
       return false;
     }
@@ -1008,8 +1014,9 @@ inline bool processTwistWithCovariance(
       }
       catch (const std::runtime_error& ex)
       {
-        ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial linear velocity measurement from '"
-                                            << source << "' source: " << ex.what());
+        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                     "Invalid partial linear velocity measurement from '"
+                                     << source << "' source: " << ex.what());
         add_constraint = false;
       }
     }
@@ -1050,8 +1057,9 @@ inline bool processTwistWithCovariance(
       }
       catch (const std::runtime_error& ex)
       {
-        ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial angular velocity measurement from '"
-                                            << source << "' source: " << ex.what());
+        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0,
+                                     "Invalid partial angular velocity measurement from '"
+                                     << source << "' source: " << ex.what());
         add_constraint = false;
       }
     }
@@ -1123,8 +1131,8 @@ inline bool processAccelWithCovariance(
 
     if (!transformMessage(tf_buffer, acceleration, transformed_message, tf_timeout))
     {
-      ROS_WARN_STREAM_DELAYED_THROTTLE(
-        10.0,
+      RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(
+        rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0,
         "Failed to transform acceleration message with stamp " << acceleration.header.stamp
                                                                << ". Cannot create constraint.");
       return false;
@@ -1162,8 +1170,9 @@ inline bool processAccelWithCovariance(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid partial linear acceleration measurement from '"
-                                          << source << "' source: " << ex.what());
+      RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger("sensor_proc"), rclcpp::Clock(), 10.0 * 1000,
+                                   "Invalid partial linear acceleration measurement from '"
+                                   << source << "' source: " << ex.what());
       return false;
     }
   }

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -70,7 +70,7 @@ public:
    *
    * @param[in] nh - The ROS node handle with which to load parameters
    */
-  void loadFromROS(const ros::NodeHandle& nh) final  // TODO(CH3): Replace with an rclcpp NodeHandle<???> (params interface probably)
+  void loadFromROS(const ros::NodeHandle& nh) final  // TODO(CH3): Replace with a NodePtr
   {
     nh.getParam("publish_tf", publish_tf);
     nh.getParam("invert_tf", invert_tf);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -70,7 +70,7 @@ public:
    *
    * @param[in] nh - The ROS node handle with which to load parameters
    */
-  void loadFromROS(const ros::NodeHandle& nh) final  // TODO(CH3): Replace with a NodePtr
+  void loadFromROS(const ros::NodeHandle& nh) final  // TODO(CH3): Replace with an rclcpp NodeHandle<???> (params interface probably)
   {
     nh.getParam("publish_tf", publish_tf);
     nh.getParam("invert_tf", invert_tf);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -40,7 +40,7 @@
 #include <fuse_core/eigen.h>
 #include <fuse_core/parameter.h>
 
-#include <ros/console.h>
+#include <rclcpp/logging.hpp>
 #include <ros/node_handle.h>
 
 #include <ceres/covariance.h>
@@ -70,7 +70,7 @@ public:
    *
    * @param[in] nh - The ROS node handle with which to load parameters
    */
-  void loadFromROS(const ros::NodeHandle& nh) final
+  void loadFromROS(const ros::NodeHandle& nh) final  // TODO(CH3): Replace with a NodePtr
   {
     nh.getParam("publish_tf", publish_tf);
     nh.getParam("invert_tf", invert_tf);
@@ -105,10 +105,11 @@ public:
 
     if (!frames_valid)
     {
-      ROS_FATAL_STREAM("Invalid frame configuration! Please note:\n" <<
-        " - The values for map_frame_id, odom_frame_id, and base_link_frame_id must be unique\n" <<
-        " - The values for map_frame_id, odom_frame_id, and base_link_output_frame_id must be unique\n" <<
-        " - The world_frame_id must be the same as the map_frame_id or odom_frame_id\n");
+      RCLCPP_FATAL_STREAM(node->get_logger(),
+        "Invalid frame configuration! Please note:\n"
+        << " - The values for map_frame_id, odom_frame_id, and base_link_frame_id must be unique\n"
+        << " - The values for map_frame_id, odom_frame_id, and base_link_output_frame_id must be unique\n"
+        << " - The world_frame_id must be the same as the map_frame_id or odom_frame_id\n");
 
       assert(frames_valid);
     }

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -68,8 +68,9 @@ void Acceleration2D::onInit()
 
   if (params_.indices.empty())
   {
-    ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
-                    " will be ignored.");
+    RCLCPP_WARN_STREAM(node_->get_logger(),
+                      "No dimensions were specified. Data from topic "
+                       << ros::names::resolve(params_.topic) << " will be ignored.");
   }
 }
 

--- a/fuse_models/src/graph_ignition.cpp
+++ b/fuse_models/src/graph_ignition.cpp
@@ -88,7 +88,7 @@ void GraphIgnition::subscriberCallback(const fuse_msgs::SerializedGraph::ConstPt
   }
   catch (const std::exception& e)
   {
-    ROS_ERROR_STREAM(e.what() << " Ignoring message.");
+    RCLCPP_ERROR_STREAM(node_->get_logger(), e.what() << " Ignoring message.");
   }
 }
 
@@ -103,7 +103,7 @@ bool GraphIgnition::setGraphServiceCallback(fuse_models::SetGraph::Request& req,
   {
     res.success = false;
     res.message = e.what();
-    ROS_ERROR_STREAM(e.what() << " Ignoring request.");
+    RCLCPP_ERROR_STREAM(node_->get_logger(), e.what() << " Ignoring request.");
   }
   return true;
 }
@@ -136,7 +136,8 @@ void GraphIgnition::process(const fuse_msgs::SerializedGraph& msg)
     // Wait for the reset service
     while (!reset_client_.waitForExistence(ros::Duration(10.0)) && ros::ok())
     {
-      ROS_WARN_STREAM("Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
+      RCLCPP_WARN_STREAM(node_->get_logger(),
+                         "Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
     }
 
     auto srv = std_srvs::Empty();
@@ -186,9 +187,10 @@ void GraphIgnition::sendGraph(const fuse_core::Graph& graph, const ros::Time& st
   // Send the transaction to the optimizer.
   sendTransaction(transaction);
 
-  ROS_INFO_STREAM("Received a set_graph request (stamp: "
-                  << transaction->stamp() << ", constraints: " << boost::size(transaction->addedConstraints())
-                  << ", variables: " << boost::size(transaction->addedVariables()) << ")");
+  RCLCPP_INFO_STREAM(node_->get_logger(),
+                     "Received a set_graph request (stamp: " << transaction->stamp() << ", constraints: "
+                     << boost::size(transaction->addedConstraints()) << ", variables: "
+                     << boost::size(transaction->addedVariables()) << ")");
 }
 
 }  // namespace fuse_models

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -76,8 +76,9 @@ void Imu2D::onInit()
       params_.linear_acceleration_indices.empty() &&
       params_.angular_velocity_indices.empty())
   {
-    ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
-                    " will be ignored.");
+    RCLCPP_WARN_STREAM(node_->get_logger(),
+                       "No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic)
+                       << " will be ignored.");
   }
 }
 
@@ -224,9 +225,9 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp " << pose.header.stamp
-                                                                              << " to orientation target frame "
-                                                                              << params_.orientation_target_frame);
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+                                "Cannot transform pose message with stamp " << pose.header.stamp
+                                << " to orientation target frame " << params_.orientation_target_frame);
     return;
   }
 
@@ -244,9 +245,9 @@ void Imu2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped& 
 
     if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
     {
-      ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform twist message with stamp " << twist.header.stamp
-                                                                                 << " to twist target frame "
-                                                                                 << params_.twist_target_frame);
+      RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+                                  "Cannot transform twist message with stamp " << twist.header.stamp
+                                  << " to twist target frame " << params_.twist_target_frame);
     }
     else
     {

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -76,8 +76,9 @@ void Odometry2D::onInit()
       params_.linear_velocity_indices.empty() &&
       params_.angular_velocity_indices.empty())
   {
-    ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
-                    " will be ignored.");
+    RCLCPP_WARN_STREAM(node_->get_logger(),
+                       "No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic)
+                       << " will be ignored.");
   }
 }
 
@@ -167,8 +168,9 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp "
-                                      << pose.header.stamp << " to pose target frame " << params_.pose_target_frame);
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+                                "Cannot transform pose message with stamp "
+                                << pose.header.stamp << " to pose target frame " << params_.pose_target_frame);
     return;
   }
 
@@ -186,9 +188,9 @@ void Odometry2D::processDifferential(const geometry_msgs::PoseWithCovarianceStam
 
     if (!common::transformMessage(tf_buffer_, twist, transformed_twist))
     {
-      ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform twist message with stamp " << twist.header.stamp
-                                                                                 << " to twist target frame "
-                                                                                 << params_.twist_target_frame);
+      RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+                                  "Cannot transform twist message with stamp " << twist.header.stamp
+                                  << " to twist target frame " << params_.twist_target_frame);
     }
     else
     {

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -111,8 +111,9 @@ void Odometry2DPublisher::notifyCallback(
       latest_stamp_ = latest_stamp;
     }
 
-    ROS_WARN_STREAM_THROTTLE(
-        10.0, "Failed to find a matching set of state variables with device id '" << device_id_ << "'.");
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 10.0 * 1000,
+                                "Failed to find a matching set of state variables with device id '"
+                                << device_id_ << "'.");
     return;
   }
 
@@ -203,8 +204,9 @@ void Odometry2DPublisher::notifyCallback(
       }
       catch (const std::exception& e)
       {
-        ROS_WARN_STREAM("An error occurred computing the covariance information for " << latest_stamp << ". "
-                        "The covariance will be set to zero.\n" << e.what());
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+                           "An error occurred computing the covariance information for " << latest_stamp
+                           << ". The covariance will be set to zero.\n" << e.what());
         std::fill(odom_output.pose.covariance.begin(), odom_output.pose.covariance.end(), 0.0);
         std::fill(odom_output.twist.covariance.begin(), odom_output.twist.covariance.end(), 0.0);
         std::fill(acceleration_output.accel.covariance.begin(), acceleration_output.accel.covariance.end(), 0.0);
@@ -305,12 +307,14 @@ bool Odometry2DPublisher::getState(
   }
   catch (const std::exception& e)
   {
-    ROS_WARN_STREAM_THROTTLE(10.0, "Failed to find a state at time " << stamp << ". Error: " << e.what());
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 10.0 * 1000,
+                                "Failed to find a state at time " << stamp << ". Error: " << e.what());
     return false;
   }
   catch (...)
   {
-    ROS_WARN_STREAM_THROTTLE(10.0, "Failed to find a state at time " << stamp << ". Error: unknown");
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 10.0 * 1000,
+                                "Failed to find a state at time " << stamp << ". Error: unknown");
     return false;
   }
 
@@ -336,8 +340,9 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 
   if (latest_stamp == Synchronizer::TIME_ZERO)
   {
-    RCLCPP_WARN_STREAM_EXPRESSION(node_->get_logger(), delayed_throttle_filter_.isEnabled(),
-                                  "No valid state data yet. Delaying tf broadcast.");
+    RCLCPP_WARN_STREAM_EXPRESSION(
+      node_->get_logger(), delayed_throttle_filter_.isEnabled(),
+      "No valid state data yet. Delaying tf broadcast.");
     return;
   }
 
@@ -507,8 +512,10 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
       }
       catch (const std::exception& e)
       {
-        ROS_WARN_STREAM_THROTTLE(5.0, "Could not lookup the " << params_.base_link_frame_id << "->" <<
-          params_.odom_frame_id << " transform. Error: " << e.what());
+        RCLCPP_WARN_STREAM_THROTTLE(
+          node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+          "Could not lookup the " << params_.base_link_frame_id << "->"
+          << params_.odom_frame_id<< " transform. Error: " << e.what());
 
         return;
       }

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -72,8 +72,9 @@ void Pose2D::onInit()
   if (params_.position_indices.empty() &&
       params_.orientation_indices.empty())
   {
-    ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
-                    " will be ignored.");
+    RCLCPP_WARN_STREAM(node_->get_logger(),
+                       "No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic)
+                       << " will be ignored.");
   }
 }
 
@@ -133,8 +134,9 @@ void Pose2D::processDifferential(const geometry_msgs::PoseWithCovarianceStamped&
 
   if (!common::transformMessage(tf_buffer_, pose, *transformed_pose))
   {
-    ROS_WARN_STREAM_THROTTLE(5.0, "Cannot transform pose message with stamp "
-                                      << pose.header.stamp << " to target frame " << params_.target_frame);
+    RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 5.0 * 1000,
+                                "Cannot transform pose message with stamp " << pose.header.stamp
+                                << " to target frame " << params_.target_frame);
     return;
   }
 

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -69,8 +69,9 @@ void Twist2D::onInit()
   if (params_.linear_indices.empty() &&
       params_.angular_indices.empty())
   {
-    ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
-                    " will be ignored.");
+    RCLCPP_WARN_STREAM(node_->get_logger(),
+                       "No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic)
+                       << " will be ignored.");
   }
 }
 

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -180,7 +180,8 @@ bool Unicycle2D::applyCallback(fuse_core::Transaction& transaction)
   }
   catch (const std::exception& e)
   {
-    ROS_ERROR_STREAM_THROTTLE(10.0, "An error occurred while completing the motion model query. Error: " << e.what());
+    RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 10.0 * 1000,
+                                 "An error occurred while completing the motion model query. Error: " << e.what());
     return false;
   }
   return true;
@@ -244,8 +245,9 @@ void Unicycle2D::generateMotionModel(
   auto base_state_pair_it = state_history_.upper_bound(beginning_stamp);
   if (base_state_pair_it == state_history_.begin())
   {
-    ROS_WARN_STREAM_COND_NAMED(!state_history_.empty(), "UnicycleModel", "Unable to locate a state in this history "
-                               "with stamp <= " << beginning_stamp << ". Variables will all be initialized to 0.");
+    RCLCPP_WARN_STREAM_EXPRESSION(node_->get_logger(), !state_history_.empty(),
+                                  "UnicycleModel", "Unable to locate a state in this history with stamp <= "
+                                  << beginning_stamp << ". Variables will all be initialized to 0.");
     base_time = beginning_stamp;
   }
   else
@@ -367,7 +369,8 @@ void Unicycle2D::generateMotionModel(
     }
     catch (const std::runtime_error& ex)
     {
-      ROS_ERROR_STREAM_THROTTLE(10.0, "Invalid '" << name_ << "' motion model: " << ex.what());
+      RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 10.0 * 1000,
+                                   "Invalid '" << name_ << "' motion model: " << ex.what());
       return;
     }
   }

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -140,7 +140,7 @@ void Unicycle2DIgnition::subscriberCallback(const geometry_msgs::PoseWithCovaria
   }
   catch (const std::exception& e)
   {
-    ROS_ERROR_STREAM(e.what() << " Ignoring message.");
+    RCLCPP_ERROR_STREAM(node_->get_logger(), e.what() << " Ignoring message.");
   }
 }
 
@@ -155,7 +155,7 @@ bool Unicycle2DIgnition::setPoseServiceCallback(fuse_models::SetPose::Request& r
   {
     res.success = false;
     res.message = e.what();
-    ROS_ERROR_STREAM(e.what() << " Ignoring request.");
+    RCLCPP_ERROR_STREAM(node_->get_logger(), e.what() << " Ignoring request.");
   }
   return true;
 }
@@ -171,7 +171,7 @@ bool Unicycle2DIgnition::setPoseDeprecatedServiceCallback(
   }
   catch (const std::exception& e)
   {
-    ROS_ERROR_STREAM(e.what() << " Ignoring request.");
+    RCLCPP_ERROR_STREAM(node_->get_logger(), e.what() << " Ignoring request.");
     return false;
   }
 }
@@ -229,7 +229,8 @@ void Unicycle2DIgnition::process(const geometry_msgs::PoseWithCovarianceStamped&
     // Wait for the reset service
     while (!reset_client_.waitForExistence(ros::Duration(10.0)) && ros::ok())
     {
-      ROS_WARN_STREAM("Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
+      RCLCPP_WARN_STREAM(node_->get_logger(),
+                         "Waiting for '" << reset_client_.getService() << "' service to become avaiable.");
     }
 
     auto srv = std_srvs::Empty();
@@ -331,8 +332,9 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::PoseWithCovarianceStampe
   // Send the transaction to the optimizer.
   sendTransaction(transaction);
 
-  ROS_INFO_STREAM("Received a set_pose request (stamp: " << stamp << ", x: " << position->x() << ", y: " <<
-                  position->y() << ", yaw: " << orientation->yaw() << ")");
+  RCLCPP_INFO_STREAM(node_->get_logger(),
+                     "Received a set_pose request (stamp: " << stamp << ", x: " << position->x() << ", y: "
+                     << position->y() << ", yaw: " << orientation->yaw() << ")");
 }
 
 }  // namespace fuse_models

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -43,6 +43,7 @@
 #include <fuse_core/transaction.h>
 #include <pluginlib/class_loader.hpp>
 #include <ros/ros.h>
+// #include <rclcpp/rclcpp.hpp> TODO(CH3): Uncomment when it's time
 
 #include <string>
 #include <unordered_map>
@@ -90,7 +91,7 @@ namespace fuse_optimizers
  *  - ...
  * @endcode
  */
-class Optimizer
+class Optimizer // : public rclcpp::Node TODO(CH3): Uncomment when it's time
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Optimizer)

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -99,10 +99,11 @@ void BatchOptimizer::applyMotionModelsToQueue()
       if (element.transaction->stamp() + params_.transaction_timeout < current_time)
       {
         // Warn that this transaction has expired, then skip it.
-        ROS_ERROR_STREAM("The queued transaction with timestamp " << element.transaction->stamp()
-                          << " could not be processed after " << (current_time - element.transaction->stamp())
-                          << " seconds, which is greater than the 'transaction_timeout' value of "
-                          << params_.transaction_timeout << ". Ignoring this transaction.");
+        RCLCPP_ERROR_STREAM(this->get_logger(),
+                            "The queued transaction with timestamp " << element.transaction->stamp()
+                            << " could not be processed after " << (current_time - element.transaction->stamp())
+                            << " seconds, which is greater than the 'transaction_timeout' value of "
+                            << params_.transaction_timeout << ". Ignoring this transaction.");
         pending_transactions_.erase(pending_transactions_.begin());
         continue;
       }

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -268,9 +268,10 @@ void Optimizer::loadSensorModels()
         associated_motion_models_[config.name].push_back(motion_model_name);
         if (motion_models_.find(motion_model_name) == motion_models_.end())
         {
-          ROS_WARN_STREAM("Sensor model '" << config.name << "' is configured to use motion model '" <<
-                          motion_model_name << "', but no motion model with that name currently exists. This is " <<
-                          "likely a configuration error.");
+          RCLCPP_WARN_STREAM(this->get_logger(),
+                             "Sensor model '" << config.name << "' is configured to use motion model '"
+                             << motion_model_name << "', but no motion model with that name currently exists. "
+                             << "This is likely a configuration error.");
         }
       }
     }
@@ -367,8 +368,9 @@ bool Optimizer::applyMotionModels(
     }
     catch (const std::exception& e)
     {
-      ROS_ERROR_STREAM("Error generating constraints for sensor '" << sensor_name << "' "
-                       << "from motion model '" << motion_model_name << "'. Error: " << e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(),
+                          "Error generating constraints for sensor '" << sensor_name << "' "
+                          << "from motion model '" << motion_model_name << "'. Error: " << e.what());
       success = false;
     }
   }
@@ -387,8 +389,9 @@ void Optimizer::notify(
     }
     catch (const std::exception& e)
     {
-      ROS_ERROR_STREAM("Failed calling graphCallback() on sensor '" << name__sensor_model.first << "'. " <<
-                       "Error: " << e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(),
+                          "Failed calling graphCallback() on sensor '" << name__sensor_model.first
+                          << "'. Error: " << e.what());
       continue;
     }
   }
@@ -400,8 +403,9 @@ void Optimizer::notify(
     }
     catch (const std::exception& e)
     {
-      ROS_ERROR_STREAM("Failed calling graphCallback() on motion model '" << name__motion_model.first << "." <<
-                       " Error: " << e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(),
+                          "Failed calling graphCallback() on motion model '" << name__motion_model.first
+                          << ". Error: " << e.what());
       continue;
     }
   }
@@ -413,8 +417,9 @@ void Optimizer::notify(
     }
     catch (const std::exception& e)
     {
-      ROS_ERROR_STREAM("Failed calling notify() on publisher '" << name__publisher.first << "." <<
-                       " Error: " << e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(),
+                          "Failed calling notify() on publisher '" << name__publisher.first
+                          << ". Error: " << e.what());
       continue;
     }
   }

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -85,13 +85,13 @@ bool findPose(
   }
   catch (const std::exception& e)
   {
-    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("pose_2d_publisher"), rclcpp::Clock(), 10.0 * 1000,
+    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                 "Failed to find a pose at time " << stamp << ". Error" << e.what());
     return false;
   }
   catch (...)
   {
-    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("pose_2d_publisher"), rclcpp::Clock(), 10.0 * 1000,
+    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
                                 "Failed to find a pose at time " << stamp << ". Error: unknown");
     return false;
   }

--- a/fuse_tutorials/src/range_sensor_model.cpp
+++ b/fuse_tutorials/src/range_sensor_model.cpp
@@ -61,7 +61,7 @@ void RangeSensorModel::priorBeaconsCallback(const sensor_msgs::PointCloud2::Cons
   {
     beacon_db_[*id_it] = Beacon { *x_it, *y_it, *sigma_it };
   }
-  ROS_INFO_STREAM("Updated Beacon Database.");
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Updated Beacon Database.");
 }
 
 void RangeSensorModel::onInit()

--- a/fuse_viz/src/mapped_covariance_visual.cpp
+++ b/fuse_viz/src/mapped_covariance_visual.cpp
@@ -122,7 +122,7 @@ void computeShapeScaleAndOrientation3D(const Eigen::Matrix3d& covariance, Ogre::
   else
   {
     RCLCPP_WARN_THROTTLE(
-      rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
+      rclcpp::get_logger("fuse"), rclcpp::Clock(), 1000,
       "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
     eigenvalues = Eigen::Vector3d::Zero();  // Setting the scale to zero will hide it on the screen
     eigenvectors = Eigen::Matrix3d::Identity();
@@ -167,7 +167,7 @@ void computeShapeScaleAndOrientation2D(const Eigen::Matrix2d& covariance, Ogre::
   else
   {
     RCLCPP_WARN_THROTTLE(
-      rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
+      rclcpp::get_logger("fuse"), rclcpp::Clock(), 1000,
       "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
     eigenvalues = Eigen::Vector2d::Zero();  // Setting the scale to zero will hide it on the screen
     eigenvectors = Eigen::Matrix2d::Identity();
@@ -314,9 +314,7 @@ void MappedCovarianceVisual::setCovariance(const geometry_msgs::PoseWithCovarian
   {
     if (std::isnan(pose.covariance[i]))
     {
-      RCLCPP_WARN_THROTTLE(
-        rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
-        "covariance contains NaN");
+      RCLCPP_WARN_THROTTLE(rclcpp::get_logger("fuse"), rclcpp::Clock(), 1000, "covariance contains NaN");
       return;
     }
   }
@@ -374,9 +372,7 @@ void MappedCovarianceVisual::updatePosition(const Eigen::Matrix6d& covariance)
   }
   else
   {
-    RCLCPP_WARN_STREAM(
-      rclcpp::get_logger("mapped_covariance_visual"),
-      "position shape_scale contains NaN: " << shape_scale);
+    RCLCPP_WARN_STREAM(rclcpp::get_logger("fuse"), "position shape_scale contains NaN: " << shape_scale);
   }
 }
 
@@ -447,9 +443,7 @@ void MappedCovarianceVisual::updateOrientation(const Eigen::Matrix6d& covariance
   }
   else
   {
-    RCLCPP_WARN_STREAM(
-      rclcpp::get_logger("mapped_covariance_visual"),
-      "orientation shape_scale contains NaN: " << shape_scale);
+    RCLCPP_WARN_STREAM(rclcpp::get_logger("fuse"), "orientation shape_scale contains NaN: " << shape_scale);
   }
 }
 

--- a/fuse_viz/src/mapped_covariance_visual.cpp
+++ b/fuse_viz/src/mapped_covariance_visual.cpp
@@ -36,7 +36,8 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
-#include <ros/console.h>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logging.hpp>
 
 #include <sstream>
 
@@ -120,7 +121,9 @@ void computeShapeScaleAndOrientation3D(const Eigen::Matrix3d& covariance, Ogre::
   }
   else
   {
-    ROS_WARN_THROTTLE(1, "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
+      "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
     eigenvalues = Eigen::Vector3d::Zero();  // Setting the scale to zero will hide it on the screen
     eigenvectors = Eigen::Matrix3d::Identity();
   }
@@ -163,7 +166,9 @@ void computeShapeScaleAndOrientation2D(const Eigen::Matrix2d& covariance, Ogre::
   }
   else
   {
-    ROS_WARN_THROTTLE(1, "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
+      "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
     eigenvalues = Eigen::Vector2d::Zero();  // Setting the scale to zero will hide it on the screen
     eigenvectors = Eigen::Matrix2d::Identity();
   }
@@ -309,7 +314,9 @@ void MappedCovarianceVisual::setCovariance(const geometry_msgs::PoseWithCovarian
   {
     if (std::isnan(pose.covariance[i]))
     {
-      ROS_WARN_THROTTLE(1, "covariance contains NaN");
+      RCLCPP_WARN_THROTTLE(
+        rclcpp::get_logger("mapped_covariance_visual"), rclcpp::Clock(), 1000,
+        "covariance contains NaN");
       return;
     }
   }
@@ -362,9 +369,15 @@ void MappedCovarianceVisual::updatePosition(const Eigen::Matrix6d& covariance)
   // Rotate and scale the position scene node
   position_node_->setOrientation(shape_orientation);
   if (!shape_scale.isNaN())
+  {
     position_node_->setScale(shape_scale);
+  }
   else
-    ROS_WARN_STREAM("position shape_scale contains NaN: " << shape_scale);
+  {
+    RCLCPP_WARN_STREAM(
+      rclcpp::get_logger("mapped_covariance_visual"),
+      "position shape_scale contains NaN: " << shape_scale);
+  }
 }
 
 void MappedCovarianceVisual::updateOrientation(const Eigen::Matrix6d& covariance, ShapeIndex index)
@@ -429,9 +442,15 @@ void MappedCovarianceVisual::updateOrientation(const Eigen::Matrix6d& covariance
   // Rotate and scale the scene node of the orientation part
   orientation_shape_[index]->setOrientation(shape_orientation);
   if (!shape_scale.isNaN())
+  {
     orientation_shape_[index]->setScale(shape_scale);
+  }
   else
-    ROS_WARN_STREAM("orientation shape_scale contains NaN: " << shape_scale);
+  {
+    RCLCPP_WARN_STREAM(
+      rclcpp::get_logger("mapped_covariance_visual"),
+      "orientation shape_scale contains NaN: " << shape_scale);
+  }
 }
 
 void MappedCovarianceVisual::setScales(float pos_scale, float ori_scale)

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -198,8 +198,7 @@ void RelativePose2DStampedConstraintVisual::setConstraint(
     if (rho[0] > squared_norm)
     {
       RCLCPP_WARN_STREAM_THROTTLE(
-        rclcpp::get_logger("relative_pose_2d_stamped_constraint_visual"),
-        rclcpp::Clock(), 10.0 * 1000,
+        rclcpp::get_logger("fuse"), rclcpp::Clock(), 10.0 * 1000,
         "Detected invalid loss value of " << rho[0] << " greater than squared residual of " << squared_norm
                                           << " for constraint " << constraint_name(constraint)
                                           << " with loss type " << constraint.loss()->type()

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -50,6 +50,9 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logging.hpp>
+
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -194,11 +197,13 @@ void RelativePose2DStampedConstraintVisual::setConstraint(
 
     if (rho[0] > squared_norm)
     {
-      ROS_WARN_STREAM_THROTTLE(10.0, "Detected invalid loss value of "
-                                         << rho[0] << " greater than squared residual of " << squared_norm
-                                         << " for constraint " << constraint_name(constraint) << " with loss type "
-                                         << constraint.loss()->type()
-                                         << ". Loss value clamped to the squared residual.");
+      RCLCPP_WARN_STREAM_THROTTLE(
+        rclcpp::get_logger("relative_pose_2d_stamped_constraint_visual"),
+        rclcpp::Clock(), 10.0 * 1000,
+        "Detected invalid loss value of " << rho[0] << " greater than squared residual of " << squared_norm
+                                          << " for constraint " << constraint_name(constraint)
+                                          << " with loss type " << constraint.loss()->type()
+                                          << ". Loss value clamped to the squared residual.");
 
       rho[0] = squared_norm;
     }

--- a/fuse_viz/src/serialized_graph_display.cpp
+++ b/fuse_viz/src/serialized_graph_display.cpp
@@ -170,7 +170,7 @@ void SerializedGraphDisplay::processMessage(const fuse_msgs::SerializedGraph::Co
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(msg->header, position, orientation))
   {
-    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("serialized_graph_display"),
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("fuse"),
                         "Error transforming from frame '" << msg->header.frame_id << "' to frame '"
                         << qPrintable(fixed_frame_) << "'");
   }

--- a/fuse_viz/src/serialized_graph_display.cpp
+++ b/fuse_viz/src/serialized_graph_display.cpp
@@ -170,8 +170,9 @@ void SerializedGraphDisplay::processMessage(const fuse_msgs::SerializedGraph::Co
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(msg->header, position, orientation))
   {
-    ROS_DEBUG_STREAM("Error transforming from frame '" << msg->header.frame_id << "' to frame '"
-                                                       << qPrintable(fixed_frame_) << "'");
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("serialized_graph_display"),
+                        "Error transforming from frame '" << msg->header.frame_id << "' to frame '"
+                        << qPrintable(fixed_frame_) << "'");
   }
 
   root_node_->setPosition(position);


### PR DESCRIPTION
See: https://github.com/locusrobotics/fuse/issues/276

This PR ports logging calls to RCLCPP across the entire stack.

Note that it won't compile since only logging's been ported (and that requires ROS 2 constructs like node pointers, which have yet to be integrated.)

Additionally, the delayed throttle filter was ported to use std::chrono to separate its functionality from ROS. (Also because ROS doesn't support negative time (: )

It's recommended to take a look at how the logging calls have been ported: https://github.com/locusrobotics/fuse/pull/279/commits/3581bd7d96d056a1fa76a13b4cda0d31096fd95b
I also left behind comments for future edits (mostly porting node handles -> nodes)

PS: Would a std::chrono::steady_clock [be preferable for the console throttler](https://github.com/locusrobotics/fuse/pull/279/files#diff-7252082b533722f0a0542d2c417f86dfc98c57db8df36e0d12b036eaebe68009)? It's a bit of a roundabout to be using it if yes, so if it's not critical I'd continue using system_clock.

Also pinging @svwilliams for visibility.