### PR TITLE
fuse -> ROS 2: Clean up macro usage warnings

### DIFF
--- a/fuse_constraints/include/fuse_constraints/absolute_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_constraint.h
@@ -72,7 +72,7 @@ template<class Variable>
 class AbsoluteConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteConstraint<Variable>);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteConstraint<Variable>)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_constraint.h
@@ -65,7 +65,7 @@ namespace fuse_constraints
 class AbsoluteOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsoluteOrientation3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsoluteOrientation3DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h
@@ -67,7 +67,7 @@ namespace fuse_constraints
 class AbsoluteOrientation3DStampedEulerConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteOrientation3DStampedEulerConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsoluteOrientation3DStampedEulerConstraint)
 
   using Euler = fuse_variables::Orientation3DStamped::Euler;
 

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_2d_stamped_constraint.h
@@ -68,7 +68,7 @@ namespace fuse_constraints
 class AbsolutePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(AbsolutePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(AbsolutePose2DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/absolute_pose_3d_stamped_constraint.h
@@ -68,7 +68,7 @@ namespace fuse_constraints
 class AbsolutePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(AbsolutePose3DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -72,7 +72,7 @@ namespace fuse_constraints
 class MarginalConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(MarginalConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(MarginalConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_orientation_3d_cost_functor.h
@@ -69,7 +69,7 @@ namespace fuse_constraints
 class NormalDeltaOrientation3DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Construct a cost function instance

--- a/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_delta_pose_3d_cost_functor.h
@@ -68,7 +68,7 @@ namespace fuse_constraints
 class NormalDeltaPose3DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Constructor

--- a/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_orientation_3d_cost_functor.h
@@ -69,7 +69,7 @@ namespace fuse_constraints
 class NormalPriorOrientation3DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Construct a cost function instance

--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_cost_functor.h
@@ -68,7 +68,7 @@ namespace fuse_constraints
 class NormalPriorPose3DCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Construct a cost function instance

--- a/fuse_constraints/include/fuse_constraints/relative_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_constraint.h
@@ -75,7 +75,7 @@ template<class Variable>
 class RelativeConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(RelativeConstraint<Variable>);
+  FUSE_CONSTRAINT_DEFINITIONS(RelativeConstraint<Variable>)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h
@@ -64,7 +64,7 @@ namespace fuse_constraints
 class RelativeOrientation3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativeOrientation3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativeOrientation3DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_2d_stamped_constraint.h
@@ -66,7 +66,7 @@ namespace fuse_constraints
 class RelativePose2DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(RelativePose2DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(RelativePose2DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/relative_pose_3d_stamped_constraint.h
@@ -65,7 +65,7 @@ namespace fuse_constraints
 class RelativePose3DStampedConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose3DStampedConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(RelativePose3DStampedConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_constraints/test/test_marginalize_variables.cpp
+++ b/fuse_constraints/test/test_marginalize_variables.cpp
@@ -62,7 +62,7 @@
 class GenericVariable : public fuse_core::Variable
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(GenericVariable);
+  FUSE_VARIABLE_DEFINITIONS(GenericVariable)
 
   GenericVariable() :
     fuse_core::Variable(fuse_core::uuid::generate()),
@@ -110,7 +110,7 @@ BOOST_CLASS_EXPORT(GenericVariable);
 class GenericConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint)
 
   GenericConstraint(std::initializer_list<fuse_core::UUID> variable_uuids) :
     Constraint("test", variable_uuids) {}
@@ -145,7 +145,7 @@ private:
 class FixedOrientation3DStamped : public fuse_variables::Orientation3DStamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(FixedOrientation3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(FixedOrientation3DStamped)
 
   FixedOrientation3DStamped() = default;
 

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -85,7 +85,7 @@ namespace fuse_core
 class AsyncMotionModel : public MotionModel
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(AsyncMotionModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncMotionModel)
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -63,7 +63,7 @@ namespace fuse_core
 class AsyncPublisher : public Publisher
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(AsyncPublisher);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncPublisher)
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -87,7 +87,7 @@ namespace fuse_core
 class AsyncSensorModel : public SensorModel
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(AsyncSensorModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(AsyncSensorModel)
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -77,7 +77,7 @@ template <typename PlusFunctor, typename MinusFunctor, int kGlobalSize, int kLoc
 class AutoDiffLocalParameterization : public LocalParameterization
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>);
+  FUSE_SMART_PTR_DEFINITIONS(AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLocalSize>)
 
   /**
    * @brief Constructs new PlusFunctor and MinusFunctor instances

--- a/fuse_core/include/fuse_core/constraint.h
+++ b/fuse_core/include/fuse_core/constraint.h
@@ -61,7 +61,7 @@
  * class Derived : public Constraint
  * {
  * public:
- *   FUSE_CONSTRAINT_CLONE_DEFINITION(Derived);
+ *   FUSE_CONSTRAINT_CLONE_DEFINITION(Derived)
  *   // The rest of the derived constraint implementation
  * }
  * @endcode
@@ -80,7 +80,7 @@
  * class Derived : public Constraint
  * {
  * public:
- *   FUSE_CONSTRAINT_SERIALIZE_DEFINITION(Derived);
+ *   FUSE_CONSTRAINT_SERIALIZE_DEFINITION(Derived)
  *   // The rest of the derived constraint implementation
  * }
  * @endcode
@@ -113,7 +113,7 @@
  * class Derived : public Constraint
  * {
  * public:
- *   FUSE_CONSTRAINT_TYPE_DEFINITION(Derived);
+ *   FUSE_CONSTRAINT_TYPE_DEFINITION(Derived)
  *   // The rest of the derived constraint implementation
  * }
  * @endcode
@@ -139,7 +139,7 @@
  * class Derived : public Constraint
  * {
  * public:
- *   FUSE_CONSTRAINT_DEFINITIONS(Derived);
+ *   FUSE_CONSTRAINT_DEFINITIONS(Derived)
  *   // The rest of the derived constraint implementation
  * }
  * @endcode
@@ -159,7 +159,7 @@
  * class Derived : public Constraint
  * {
  * public:
- *   FUSE_CONSTRAINT_DEFINITIONS_WTIH_EIGEN(Derived);
+ *   FUSE_CONSTRAINT_DEFINITIONS_WTIH_EIGEN(Derived)
  *   // The rest of the derived constraint implementation
  * }
  * @endcode
@@ -193,7 +193,7 @@ namespace fuse_core
 class Constraint
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Constraint);
+  FUSE_SMART_PTR_ALIASES_ONLY(Constraint)
 
   /**
    * @brief Default constructor

--- a/fuse_core/include/fuse_core/graph.h
+++ b/fuse_core/include/fuse_core/graph.h
@@ -65,7 +65,7 @@
  * class Derived : public Graph
  * {
  * public:
- *   FUSE_GRAPH_SERIALIZE_DEFINITION(Derived);
+ *   FUSE_GRAPH_SERIALIZE_DEFINITION(Derived)
  *   // The rest of the derived graph implementation
  * }
  * @endcode
@@ -98,7 +98,7 @@
  * class Derived : public Graph
  * {
  * public:
- *   FUSE_GRAPH_TYPE_DEFINITION(Derived);
+ *   FUSE_GRAPH_TYPE_DEFINITION(Derived)
  *   // The rest of the derived graph implementation
  * }
  * @endcode
@@ -124,7 +124,7 @@
 * class Derived : public Graph
 * {
 * public:
-*   FUSE_GRAPH_DEFINITIONS(Derived);
+*   FUSE_GRAPH_DEFINITIONS(Derived)
 *   // The rest of the derived graph implementation
 * }
 * @endcode
@@ -149,7 +149,7 @@ namespace fuse_core
 class Graph
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Graph);
+  FUSE_SMART_PTR_ALIASES_ONLY(Graph)
 
   /**
    * @brief A range of fuse_ros::Constraint objects

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -57,7 +57,7 @@ namespace fuse_core
 class LocalParameterization : public ceres::LocalParameterization
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
+  FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization)
 
   /**
    * @brief Generalization of the subtraction operation

--- a/fuse_core/include/fuse_core/loss.h
+++ b/fuse_core/include/fuse_core/loss.h
@@ -53,7 +53,7 @@
  * class Derived : public Loss
  * {
  * public:
- *   FUSE_LOSS_CLONE_DEFINITION(Derived);
+ *   FUSE_LOSS_CLONE_DEFINITION(Derived)
  *   // The rest of the derived loss function implementation
  * }
  * @endcode
@@ -72,7 +72,7 @@
  * class Derived : public Loss
  * {
  * public:
- *   FUSE_LOSS_SERIALIZE_DEFINITION(Derived);
+ *   FUSE_LOSS_SERIALIZE_DEFINITION(Derived)
  *   // The rest of the derived loss function implementation
  * }
  * @endcode
@@ -105,7 +105,7 @@
  * class Derived : public Loss
  * {
  * public:
- *   FUSE_LOSS_TYPE_DEFINITION(Derived);
+ *   FUSE_LOSS_TYPE_DEFINITION(Derived)
  *   // The rest of the derived loss function implementation
  * }
  * @endcode
@@ -131,7 +131,7 @@
  * class Derived : public Loss
  * {
  * public:
- *   FUSE_LOSS_DEFINITIONS(Derived);
+ *   FUSE_LOSS_DEFINITIONS(Derived)
  *   // The rest of the derived loss function implementation
  * }
  * @endcode
@@ -169,7 +169,7 @@ namespace fuse_core
 class Loss
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Loss);
+  FUSE_SMART_PTR_ALIASES_ONLY(Loss)
 
   static constexpr ceres::Ownership Ownership =
       ceres::Ownership::TAKE_OWNERSHIP;  //!< The ownership of the ceres::LossFunction* returned by lossFunction()

--- a/fuse_core/include/fuse_core/message_buffer.h
+++ b/fuse_core/include/fuse_core/message_buffer.h
@@ -61,7 +61,7 @@ template <typename Message>
 class MessageBuffer
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(MessageBuffer<Message>);
+  FUSE_SMART_PTR_DEFINITIONS(MessageBuffer<Message>)
 
   /**
    * @brief A range of messages

--- a/fuse_core/include/fuse_core/motion_model.h
+++ b/fuse_core/include/fuse_core/motion_model.h
@@ -53,7 +53,7 @@ namespace fuse_core
 class MotionModel
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(MotionModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(MotionModel)
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/publisher.h
+++ b/fuse_core/include/fuse_core/publisher.h
@@ -57,7 +57,7 @@ namespace fuse_core
 class Publisher
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Publisher);
+  FUSE_SMART_PTR_ALIASES_ONLY(Publisher)
 
   /**
    * @brief Constructor

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -68,7 +68,7 @@ using TransactionCallback = std::function<void(Transaction::SharedPtr transactio
 class SensorModel
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(SensorModel);
+  FUSE_SMART_PTR_ALIASES_ONLY(SensorModel)
 
   /**
    * @brief Destructor

--- a/fuse_core/include/fuse_core/timestamp_manager.h
+++ b/fuse_core/include/fuse_core/timestamp_manager.h
@@ -65,7 +65,7 @@ namespace fuse_core
 class TimestampManager
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(TimestampManager);
+  FUSE_SMART_PTR_DEFINITIONS(TimestampManager)
 
   /**
    * @brief Function that generates motion model constraints between the requested timestamps

--- a/fuse_core/include/fuse_core/transaction.h
+++ b/fuse_core/include/fuse_core/transaction.h
@@ -66,7 +66,7 @@ namespace fuse_core
 class Transaction
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Transaction);
+  FUSE_SMART_PTR_DEFINITIONS(Transaction)
 
   /**
    * @brief A range of Constraint::SharedPtr objects

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -55,7 +55,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_CLONE_DEFINITION(Derived);
+ *   FUSE_VARIABLE_CLONE_DEFINITION(Derived)
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -74,7 +74,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_SERIALIZE_DEFINITION(Derived);
+ *   FUSE_VARIABLE_SERIALIZE_DEFINITION(Derived)
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -107,7 +107,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_TYPE_DEFINITION(Derived);
+ *   FUSE_VARIABLE_TYPE_DEFINITION(Derived)
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -133,7 +133,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_DEFINITIONS(Derived);
+ *   FUSE_VARIABLE_DEFINITIONS(Derived)
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -153,7 +153,7 @@
  * class Derived : public Variable
  * {
  * public:
- *   FUSE_VARIABLE_DEFINITIONS_WTIH_EIGEN(Derived);
+ *   FUSE_VARIABLE_DEFINITIONS_WTIH_EIGEN(Derived)
  *   // The rest of the derived variable implementation
  * }
  * @endcode
@@ -188,7 +188,7 @@ namespace fuse_core
 class Variable
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Variable);
+  FUSE_SMART_PTR_ALIASES_ONLY(Variable)
 
   /**
    * @brief Default constructor

--- a/fuse_core/test/example_constraint.h
+++ b/fuse_core/test/example_constraint.h
@@ -53,7 +53,7 @@
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint)
 
   ExampleConstraint() = default;
 

--- a/fuse_core/test/example_loss.h
+++ b/fuse_core/test/example_loss.h
@@ -52,7 +52,7 @@
 class ExampleLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(ExampleLoss);
+  FUSE_LOSS_DEFINITIONS(ExampleLoss)
 
   explicit ExampleLoss(const double a = 1.0) : a(a)
   {

--- a/fuse_core/test/example_variable.h
+++ b/fuse_core/test/example_variable.h
@@ -50,7 +50,7 @@
 class ExampleVariable : public fuse_core::Variable
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable)
 
   ExampleVariable() :
     fuse_core::Variable(fuse_core::uuid::generate()),

--- a/fuse_graphs/benchmark/benchmark_create_problem.cpp
+++ b/fuse_graphs/benchmark/benchmark_create_problem.cpp
@@ -90,7 +90,7 @@ private:
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint)
 
   ExampleConstraint() = default;
 

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -75,7 +75,7 @@ namespace fuse_graphs
 class HashGraph : public fuse_core::Graph
 {
 public:
-  FUSE_GRAPH_DEFINITIONS(HashGraph);
+  FUSE_GRAPH_DEFINITIONS(HashGraph)
 
   /**
    * @brief Constructor

--- a/fuse_graphs/test/covariance_constraint.h
+++ b/fuse_graphs/test/covariance_constraint.h
@@ -142,7 +142,7 @@ public:
 class CovarianceConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(CovarianceConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(CovarianceConstraint)
 
   CovarianceConstraint() = default;
 

--- a/fuse_graphs/test/example_constraint.h
+++ b/fuse_graphs/test/example_constraint.h
@@ -75,7 +75,7 @@ private:
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint)
 
   ExampleConstraint() = default;
 

--- a/fuse_graphs/test/example_loss.h
+++ b/fuse_graphs/test/example_loss.h
@@ -52,7 +52,7 @@
 class ExampleLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(ExampleLoss);
+  FUSE_LOSS_DEFINITIONS(ExampleLoss)
 
   explicit ExampleLoss(const double a = 1.0) : a(a)
   {

--- a/fuse_graphs/test/example_variable.h
+++ b/fuse_graphs/test/example_variable.h
@@ -52,7 +52,7 @@
 class ExampleVariable : public fuse_core::Variable
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable)
 
   explicit ExampleVariable(size_t N = 1) :
     fuse_core::Variable(fuse_core::uuid::generate()),

--- a/fuse_loss/include/fuse_loss/arctan_loss.h
+++ b/fuse_loss/include/fuse_loss/arctan_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class ArctanLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(ArctanLoss);
+  FUSE_LOSS_DEFINITIONS(ArctanLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/cauchy_loss.h
+++ b/fuse_loss/include/fuse_loss/cauchy_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class CauchyLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(CauchyLoss);
+  FUSE_LOSS_DEFINITIONS(CauchyLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/composed_loss.h
+++ b/fuse_loss/include/fuse_loss/composed_loss.h
@@ -58,7 +58,7 @@ namespace fuse_loss
 class ComposedLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(ComposedLoss);
+  FUSE_LOSS_DEFINITIONS(ComposedLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/dcs_loss.h
+++ b/fuse_loss/include/fuse_loss/dcs_loss.h
@@ -61,7 +61,7 @@ namespace fuse_loss
 class DCSLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(DCSLoss);
+  FUSE_LOSS_DEFINITIONS(DCSLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/fair_loss.h
+++ b/fuse_loss/include/fuse_loss/fair_loss.h
@@ -61,7 +61,7 @@ namespace fuse_loss
 class FairLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(FairLoss);
+  FUSE_LOSS_DEFINITIONS(FairLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
+++ b/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
@@ -61,7 +61,7 @@ namespace fuse_loss
 class GemanMcClureLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(GemanMcClureLoss);
+  FUSE_LOSS_DEFINITIONS(GemanMcClureLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/huber_loss.h
+++ b/fuse_loss/include/fuse_loss/huber_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class HuberLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(HuberLoss);
+  FUSE_LOSS_DEFINITIONS(HuberLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/scaled_loss.h
+++ b/fuse_loss/include/fuse_loss/scaled_loss.h
@@ -58,7 +58,7 @@ namespace fuse_loss
 class ScaledLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(ScaledLoss);
+  FUSE_LOSS_DEFINITIONS(ScaledLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/softlone_loss.h
+++ b/fuse_loss/include/fuse_loss/softlone_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class SoftLOneLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(SoftLOneLoss);
+  FUSE_LOSS_DEFINITIONS(SoftLOneLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/tolerant_loss.h
+++ b/fuse_loss/include/fuse_loss/tolerant_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class TolerantLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(TolerantLoss);
+  FUSE_LOSS_DEFINITIONS(TolerantLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/trivial_loss.h
+++ b/fuse_loss/include/fuse_loss/trivial_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class TrivialLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(TrivialLoss);
+  FUSE_LOSS_DEFINITIONS(TrivialLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/tukey_loss.h
+++ b/fuse_loss/include/fuse_loss/tukey_loss.h
@@ -57,7 +57,7 @@ namespace fuse_loss
 class TukeyLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(TukeyLoss);
+  FUSE_LOSS_DEFINITIONS(TukeyLoss)
 
   /**
    * @brief Constructor

--- a/fuse_loss/include/fuse_loss/welsch_loss.h
+++ b/fuse_loss/include/fuse_loss/welsch_loss.h
@@ -61,7 +61,7 @@ namespace fuse_loss
 class WelschLoss : public fuse_core::Loss
 {
 public:
-  FUSE_LOSS_DEFINITIONS(WelschLoss);
+  FUSE_LOSS_DEFINITIONS(WelschLoss)
 
   /**
    * @brief Constructor

--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -68,7 +68,7 @@ namespace fuse_models
 class Acceleration2D : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Acceleration2D);
+  FUSE_SMART_PTR_DEFINITIONS(Acceleration2D)
   using ParameterType = parameters::Acceleration2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/graph_ignition.h
+++ b/fuse_models/include/fuse_models/graph_ignition.h
@@ -71,7 +71,7 @@ namespace fuse_models
 class GraphIgnition : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(GraphIgnition);
+  FUSE_SMART_PTR_DEFINITIONS(GraphIgnition)
   using ParameterType = parameters::GraphIgnitionParams;
 
   /**

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -86,7 +86,7 @@ namespace fuse_models
 class Imu2D : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Imu2D);
+  FUSE_SMART_PTR_DEFINITIONS(Imu2D)
   using ParameterType = parameters::Imu2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -82,7 +82,7 @@ namespace fuse_models
 class Odometry2D : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Odometry2D);
+  FUSE_SMART_PTR_DEFINITIONS(Odometry2D)
   using ParameterType = parameters::Odometry2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -96,7 +96,7 @@ namespace fuse_models
 class Odometry2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher)
   using ParameterType = parameters::Odometry2DPublisherParams;
 
   /**

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -71,7 +71,7 @@ namespace fuse_models
 class Pose2D : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Pose2D);
+  FUSE_SMART_PTR_DEFINITIONS(Pose2D)
   using ParameterType = parameters::Pose2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/transaction.h
+++ b/fuse_models/include/fuse_models/transaction.h
@@ -63,7 +63,7 @@ namespace fuse_models
 class Transaction : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Transaction);
+  FUSE_SMART_PTR_DEFINITIONS(Transaction)
   using ParameterType = parameters::TransactionParams;
 
   /**

--- a/fuse_models/include/fuse_models/twist_2d.h
+++ b/fuse_models/include/fuse_models/twist_2d.h
@@ -66,7 +66,7 @@ namespace fuse_models
 class Twist2D : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Twist2D);
+  FUSE_SMART_PTR_DEFINITIONS(Twist2D)
   using ParameterType = parameters::Twist2DParams;
 
   /**

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -72,7 +72,7 @@ namespace fuse_models
 class Unicycle2D : public fuse_core::AsyncMotionModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Unicycle2D);
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(Unicycle2D)
 
   /**
    * @brief Default constructor

--- a/fuse_models/include/fuse_models/unicycle_2d_ignition.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_ignition.h
@@ -78,7 +78,7 @@ namespace fuse_models
 class Unicycle2DIgnition : public fuse_core::AsyncSensorModel
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Unicycle2DIgnition);
+  FUSE_SMART_PTR_DEFINITIONS(Unicycle2DIgnition)
   using ParameterType = parameters::Unicycle2DIgnitionParams;
 
   /**

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_function.h
@@ -85,7 +85,7 @@ namespace fuse_models
 class Unicycle2DStateCostFunction : public ceres::SizedCostFunction<8, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2>
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Construct a cost function instance

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
@@ -83,7 +83,7 @@ namespace fuse_models
 class Unicycle2DStateCostFunctor
 {
 public:
-  FUSE_MAKE_ALIGNED_OPERATOR_NEW();
+  FUSE_MAKE_ALIGNED_OPERATOR_NEW()
 
   /**
    * @brief Construct a cost function instance

--- a/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_kinematic_constraint.h
@@ -66,7 +66,7 @@ namespace fuse_models
 class Unicycle2DStateKinematicConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(Unicycle2DStateKinematicConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS_WITH_EIGEN(Unicycle2DStateKinematicConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_models/test/example_constraint.h
+++ b/fuse_models/test/example_constraint.h
@@ -55,7 +55,7 @@
 class ExampleConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(ExampleConstraint)
 
   ExampleConstraint() = default;
 

--- a/fuse_models/test/example_variable.h
+++ b/fuse_models/test/example_variable.h
@@ -50,7 +50,7 @@
 class ExampleVariable : public fuse_core::Variable
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(ExampleVariable);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariable)
 
   ExampleVariable() : fuse_core::Variable(fuse_core::uuid::generate()), data_(0.0)
   {

--- a/fuse_models/test/example_variable_stamped.h
+++ b/fuse_models/test/example_variable_stamped.h
@@ -51,7 +51,7 @@
 class ExampleVariableStamped : public fuse_core::Variable, public fuse_variables::Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(ExampleVariableStamped);
+  FUSE_VARIABLE_DEFINITIONS(ExampleVariableStamped)
 
   ExampleVariableStamped() = default;
 

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -96,7 +96,7 @@ namespace fuse_optimizers
 class BatchOptimizer : public Optimizer
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(BatchOptimizer);
+  FUSE_SMART_PTR_DEFINITIONS(BatchOptimizer)
   using ParameterType = BatchOptimizerParams;
 
   /**

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -105,7 +105,7 @@ namespace fuse_optimizers
 class FixedLagSmoother : public Optimizer
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(FixedLagSmoother);
+  FUSE_SMART_PTR_DEFINITIONS(FixedLagSmoother)
   using ParameterType = FixedLagSmootherParams;
 
   /**

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -93,7 +93,7 @@ namespace fuse_optimizers
 class Optimizer
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Optimizer);
+  FUSE_SMART_PTR_ALIASES_ONLY(Optimizer)
 
   /**
    * @brief Constructor

--- a/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
+++ b/fuse_optimizers/include/fuse_optimizers/variable_stamp_index.h
@@ -56,7 +56,7 @@ namespace fuse_optimizers
 class VariableStampIndex
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(VariableStampIndex);
+  FUSE_SMART_PTR_DEFINITIONS(VariableStampIndex)
 
   /**
    * @brief Constructor

--- a/fuse_optimizers/test/example_optimizer.h
+++ b/fuse_optimizers/test/example_optimizer.h
@@ -47,7 +47,7 @@
 class ExampleOptimizer : public fuse_optimizers::Optimizer
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(ExampleOptimizer);
+  FUSE_SMART_PTR_DEFINITIONS(ExampleOptimizer)
 
   ExampleOptimizer(fuse_core::Graph::UniquePtr graph, const ros::NodeHandle& node_handle = ros::NodeHandle(),
                  const ros::NodeHandle& private_node_handle = ros::NodeHandle("~"))

--- a/fuse_optimizers/test/test_variable_stamp_index.cpp
+++ b/fuse_optimizers/test/test_variable_stamp_index.cpp
@@ -58,7 +58,7 @@
 class StampedVariable : public fuse_core::Variable, public fuse_variables::Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(StampedVariable);
+  FUSE_VARIABLE_DEFINITIONS(StampedVariable)
 
   explicit StampedVariable(const ros::Time& stamp = ros::Time(0, 0)) :
     fuse_core::Variable(fuse_core::uuid::generate()),
@@ -115,7 +115,7 @@ BOOST_CLASS_EXPORT(StampedVariable);
 class UnstampedVariable : public fuse_core::Variable
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(UnstampedVariable);
+  FUSE_VARIABLE_DEFINITIONS(UnstampedVariable)
 
   UnstampedVariable() :
     fuse_core::Variable(fuse_core::uuid::generate()),
@@ -170,7 +170,7 @@ BOOST_CLASS_EXPORT(UnstampedVariable);
 class GenericConstraint : public fuse_core::Constraint
 {
 public:
-  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(GenericConstraint)
 
   GenericConstraint() = default;
 

--- a/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
@@ -57,7 +57,7 @@ namespace fuse_publishers
 class Path2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Path2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(Path2DPublisher)
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -97,7 +97,7 @@ namespace fuse_publishers
 class Pose2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(Pose2DPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(Pose2DPublisher)
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -53,7 +53,7 @@ namespace fuse_publishers
 class SerializedPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(SerializedPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(SerializedPublisher)
 
   /**
    * @brief Constructor

--- a/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
+++ b/fuse_publishers/include/fuse_publishers/stamped_variable_synchronizer.h
@@ -67,7 +67,7 @@ template <typename ...Ts>
 class StampedVariableSynchronizer
 {
 public:
-  FUSE_SMART_PTR_DEFINITIONS(StampedVariableSynchronizer);
+  FUSE_SMART_PTR_DEFINITIONS(StampedVariableSynchronizer)
   static const ros::Time TIME_ZERO;  //!< Constant representing a zero timestamp
 
   /**

--- a/fuse_tutorials/include/fuse_tutorials/beacon_publisher.h
+++ b/fuse_tutorials/include/fuse_tutorials/beacon_publisher.h
@@ -101,7 +101,7 @@ class BeaconPublisher : public fuse_core::AsyncPublisher
 public:
   // It is convenient to have some typedefs for various smart pointer types (shared, unique, etc.). A macro is provided
   // to make it easy to define these typedefs and ensures that the naming is consistent throughout all fuse packages.
-  FUSE_SMART_PTR_DEFINITIONS(BeaconPublisher);
+  FUSE_SMART_PTR_DEFINITIONS(BeaconPublisher)
 
   /**
    * @brief Default constructor

--- a/fuse_tutorials/include/fuse_tutorials/range_constraint.h
+++ b/fuse_tutorials/include/fuse_tutorials/range_constraint.h
@@ -75,7 +75,7 @@ public:
   // There are some boilerplate types and functions that must be implemented for each constraint, such as shared pointer
   // typedefs and clone() methods. These are formulaic, but the derived type is needed for their proper implementation.
   // A few different macro options are provided to make implementing this boilerplate code easy.
-  FUSE_CONSTRAINT_DEFINITIONS(RangeConstraint);
+  FUSE_CONSTRAINT_DEFINITIONS(RangeConstraint)
 
   /**
    * @brief Default constructor

--- a/fuse_tutorials/include/fuse_tutorials/range_sensor_model.h
+++ b/fuse_tutorials/include/fuse_tutorials/range_sensor_model.h
@@ -106,7 +106,7 @@ class RangeSensorModel : public fuse_core::AsyncSensorModel
 public:
   // It is convenient to have some typedefs for various smart pointer types (shared, unique, etc.). A macro is provided
   // to make it easy to define these typedefs and ensures that the naming is consistent throughout all fuse packages.
-  FUSE_SMART_PTR_DEFINITIONS(RangeSensorModel);
+  FUSE_SMART_PTR_DEFINITIONS(RangeSensorModel)
 
   /**
    * @brief Default constructor

--- a/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_2d_stamped.h
@@ -60,7 +60,7 @@ namespace fuse_variables
 class AccelerationAngular2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_angular_3d_stamped.h
@@ -61,7 +61,7 @@ namespace fuse_variables
 class AccelerationAngular3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationAngular3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_2d_stamped.h
@@ -60,7 +60,7 @@ namespace fuse_variables
 class AccelerationLinear2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/acceleration_linear_3d_stamped.h
@@ -61,7 +61,7 @@ namespace fuse_variables
 class AccelerationLinear3DStamped : public FixedSizeVariable<3>,  public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(AccelerationLinear3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/fixed_size_variable.h
+++ b/fuse_variables/include/fuse_variables/fixed_size_variable.h
@@ -62,7 +62,7 @@ template <size_t N>
 class FixedSizeVariable : public fuse_core::Variable
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(FixedSizeVariable<N>);
+  FUSE_SMART_PTR_ALIASES_ONLY(FixedSizeVariable<N>)
 
   /**
    * @brief A static version of the variable size

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -135,7 +135,7 @@ private:
 class Orientation2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Orientation2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Orientation2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -172,7 +172,7 @@ private:
 class Orientation3DStamped : public FixedSizeVariable<4>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Orientation3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Orientation3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the quaternion

--- a/fuse_variables/include/fuse_variables/point_2d_fixed_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_2d_fixed_landmark.h
@@ -56,7 +56,7 @@ namespace fuse_variables
 class Point2DFixedLandmark : public FixedSizeVariable<2>
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Point2DFixedLandmark);
+  FUSE_VARIABLE_DEFINITIONS(Point2DFixedLandmark)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/point_2d_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_2d_landmark.h
@@ -56,7 +56,7 @@ namespace fuse_variables
 class Point2DLandmark : public FixedSizeVariable<2>
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Point2DLandmark);
+  FUSE_VARIABLE_DEFINITIONS(Point2DLandmark)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/point_3d_fixed_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_3d_fixed_landmark.h
@@ -56,7 +56,7 @@ namespace fuse_variables
 class Point3DFixedLandmark : public FixedSizeVariable<3>
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Point3DFixedLandmark);
+  FUSE_VARIABLE_DEFINITIONS(Point3DFixedLandmark)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/point_3d_landmark.h
+++ b/fuse_variables/include/fuse_variables/point_3d_landmark.h
@@ -59,7 +59,7 @@ namespace fuse_variables
 class Point3DLandmark : public FixedSizeVariable<3>
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Point3DLandmark);
+  FUSE_VARIABLE_DEFINITIONS(Point3DLandmark)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/position_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_2d_stamped.h
@@ -60,7 +60,7 @@ namespace fuse_variables
 class Position2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Position2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Position2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/position_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/position_3d_stamped.h
@@ -62,7 +62,7 @@ namespace fuse_variables
 class Position3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(Position3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(Position3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/stamped.h
+++ b/fuse_variables/include/fuse_variables/stamped.h
@@ -57,7 +57,7 @@ namespace fuse_variables
 class Stamped
 {
 public:
-  FUSE_SMART_PTR_ALIASES_ONLY(Stamped);
+  FUSE_SMART_PTR_ALIASES_ONLY(Stamped)
 
   /**
    * @brief Default constructor

--- a/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_2d_stamped.h
@@ -60,7 +60,7 @@ namespace fuse_variables
 class VelocityAngular2DStamped : public FixedSizeVariable<1>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(VelocityAngular2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityAngular2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_angular_3d_stamped.h
@@ -61,7 +61,7 @@ namespace fuse_variables
 class VelocityAngular3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(VelocityAngular3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityAngular3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_2d_stamped.h
@@ -60,7 +60,7 @@ namespace fuse_variables
 class VelocityLinear2DStamped : public FixedSizeVariable<2>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(VelocityLinear2DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityLinear2DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/velocity_linear_3d_stamped.h
@@ -61,7 +61,7 @@ namespace fuse_variables
 class VelocityLinear3DStamped : public FixedSizeVariable<3>, public Stamped
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(VelocityLinear3DStamped);
+  FUSE_VARIABLE_DEFINITIONS(VelocityLinear3DStamped)
 
   /**
    * @brief Can be used to directly index variables in the data array

--- a/fuse_variables/test/test_fixed_size_variable.cpp
+++ b/fuse_variables/test/test_fixed_size_variable.cpp
@@ -43,7 +43,7 @@
 class TestVariable : public fuse_variables::FixedSizeVariable<2>
 {
 public:
-  FUSE_VARIABLE_DEFINITIONS(TestVariable);
+  FUSE_VARIABLE_DEFINITIONS(TestVariable)
 
   TestVariable() :
     fuse_variables::FixedSizeVariable<2>(fuse_core::uuid::generate())


### PR DESCRIPTION
See: #276

Trivial PR to remove the giant mass of build warnings that come from using the semicolon after the fuse macro invocation.

This is just for my sanity during the porting :grimace:

Also pinging @svwilliams for visibility.