### PR TITLE
fuse -> ROS 2 fuse_core : Nodes and Waitables

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -29,21 +29,22 @@ include(boost-extras.cmake)
 
 ## fuse_core library
 add_library(${PROJECT_NAME} SHARED
-#    src/async_motion_model.cpp
-#    src/async_publisher.cpp
-#    src/async_sensor_model.cpp
-#    src/ceres_options.cpp
-    src/constraint.cpp
-    src/graph.cpp
-    src/graph_deserializer.cpp
-    src/loss.cpp
-    src/serialization.cpp
-    src/time.cpp
-    src/timestamp_manager.cpp
-    src/transaction.cpp
-    src/transaction_deserializer.cpp
-    src/uuid.cpp
-    src/variable.cpp
+  src/async_motion_model.cpp
+  src/async_publisher.cpp
+  src/async_sensor_model.cpp
+  src/callback_wrapper.cpp
+  # src/ceres_options.cpp
+  src/constraint.cpp
+  src/graph.cpp
+  src/graph_deserializer.cpp
+  src/loss.cpp
+  src/serialization.cpp
+  src/time.cpp
+  src/timestamp_manager.cpp
+  src/transaction.cpp
+  src/transaction_deserializer.cpp
+  src/uuid.cpp
+  src/variable.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -82,8 +82,58 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  # find_package(ament_cmake_gtest REQUIRED)
-  # add_subdirectory(test)
+  ament_add_gtest(test_constraint
+    test/test_constraint.cpp)
+  target_link_libraries(test_constraint ${PROJECT_NAME})
+  target_include_directories(test_constraint PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_eigen
+    test/test_eigen.cpp)
+  target_link_libraries(test_eigen ${PROJECT_NAME})
+  target_include_directories(test_eigen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # TODO(sloretz) fails to build: can't include ros/node_handle.h
+  # ament_add_gtest(test_local_parameterization
+  #   test/test_local_parameterization.cpp)
+  # target_link_libraries(test_local_parameterization ${PROJECT_NAME})
+  # target_include_directories(test_local_parameterization PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_loss
+    test/test_loss.cpp)
+  target_link_libraries(test_loss ${PROJECT_NAME})
+  target_include_directories(test_loss PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # TODO(sloretz) fails to build: invalid use of rclcpp::Time::get_clock_type()
+  # ament_add_gtest(test_message_buffer
+  #   test/test_message_buffer.cpp)
+  # target_link_libraries(test_message_buffer ${PROJECT_NAME})
+  # target_include_directories(test_message_buffer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_timestamp_manager
+    test/test_timestamp_manager.cpp)
+  target_link_libraries(test_timestamp_manager ${PROJECT_NAME})
+  target_include_directories(test_timestamp_manager PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_transaction
+    test/test_transaction.cpp)
+  target_link_libraries(test_transaction ${PROJECT_NAME})
+  target_include_directories(test_transaction PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # TODO(sloretz) fails to build: can't include ros/node_handle.h
+  # ament_add_gtest(test_util
+  #   test/test_util.cpp)
+  # target_link_libraries(test_util ${PROJECT_NAME})
+  # target_include_directories(test_util PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_uuid
+    test/test_uuid.cpp)
+  target_link_libraries(test_uuid ${PROJECT_NAME})
+  target_include_directories(test_uuid PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  ament_add_gtest(test_variable
+    test/test_variable.cpp)
+  target_link_libraries(test_variable ${PROJECT_NAME})
+  target_include_directories(test_variable PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 # TODO(CH3): Move this to the test directory and port to ROS 2
@@ -199,173 +249,6 @@ endif()
 #       CXX_STANDARD_REQUIRED YES
 #   )
 
-#   # Constraint tests
-#   catkin_add_gtest(test_constraint
-#     test/test_constraint.cpp
-#   )
-#   add_dependencies(test_constraint
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_constraint
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${CMAKE_CURRENT_SOURCE_DIR}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_constraint
-#     ${PROJECT_NAME}
-#   )
-#   set_target_properties(test_constraint
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Eigen tests
-#   catkin_add_gtest(test_eigen
-#     test/test_eigen.cpp
-#   )
-#   add_dependencies(test_eigen
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_eigen
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${CMAKE_CURRENT_SOURCE_DIR}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_eigen
-#     ${PROJECT_NAME}
-#   )
-#   set_target_properties(test_eigen
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Local Parameterization tests
-#   catkin_add_gtest(test_local_parameterization
-#     test/test_local_parameterization.cpp
-#   )
-#   target_include_directories(test_local_parameterization
-#     PRIVATE
-#       include
-#   )
-#   target_link_libraries(test_local_parameterization
-#     ${PROJECT_NAME}
-#   )
-#   set_target_properties(test_local_parameterization
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Loss tests
-#   catkin_add_gtest(test_loss
-#     test/test_loss.cpp
-#   )
-#   add_dependencies(test_loss
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_loss
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${CMAKE_CURRENT_SOURCE_DIR}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_loss
-#     ${PROJECT_NAME}
-#   )
-#   set_target_properties(test_loss
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Message Buffer Tests
-#   catkin_add_gtest(test_message_buffer
-#     test/test_message_buffer.cpp
-#   )
-#   add_dependencies(test_message_buffer
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_message_buffer
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_message_buffer
-#     ${catkin_LIBRARIES}
-#   )
-#   set_target_properties(test_message_buffer
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Timestamp Manager Tests
-#   catkin_add_gtest(test_timestamp_manager
-#     test/test_timestamp_manager.cpp
-#   )
-#   add_dependencies(test_timestamp_manager
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_timestamp_manager
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_timestamp_manager
-#     ${PROJECT_NAME}
-#     ${catkin_LIBRARIES}
-#   )
-#   set_target_properties(test_timestamp_manager
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Transaction tests
-#   catkin_add_gtest(test_transaction
-#     test/test_transaction.cpp
-#   )
-#   add_dependencies(test_transaction
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_transaction
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${CMAKE_CURRENT_SOURCE_DIR}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_transaction
-#     ${PROJECT_NAME}
-#     ${catkin_LIBRARIES}
-#   )
-#   set_target_properties(test_transaction
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
 #   # Parameter tests
 #   add_rostest_gtest(test_parameter
 #     test/parameter.test
@@ -402,80 +285,6 @@ endif()
 #     ${catkin_LIBRARIES}
 #   )
 #   set_target_properties(test_throttled_callback
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Util tests
-#   catkin_add_gtest(test_util
-#     test/test_util.cpp
-#   )
-#   add_dependencies(test_util
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_util
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_util
-#     ${catkin_LIBRARIES}
-#   )
-#   set_target_properties(test_util
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # UUID tests
-#   catkin_add_gtest(test_uuid
-#     test/test_uuid.cpp
-#   )
-#   add_dependencies(test_uuid
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_uuid
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_uuid
-#     ${PROJECT_NAME}
-#     ${catkin_LIBRARIES}
-#   )
-#   set_target_properties(test_uuid
-#     PROPERTIES
-#       CXX_STANDARD 14
-#       CXX_STANDARD_REQUIRED YES
-#   )
-
-#   # Variable tests
-#   catkin_add_gtest(test_variable
-#     test/test_variable.cpp
-#   )
-#   add_dependencies(test_variable
-#     ${catkin_EXPORTED_TARGETS}
-#   )
-#   target_include_directories(test_variable
-#     PRIVATE
-#       include
-#       ${Boost_INCLUDE_DIRS}
-#       ${catkin_INCLUDE_DIRS}
-#       ${CERES_INCLUDE_DIRS}
-#       ${CMAKE_CURRENT_SOURCE_DIR}
-#       ${EIGEN3_INCLUDE_DIRS}
-#   )
-#   target_link_libraries(test_variable
-#     ${PROJECT_NAME}
-#   )
-#   set_target_properties(test_variable
 #     PROPERTIES
 #       CXX_STANDARD 14
 #       CXX_STANDARD_REQUIRED YES

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME} SHARED
 #    src/async_motion_model.cpp
 #    src/async_publisher.cpp
 #    src/async_sensor_model.cpp
+  src/callback_wrapper.cpp
 #    src/ceres_options.cpp
     src/constraint.cpp
     src/graph.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -29,11 +29,11 @@ include(boost-extras.cmake)
 
 ## fuse_core library
 add_library(${PROJECT_NAME} SHARED
-#    src/async_motion_model.cpp
-#    src/async_publisher.cpp
-#    src/async_sensor_model.cpp
-  src/callback_wrapper.cpp
-#    src/ceres_options.cpp
+    src/async_motion_model.cpp
+#   src/async_publisher.cpp
+#   src/async_sensor_model.cpp
+    src/callback_wrapper.cpp
+#   src/ceres_options.cpp
     src/constraint.cpp
     src/graph.cpp
     src/graph_deserializer.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(${PROJECT_NAME} SHARED
   src/async_publisher.cpp
   src/async_sensor_model.cpp
   src/callback_wrapper.cpp
-  src/ceres_options.cpp
+  # src/ceres_options.cpp
   src/constraint.cpp
   src/graph.cpp
   src/graph_deserializer.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -29,21 +29,22 @@ include(boost-extras.cmake)
 
 ## fuse_core library
 add_library(${PROJECT_NAME} SHARED
-    src/async_motion_model.cpp
-#   src/async_publisher.cpp
-#   src/async_sensor_model.cpp
-    src/callback_wrapper.cpp
-#   src/ceres_options.cpp
-    src/constraint.cpp
-    src/graph.cpp
-    src/graph_deserializer.cpp
-    src/loss.cpp
-    src/serialization.cpp
-    src/timestamp_manager.cpp
-    src/transaction.cpp
-    src/transaction_deserializer.cpp
-    src/uuid.cpp
-    src/variable.cpp
+  src/async_motion_model.cpp
+  src/async_publisher.cpp
+  src/async_sensor_model.cpp
+  src/callback_wrapper.cpp
+  src/ceres_options.cpp
+  src/constraint.cpp
+  src/graph.cpp
+  src/graph_deserializer.cpp
+  src/loss.cpp
+  src/serialization.cpp
+  src/time.cpp
+  src/timestamp_manager.cpp
+  src/transaction.cpp
+  src/transaction_deserializer.cpp
+  src/uuid.cpp
+  src/variable.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -34,14 +34,15 @@
 #ifndef FUSE_CORE_ASYNC_MOTION_MODEL_H
 #define FUSE_CORE_ASYNC_MOTION_MODEL_H
 
-#include <fuse_core/graph.h>
-#include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
+
 #include <fuse_core/transaction.h>
-// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
-#include <ros/callback_queue.h>
-#include <ros/node_handle.h>
-#include <ros/spinner.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/callback_wrapper.h>
+
+//#include <fuse_core/fuse_macros.h>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
 
@@ -171,13 +172,12 @@ public:
   void stop() override;
 
 protected:
-  ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_; //!< The callback queue used for fuse internal callbacks
   std::string name_;  //!< The unique name for this motion model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this motion model (TODO(CH3): Uncomment when it's time)
-  ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
-  ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
-  ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
-
+  rclcpp::Node::SharedPtr node_;  //!< The node for this motion model
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
+  size_t executor_thread_count_;
   /**
    * @brief Constructor
    *

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -38,6 +38,8 @@
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
 #include <fuse_core/transaction.h>
+#include <fuse_core/callback_wrapper.h>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <string>
@@ -168,11 +170,12 @@ public:
   void stop() override;
 
 protected:
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this motion model instance
   rclcpp::Node::SharedPtr node_;  //!< The node for this motion model
-  rclcpp::executors::MultiThreadedExecutor executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
   rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
-
+  size_t executor_thread_count_;
   /**
    * @brief Constructor
    *

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -34,11 +34,13 @@
 #ifndef FUSE_CORE_ASYNC_MOTION_MODEL_H
 #define FUSE_CORE_ASYNC_MOTION_MODEL_H
 
-#include <fuse_core/graph.h>
-#include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
+
 #include <fuse_core/transaction.h>
+#include <fuse_core/graph.h>
 #include <fuse_core/callback_wrapper.h>
+
+//#include <fuse_core/fuse_macros.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -170,7 +172,7 @@ public:
   void stop() override;
 
 protected:
-  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_;  //!< The local callback queue used for all subscriptions
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_; //!< The callback queue used for fuse internal callbacks
   std::string name_;  //!< The unique name for this motion model instance
   rclcpp::Node::SharedPtr node_;  //!< The node for this motion model
   rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -38,10 +38,7 @@
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/motion_model.h>
 #include <fuse_core/transaction.h>
-// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
-#include <ros/callback_queue.h>
-#include <ros/node_handle.h>
-#include <ros/spinner.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
 
@@ -171,12 +168,10 @@ public:
   void stop() override;
 
 protected:
-  ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
   std::string name_;  //!< The unique name for this motion model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this motion model (TODO(CH3): Uncomment when it's time)
-  ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
-  ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
-  ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::Node::SharedPtr node_;  //!< The node for this motion model
+  rclcpp::executors::MultiThreadedExecutor executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
 
   /**
    * @brief Constructor

--- a/fuse_core/include/fuse_core/async_motion_model.h
+++ b/fuse_core/include/fuse_core/async_motion_model.h
@@ -40,8 +40,6 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/callback_wrapper.h>
 
-//#include <fuse_core/fuse_macros.h>
-
 #include <rclcpp/rclcpp.hpp>
 
 #include <string>

--- a/fuse_core/include/fuse_core/async_publisher.h
+++ b/fuse_core/include/fuse_core/async_publisher.h
@@ -34,16 +34,20 @@
 #ifndef FUSE_CORE_ASYNC_PUBLISHER_H
 #define FUSE_CORE_ASYNC_PUBLISHER_H
 
-#include <fuse_core/graph.h>
-#include <fuse_core/fuse_macros.h>
 #include <fuse_core/publisher.h>
-#include <fuse_core/transaction.h>
-// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
-#include <ros/callback_queue.h>
-#include <ros/node_handle.h>
-#include <ros/spinner.h>
 
+#include <fuse_core/transaction.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/callback_wrapper.h>
+
+#include <fuse_core/fuse_macros.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <functional>
+#include <utility>
 #include <string>
+
 
 
 namespace fuse_core
@@ -134,12 +138,12 @@ public:
   void stop() override;
 
 protected:
-  ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_; //!< The callback queue used for fuse internal callbacks
   std::string name_;  //!< The unique name for this publisher instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this publisher (TODO(CH3): Uncomment when it's time)
-  ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
-  ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
-  ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::Node::SharedPtr node_;  //!< The node for this publisher
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
+  size_t executor_thread_count_;
 
   /**
    * @brief Constructor
@@ -153,7 +157,7 @@ protected:
   /**
    * @brief Perform any required initialization for the publisher
    *
-   * The node_handle_ and private_node_handle_ member variables will be completely initialized before this
+   * The node_ and member variables will be completely initialized before this
    * call occurs. Spinning of the callback queue will not begin until after the call to AsyncPublisher::onInit()
    * completes.
    *

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -34,14 +34,13 @@
 #ifndef FUSE_CORE_ASYNC_SENSOR_MODEL_H
 #define FUSE_CORE_ASYNC_SENSOR_MODEL_H
 
-#include <fuse_core/graph.h>
-#include <fuse_core/fuse_macros.h>
 #include <fuse_core/sensor_model.h>
+
 #include <fuse_core/transaction.h>
-// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
-#include <ros/callback_queue.h>
-#include <ros/node_handle.h>
-#include <ros/spinner.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/callback_wrapper.h>
+
+//#include <fuse_core/fuse_macros.h>
 
 #include <functional>
 #include <string>
@@ -175,14 +174,13 @@ public:
   void stop() override;
 
 protected:
-  // TODO(CH3): Add a node clock interface
-  ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_; //!< The callback queue used for fuse internal callbacks
   std::string name_;  //!< The unique name for this sensor model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model (TODO(CH3): Uncomment when it's time)
-  ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
-  ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
-  ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
   TransactionCallback transaction_callback_;  //!< The function to be executed every time a Transaction is "published"
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
+  size_t executor_thread_count_;
 
   /**
    * @brief Constructor

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -40,8 +40,6 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/callback_wrapper.h>
 
-//#include <fuse_core/fuse_macros.h>
-
 #include <functional>
 #include <string>
 

--- a/fuse_core/include/fuse_core/async_sensor_model.h
+++ b/fuse_core/include/fuse_core/async_sensor_model.h
@@ -34,14 +34,13 @@
 #ifndef FUSE_CORE_ASYNC_SENSOR_MODEL_H
 #define FUSE_CORE_ASYNC_SENSOR_MODEL_H
 
-#include <fuse_core/graph.h>
-#include <fuse_core/fuse_macros.h>
 #include <fuse_core/sensor_model.h>
+
 #include <fuse_core/transaction.h>
-// #include <rclcpp/rclcpp.hpp>  TODO(CH3): Uncomment when ready
-#include <ros/callback_queue.h>
-#include <ros/node_handle.h>
-#include <ros/spinner.h>
+#include <fuse_core/graph.h>
+#include <fuse_core/callback_wrapper.h>
+
+//#include <fuse_core/fuse_macros.h>
 
 #include <functional>
 #include <string>
@@ -175,13 +174,13 @@ public:
   void stop() override;
 
 protected:
-  ros::CallbackQueue callback_queue_;  //!< The local callback queue used for all subscriptions
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_; //!< The callback queue used for fuse internal callbacks
   std::string name_;  //!< The unique name for this sensor model instance
-  // rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model (TODO(CH3): Uncomment when it's time)
-  ros::NodeHandle node_handle_;  //!< A node handle in the global namespace using the local callback queue
-  ros::NodeHandle private_node_handle_;  //!< A node handle in the private namespace using the local callback queue
-  ros::AsyncSpinner spinner_;  //!< A single/multi-threaded spinner assigned to the local callback queue
+  rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;  //!< A single/multi-threaded spinner assigned to the local callback queue
   TransactionCallback transaction_callback_;  //!< The function to be executed every time a Transaction is "published"
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr waitables_interface_;
+  size_t executor_thread_count_;
 
   /**
    * @brief Constructor

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -152,7 +152,7 @@ class CallbackAdapter : public rclcpp::Waitable
 {
 public:
 
-  explicit CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr);
+  CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr);
 
   /**
    * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
@@ -173,9 +173,10 @@ public:
    */
   bool add_to_wait_set(rcl_wait_set_t * wait_set);
 
+  std::shared_ptr< void > take_data();
 
   // XXX check this against the threading model of the multi-threaded executor.
-  void execute();
+  void execute(std::shared_ptr<void> & /*data*/);
 
   void addCallback(const std::shared_ptr<CallbackWrapperBase> &callback);
 

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -157,13 +157,13 @@ public:
   /**
    * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
    */
-  size_t get_number_of_ready_guard_conditions();
+  size_t get_number_of_ready_guard_conditions() override;
 
 
   /**
    * @brief tell the CallbackGroup that this waitable is ready to execute anything
    */
-  bool is_ready(rcl_wait_set_t * wait_set);
+  bool is_ready(rcl_wait_set_t * wait_set) override;
 
 
   /**
@@ -171,12 +171,12 @@ public:
     waitable_ptr = std::make_shared<CallbackWrapper>();
     node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
    */
-  void add_to_wait_set(rcl_wait_set_t * wait_set);
+  void add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
-  std::shared_ptr< void > take_data();
+  std::shared_ptr< void > take_data() override;
 
   // XXX check this against the threading model of the multi-threaded executor.
-  void execute(std::shared_ptr<void> & /*data*/);
+  void execute(std::shared_ptr<void> & data) override;
 
   void addCallback(const std::shared_ptr<CallbackWrapperBase> &callback);
 
@@ -186,10 +186,11 @@ public:
 
 
 private:
-  std::recursive_mutex reentrant_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
+  std::recursive_mutex reentrant_mutex_;  //!< mutex to allow multiple threads to add callbacks into a single queue simultaneously
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable
 
   std::recursive_mutex queue_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
+  std::mutex ready_mutex_;  //!< mutex to prevent multiple simultaneous calls of is_ready
   std::deque<std::shared_ptr<CallbackWrapperBase> > callback_queue_;
 };
 

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -186,11 +186,9 @@ public:
 
 
 private:
-  std::recursive_mutex reentrant_mutex_;  //!< mutex to allow multiple threads to add callbacks into a single queue simultaneously
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable
 
-  std::recursive_mutex queue_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
-  std::mutex ready_mutex_;  //!< mutex to prevent multiple simultaneous calls of is_ready
+  std::mutex queue_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
   std::deque<std::shared_ptr<CallbackWrapperBase> > callback_queue_;
 };
 

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -128,7 +128,7 @@ public:
   /**
    * @brief Call this function. This is used by the callback queue.
    */
-  void call()
+  void call() override
   {
     promise_.set_value(callback_());
   }

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -34,8 +34,6 @@
 #ifndef FUSE_CORE_CALLBACK_WRAPPER_H
 #define FUSE_CORE_CALLBACK_WRAPPER_H
 
-#include <ros/callback_queue_interface.h>
-
 #include <functional>
 #include <future>
 

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -175,7 +175,7 @@ public:
 
   std::shared_ptr< void > take_data() override;
 
-  // XXX check this against the threading model of the multi-threaded executor.
+  // TODO(CH3): check this against the threading model of the multi-threaded executor.
   void execute(std::shared_ptr<void> & data) override;
 
   void addCallback(const std::shared_ptr<CallbackWrapperBase> &callback);

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -37,7 +37,7 @@
 
 #include <functional>
 #include <future>
-#include <queue>
+#include <deque>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -78,7 +78,7 @@ namespace fuse_core
  * };
  *
  * auto callback_queue = std::make_shared<CallbackAdapter>(
- *   rclcpp::contexts::default_context::get_global_default_context());
+ *   rclcpp::contexts::get_global_default_context());
  * node->get_node_waitables_interface()->add_waitable(callback_queue, (rclcpp::CallbackGroup::SharedPtr) nullptr);
  * MyClass my_object;
  * std::vector<double> really_big_data(1000000);
@@ -171,7 +171,7 @@ public:
     waitable_ptr = std::make_shared<CallbackWrapper>();
     node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
    */
-  bool add_to_wait_set(rcl_wait_set_t * wait_set);
+  void add_to_wait_set(rcl_wait_set_t * wait_set);
 
   std::shared_ptr< void > take_data();
 
@@ -188,9 +188,9 @@ public:
 private:
   std::recursive_mutex reentrant_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable
-  
+
   std::recursive_mutex queue_mutex_;  //!< mutex to allow this callback to be added to multiple callback groups simultaneously
-  std::queue<std::shared_ptr<CallbackWrapperBase> > callback_queue_;
+  std::deque<std::shared_ptr<CallbackWrapperBase> > callback_queue_;
 };
 
 

--- a/fuse_core/include/fuse_core/callback_wrapper.h
+++ b/fuse_core/include/fuse_core/callback_wrapper.h
@@ -97,7 +97,7 @@ public:
   /**
    * @brief Call this function. This is used by the callback queue.
    */
-  virtual void call();
+  virtual void call() = 0;
 
 };
 

--- a/fuse_core/include/fuse_core/throttled_callback.h
+++ b/fuse_core/include/fuse_core/throttled_callback.h
@@ -34,8 +34,6 @@
 #ifndef FUSE_CORE_THROTTLED_CALLBACK_H
 #define FUSE_CORE_THROTTLED_CALLBACK_H
 
-//#include <ros/subscriber.h>
-
 #include <functional>
 #include <utility>
 

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -36,11 +36,11 @@
 #include <fuse_core/callback_wrapper.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
-#include <ros/node_handle.h>
-
-#include <boost/make_shared.hpp>
+#include <rclcpp/contexts/default_context.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <functional>
+#include <memory>
 #include <utility>
 #include <string>
 
@@ -50,7 +50,7 @@ namespace fuse_core
 
 AsyncMotionModel::AsyncMotionModel(size_t thread_count) :
   name_("uninitialized"),
-  spinner_(thread_count, &callback_queue_)
+  executor_thread_count_(thread_count)
 {
 }
 
@@ -62,56 +62,79 @@ bool AsyncMotionModel::apply(Transaction& transaction)
   // Thus, it is functionally similar to a service callback, and should be a familiar pattern for ROS developers.
   // This function blocks until the queryCallback() call completes, thus enforcing that motion models are generated
   // in order.
-  auto callback = boost::make_shared<CallbackWrapper<bool>>(
+  auto callback = std::make_shared<CallbackWrapper<bool>>(
     std::bind(&AsyncMotionModel::applyCallback, this, std::ref(transaction)));
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
   result.wait();
-  return result.get();
-}
 
-void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
-{
-  callback_queue_.addCallback(
-    boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))),
-    reinterpret_cast<uint64_t>(this));
+  return result.get();
 }
 
 void AsyncMotionModel::initialize(const std::string& name)
 {
   // Initialize internal state
   name_ = name;
-  node_handle_.setCallbackQueue(&callback_queue_);
-  private_node_handle_ = ros::NodeHandle("~/" + name_);
-  private_node_handle_.setCallbackQueue(&callback_queue_);
+  std::string node_namespace = "";
+
+  rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
+  auto node_options = rclcpp::NodeOptions();
+
+  ros_context->init(0, NULL);    // XXX should expose the init arg list
+  node_options.context(ros_context); //set a context to generate the node in
+
+  node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
+
+  auto executor_options = rclcpp::ExecutorOptions();
+  executor_options.context = ros_context;
+  executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(executor_options, executor_thread_count_);
+
+  callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
+  node_->get_node_waitables_interface()->add_waitable(
+    callback_queue_, (rclcpp::CallbackGroup::SharedPtr) nullptr);
 
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
-  // Start the async spinner to service the local callback queue
-  spinner_.start();
+  executor_->add_node(node_);
+}
+
+void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
+{
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))
+  );
+  auto result = callback->getFuture();
+  callback_queue_->addCallback(callback);
+  result.wait();
 }
 
 void AsyncMotionModel::start()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStart, this));
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncMotionModel::onStart, this)
+  );
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
   result.wait();
 }
 
 void AsyncMotionModel::stop()
 {
-  if (ros::ok())
+  if (rclcpp::ok())
   {
-    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStop, this));
+    auto callback = std::make_shared<CallbackWrapper<void>>(
+      std::bind(&AsyncMotionModel::onStop, this)
+    );
     auto result = callback->getFuture();
-    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    callback_queue_->addCallback(callback);
     result.wait();
   }
   else
   {
-    spinner_.stop();
+    executor_->cancel();
+    executor_->remove_node(node_);
+
     onStop();
   }
 }

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -36,6 +36,7 @@
 #include <fuse_core/callback_wrapper.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
+#include <rclcpp/contexts/default_context.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <functional>
@@ -76,7 +77,7 @@ void AsyncMotionModel::initialize(const std::string& name)
   name_ = name;
   std::string node_namespace = "";
 
-  rclcpp::Context::SharedPtr ros_context = std::make_shared<rclcpp::Context>();
+  rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
 
   ros_context->init(0, NULL);    // XXX should expose the init arg list

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -104,9 +104,9 @@ void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
   auto callback = std::make_shared<CallbackWrapper<void>>(
     std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))
   );
-  auto result = callback->getFuture();
+  // auto result = callback->getFuture();  // TODO(CH3): Circle back if we need this again
   callback_queue_->addCallback(callback);
-  result.wait();
+  // result.wait();
 }
 
 void AsyncMotionModel::start()

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -70,14 +70,6 @@ bool AsyncMotionModel::apply(Transaction& transaction)
   return result.get();
 }
 
-void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
-{
-  auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph)));
-  auto result = callback->getFuture();
-  callback_queue_->addCallback(callback);
-  result.wait();
-}
-
 void AsyncMotionModel::initialize(const std::string& name)
 {
   // Initialize internal state
@@ -106,9 +98,21 @@ void AsyncMotionModel::initialize(const std::string& name)
   executor_->add_node(node_);
 }
 
+void AsyncMotionModel::graphCallback(Graph::ConstSharedPtr graph)
+{
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncMotionModel::onGraphUpdate, this, std::move(graph))
+  );
+  auto result = callback->getFuture();
+  callback_queue_->addCallback(callback);
+  result.wait();
+}
+
 void AsyncMotionModel::start()
 {
-  auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStart, this));
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncMotionModel::onStart, this)
+  );
   auto result = callback->getFuture();
   callback_queue_->addCallback(callback);
   result.wait();
@@ -118,7 +122,9 @@ void AsyncMotionModel::stop()
 {
   if (rclcpp::ok())
   {
-    auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncMotionModel::onStop, this));
+    auto callback = std::make_shared<CallbackWrapper<void>>(
+      std::bind(&AsyncMotionModel::onStop, this)
+    );
     auto result = callback->getFuture();
     callback_queue_->addCallback(callback);
     result.wait();

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -119,7 +119,7 @@ void AsyncMotionModel::start()
 
 void AsyncMotionModel::stop()
 {
-  if (rclcpp::ok())
+  if (node_->get_node_base_interface()->get_context()->is_valid())
   {
     auto callback = std::make_shared<CallbackWrapper<void>>(
       std::bind(&AsyncMotionModel::onStop, this)

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -79,8 +79,6 @@ void AsyncMotionModel::initialize(const std::string& name)
 
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
-
-  ros_context->init(0, NULL);    // XXX should expose the init arg list
   node_options.context(ros_context); //set a context to generate the node in
 
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);

--- a/fuse_core/src/async_motion_model.cpp
+++ b/fuse_core/src/async_motion_model.cpp
@@ -77,10 +77,12 @@ void AsyncMotionModel::initialize(const std::string& name)
   name_ = name;
   std::string node_namespace = "";
 
+  // TODO(CH3): Pass in the context or a node to get the context from
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
   node_options.context(ros_context); //set a context to generate the node in
 
+  // TODO(CH3): Potentially pass in the optimizer node instead of spinning a new one
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
 
   auto executor_options = rclcpp::ExecutorOptions();

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -33,6 +33,8 @@
  */
 #include <fuse_core/async_publisher.h>
 
+#include <rclcpp/contexts/default_context.hpp>
+
 
 namespace fuse_core
 {
@@ -49,7 +51,7 @@ void AsyncPublisher::initialize(const std::string& name)
   name_ = name;
   std::string node_namespace = "";
 
-  rclcpp::Context::SharedPtr ros_context = std::make_shared<rclcpp::Context>();
+  rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
 
   ros_context->init(0, NULL);    // XXX should expose the init arg list

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -91,7 +91,7 @@ void AsyncPublisher::start()
 
 void AsyncPublisher::stop()
 {
-  if (rclcpp::ok())
+  if (node_->get_node_base_interface()->get_context()->is_valid())
   {
     auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStop, this));
     auto result = callback->getFuture();

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -70,8 +70,7 @@ void AsyncPublisher::initialize(const std::string& name)
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
-  // Start the async spinner to service the local callback queue
-  // XXX spinner_.start();
+  executor_->add_node(node_);
 }
 
 void AsyncPublisher::notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph)

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -33,24 +33,13 @@
  */
 #include <fuse_core/async_publisher.h>
 
-#include <fuse_core/callback_wrapper.h>
-#include <fuse_core/graph.h>
-#include <fuse_core/transaction.h>
-#include <ros/node_handle.h>
-
-#include <boost/make_shared.hpp>
-
-#include <functional>
-#include <utility>
-#include <string>
-
 
 namespace fuse_core
 {
 
 AsyncPublisher::AsyncPublisher(size_t thread_count) :
   name_("uninitialized"),
-  spinner_(thread_count, &callback_queue_)
+  executor_thread_count_(thread_count)
 {
 }
 
@@ -58,46 +47,62 @@ void AsyncPublisher::initialize(const std::string& name)
 {
   // Initialize internal state
   name_ = name;
-  node_handle_.setCallbackQueue(&callback_queue_);
-  private_node_handle_ = ros::NodeHandle("~/" + name_);
-  private_node_handle_.setCallbackQueue(&callback_queue_);
+  std::string node_namespace = "";
+
+  rclcpp::Context::SharedPtr ros_context = std::make_shared<rclcpp::Context>();
+  auto node_options = rclcpp::NodeOptions();
+
+  ros_context->init(0, NULL);    // XXX should expose the init arg list
+  node_options.context(ros_context); //set a context to generate the node in
+
+  node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
+
+  auto executor_options = rclcpp::ExecutorOptions();
+  executor_options.context = ros_context;
+  executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(executor_options, executor_thread_count_);
+
+  callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
+  node_->get_node_waitables_interface()->add_waitable(
+    callback_queue_, (rclcpp::CallbackGroup::SharedPtr) nullptr);
 
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
   // Start the async spinner to service the local callback queue
-  spinner_.start();
+  // XXX spinner_.start();
 }
 
 void AsyncPublisher::notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph)
 {
   // Insert a call to the `notifyCallback` method into the internal callback queue.
   // This minimizes the time spent by the optimizer's thread calling this function.
-  auto callback = boost::make_shared<CallbackWrapper<void>>(
+  auto callback = std::make_shared<CallbackWrapper<void>>(
     std::bind(&AsyncPublisher::notifyCallback, this, std::move(transaction), std::move(graph)));
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
 }
 
 void AsyncPublisher::start()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStart, this));
+  auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStart, this));
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
   result.wait();
 }
 
 void AsyncPublisher::stop()
 {
-  if (ros::ok())
+  if (rclcpp::ok())
   {
-    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStop, this));
+    auto callback = std::make_shared<CallbackWrapper<void>>(std::bind(&AsyncPublisher::onStop, this));
     auto result = callback->getFuture();
-    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    callback_queue_->addCallback(callback);
     result.wait();
   }
   else
   {
-    spinner_.stop();
+    executor_->cancel();
+    executor_->remove_node(node_);
+
     onStop();
   }
 }

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -53,8 +53,6 @@ void AsyncPublisher::initialize(const std::string& name)
 
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
-
-  ros_context->init(0, NULL);    // XXX should expose the init arg list
   node_options.context(ros_context); //set a context to generate the node in
 
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -51,10 +51,12 @@ void AsyncPublisher::initialize(const std::string& name)
   name_ = name;
   std::string node_namespace = "";
 
+  // TODO(CH3): Pass in the context or a node to get the context from
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
   node_options.context(ros_context); //set a context to generate the node in
 
+  // TODO(CH3): Potentially pass in the optimizer node instead of spinning a new one
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
 
   auto executor_options = rclcpp::ExecutorOptions();

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -36,30 +36,22 @@
 #include <fuse_core/callback_wrapper.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
-#include <ros/callback_queue.h>
-
-#include <boost/make_shared.hpp>
 
 #include <functional>
 #include <utility>
 #include <string>
 
+#include <rclcpp/contexts/default_context.hpp>
 
 namespace fuse_core
 {
 
 AsyncSensorModel::AsyncSensorModel(size_t thread_count) :
   name_("uninitialized"),
-  spinner_(thread_count, &callback_queue_)
+  executor_thread_count_(thread_count)
 {
 }
 
-void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)
-{
-  callback_queue_.addCallback(
-    boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))),
-    reinterpret_cast<uint64_t>(this));
-}
 
 void AsyncSensorModel::initialize(
   const std::string& name,
@@ -67,16 +59,39 @@ void AsyncSensorModel::initialize(
 {
   // Initialize internal state
   name_ = name;
-  node_handle_.setCallbackQueue(&callback_queue_);
-  private_node_handle_ = ros::NodeHandle("~/" + name_);
-  private_node_handle_.setCallbackQueue(&callback_queue_);
+  std::string node_namespace = "";
+
+  rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
+  auto node_options = rclcpp::NodeOptions();
+
+  ros_context->init(0, NULL);    // XXX should expose the init arg list
+  node_options.context(ros_context); //set a context to generate the node in
+
+  node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
+
+  auto executor_options = rclcpp::ExecutorOptions();
+  executor_options.context = ros_context;
+  executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(executor_options, executor_thread_count_);
+
+  callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
+  node_->get_node_waitables_interface()->add_waitable(
+    callback_queue_, (rclcpp::CallbackGroup::SharedPtr) nullptr);
+
   transaction_callback_ = transaction_callback;
 
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
   // Start the async spinner to service the local callback queue
-  spinner_.start();
+  executor_->add_node(node_);
+}
+
+void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)
+{
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))
+  );
+  callback_queue_->addCallback(callback);
 }
 
 void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
@@ -86,24 +101,30 @@ void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
 
 void AsyncSensorModel::start()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStart, this));
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncSensorModel::onStart, this)
+  );
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
   result.wait();
 }
 
 void AsyncSensorModel::stop()
 {
-  if (ros::ok())
+  if (rclcpp::ok())
   {
-    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStop, this));
+    auto callback = std::make_shared<CallbackWrapper<void>>(
+      std::bind(&AsyncSensorModel::onStop, this)
+    );
     auto result = callback->getFuture();
-    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    callback_queue_->addCallback(callback);
     result.wait();
   }
   else
   {
-    spinner_.stop();
+    executor_->cancel();
+    executor_->remove_node(node_);
+
     onStop();
   }
 }

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -41,6 +41,7 @@
 #include <utility>
 #include <string>
 
+#include <rclcpp/contexts/default_context.hpp>
 
 namespace fuse_core
 {
@@ -60,7 +61,7 @@ void AsyncSensorModel::initialize(
   name_ = name;
   std::string node_namespace = "";
 
-  rclcpp::Context::SharedPtr ros_context = std::make_shared<rclcpp::Context>();
+  rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
 
   ros_context->init(0, NULL);    // XXX should expose the init arg list

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -36,9 +36,6 @@
 #include <fuse_core/callback_wrapper.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
-#include <ros/callback_queue.h>
-
-#include <boost/make_shared.hpp>
 
 #include <functional>
 #include <utility>
@@ -50,16 +47,10 @@ namespace fuse_core
 
 AsyncSensorModel::AsyncSensorModel(size_t thread_count) :
   name_("uninitialized"),
-  spinner_(thread_count, &callback_queue_)
+  executor_thread_count_(thread_count)
 {
 }
 
-void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)
-{
-  callback_queue_.addCallback(
-    boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))),
-    reinterpret_cast<uint64_t>(this));
-}
 
 void AsyncSensorModel::initialize(
   const std::string& name,
@@ -67,16 +58,39 @@ void AsyncSensorModel::initialize(
 {
   // Initialize internal state
   name_ = name;
-  node_handle_.setCallbackQueue(&callback_queue_);
-  private_node_handle_ = ros::NodeHandle("~/" + name_);
-  private_node_handle_.setCallbackQueue(&callback_queue_);
+  std::string node_namespace = "";
+
+  rclcpp::Context::SharedPtr ros_context = std::make_shared<rclcpp::Context>();
+  auto node_options = rclcpp::NodeOptions();
+
+  ros_context->init(0, NULL);    // XXX should expose the init arg list
+  node_options.context(ros_context); //set a context to generate the node in
+
+  node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
+
+  auto executor_options = rclcpp::ExecutorOptions();
+  executor_options.context = ros_context;
+  executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(executor_options, executor_thread_count_);
+
+  callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
+  node_->get_node_waitables_interface()->add_waitable(
+    callback_queue_, (rclcpp::CallbackGroup::SharedPtr) nullptr);
+
   transaction_callback_ = transaction_callback;
 
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
   // Start the async spinner to service the local callback queue
-  spinner_.start();
+  executor_->add_node(node_);
+}
+
+void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)
+{
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncSensorModel::onGraphUpdate, this, std::move(graph))
+  );
+  callback_queue_->addCallback(callback);
 }
 
 void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
@@ -86,24 +100,30 @@ void AsyncSensorModel::sendTransaction(Transaction::SharedPtr transaction)
 
 void AsyncSensorModel::start()
 {
-  auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStart, this));
+  auto callback = std::make_shared<CallbackWrapper<void>>(
+    std::bind(&AsyncSensorModel::onStart, this)
+  );
   auto result = callback->getFuture();
-  callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+  callback_queue_->addCallback(callback);
   result.wait();
 }
 
 void AsyncSensorModel::stop()
 {
-  if (ros::ok())
+  if (rclcpp::ok())
   {
-    auto callback = boost::make_shared<CallbackWrapper<void>>(std::bind(&AsyncSensorModel::onStop, this));
+    auto callback = std::make_shared<CallbackWrapper<void>>(
+      std::bind(&AsyncSensorModel::onStop, this)
+    );
     auto result = callback->getFuture();
-    callback_queue_.addCallback(callback, reinterpret_cast<uint64_t>(this));
+    callback_queue_->addCallback(callback);
     result.wait();
   }
   else
   {
-    spinner_.stop();
+    executor_->cancel();
+    executor_->remove_node(node_);
+
     onStop();
   }
 }

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -109,7 +109,7 @@ void AsyncSensorModel::start()
 
 void AsyncSensorModel::stop()
 {
-  if (rclcpp::ok())
+  if (node_->get_node_base_interface()->get_context()->is_valid())
   {
     auto callback = std::make_shared<CallbackWrapper<void>>(
       std::bind(&AsyncSensorModel::onStop, this)

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -63,8 +63,6 @@ void AsyncSensorModel::initialize(
 
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
-
-  ros_context->init(0, NULL);    // XXX should expose the init arg list
   node_options.context(ros_context); //set a context to generate the node in
 
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -61,10 +61,12 @@ void AsyncSensorModel::initialize(
   name_ = name;
   std::string node_namespace = "";
 
+  // TODO(CH3): Pass in the context or a node to get the context from
   rclcpp::Context::SharedPtr ros_context = rclcpp::contexts::get_global_default_context();
   auto node_options = rclcpp::NodeOptions();
   node_options.context(ros_context); //set a context to generate the node in
 
+  // TODO(CH3): Potentially pass in the optimizer node instead of spinning a new one
   node_ = rclcpp::Node::make_shared(name_, node_namespace, node_options);
 
   auto executor_options = rclcpp::ExecutorOptions();

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -1,0 +1,145 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Brett Downing
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_core/callback_wrapper.h>
+
+namespace fuse_core
+{
+
+
+  CallbackAdapter::CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr){
+
+    rcl_guard_condition_options_t guard_condition_options =
+        rcl_guard_condition_get_default_options();
+
+    // Guard condition is used by the wait set to handle execute-or-not logic
+    gc_ = rcl_get_zero_initialized_guard_condition();
+    if (RCL_RET_OK != rcl_guard_condition_init(
+      &gc_, context_ptr->get_rcl_context().get(), guard_condition_options)
+    ) {
+      RCLCPP_WARN(rclcpp::get_logger("fuse"),
+                  "Could not init guard condition for callback waitable.");
+    }
+  }
+
+  /**
+   * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
+   */
+  size_t CallbackAdapter::get_number_of_ready_guard_conditions() { return 1;}
+
+
+  /**
+   * @brief tell the CallbackGroup that this waitable is ready to execute anything
+   */
+  bool CallbackAdapter::is_ready(rcl_wait_set_t * wait_set) {
+    (void) wait_set;
+    // std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    // a thread glitch isn't a disaster here and a mutex wouldn't stop it anyway
+    return !callback_queue_.empty();
+  }
+
+
+  /**
+   * @brief add_to_wait_set is called by rclcpp during NodeWaitables::add_waitable() and CallbackGroup::add_waitable()
+    waitable_ptr = std::make_shared<CallbackAdapter>();
+    node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
+   */
+  void CallbackAdapter::add_to_wait_set(rcl_wait_set_t * wait_set)
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+    RCLCPP_WARN(rclcpp::get_logger("fuse"),
+    "Could not add callback waitable to wait set.");
+    if (RCL_RET_OK != rcl_wait_set_add_guard_condition(wait_set, &gc_, NULL)) {
+    }
+  }
+
+  /**
+   * @brief unused part of the rclcpp::waitables interface
+   *
+   */
+  std::shared_ptr< void > CallbackAdapter::take_data(){
+    return nullptr;
+  }
+
+  /**
+   * @brief hook that allows the rclcpp::waitables interface to run the next callback
+   *
+   */
+  void CallbackAdapter::execute(std::shared_ptr<void> & /*data*/){
+    std::shared_ptr<CallbackWrapperBase> cb_wrapper = nullptr;
+    // fetch the callback ptr and release the lock without spending time in the callback
+    {
+      std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+      if(!callback_queue_.empty()){
+        cb_wrapper = callback_queue_.front();
+        callback_queue_.pop_front();
+      }
+    }
+    //the lock is released and the callback is no longer associated with the queue, run it.
+    if(cb_wrapper) {
+      cb_wrapper->call();
+    }
+  }
+
+  void CallbackAdapter::addCallback(const std::shared_ptr<CallbackWrapperBase> &callback){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    callback_queue_.push_back(callback);
+    if (RCL_RET_OK != rcl_trigger_guard_condition(&gc_)) {
+      RCLCPP_WARN(rclcpp::get_logger("fuse"),
+                  "Could not trigger guard condition for callback, pulling callback off the queue.");
+      callback_queue_.pop_back();  // Undo
+    }
+  }
+
+  void CallbackAdapter::addCallback(std::shared_ptr<CallbackWrapperBase> && callback){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    callback_queue_.push_back(std::move(callback));
+    if (RCL_RET_OK != rcl_trigger_guard_condition(&gc_)) {
+      RCLCPP_WARN(rclcpp::get_logger("fuse"),
+                  "Could not trigger guard condition for callback, pulling callback off the queue.");
+      callback_queue_.pop_back();  // Undo
+    }
+  }
+
+  void CallbackAdapter::removeAllCallbacks(){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    while(!callback_queue_.empty()){
+      callback_queue_.pop_front();
+    }
+  }
+
+
+
+
+}  // namespace fuse_core

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -127,7 +127,7 @@ namespace fuse_core
   void CallbackAdapter::removeAllCallbacks(){
     std::lock_guard<std::mutex> lock(queue_mutex_);
     while(!callback_queue_.empty()){
-      callback_queue_.pop_front();
+      callback_queue_.clear();
     }
   }
 

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -84,7 +84,7 @@ namespace fuse_core
    * @brief unused part of the rclcpp::waitables interface
    *
    */
-  std::shared_ptr< void > take_data(){
+  std::shared_ptr< void > CallbackAdapter::take_data(){
     return nullptr;
   }
 

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -1,0 +1,121 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Brett Downing
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_core/callback_wrapper.h>
+
+namespace fuse_core
+{
+
+
+  CallbackAdapter::CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr){
+
+    rcl_guard_condition_options_t guard_condition_options = 
+        rcl_guard_condition_get_default_options();
+
+    // Guard condition is used by the wait set to handle execute-or-not logic
+    gc_ = rcl_get_zero_initialized_guard_condition();
+    rcl_ret_t ret = rcl_guard_condition_init(
+        &gc_, context_ptr->get_rcl_context().get(), guard_condition_options);
+  }
+
+  /**
+   * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
+   */
+  size_t CallbackAdapter::get_number_of_ready_guard_conditions() { return 1;}
+
+
+  /**
+   * @brief tell the CallbackGroup that this waitable is ready to execute anything
+   */
+  bool CallbackAdapter::is_ready(rcl_wait_set_t * wait_set) {
+    (void) wait_set;
+    // std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    // a thread glitch isn't a disaster here and a mutex wouldn't stop it anyway
+    return !callback_queue_.empty();
+  }
+
+
+  /**
+   * @brief add_to_wait_set is called by rclcpp during NodeWaitables::add_waitable() and CallbackGroup::add_waitable()
+    waitable_ptr = std::make_shared<CallbackAdapter>();
+    node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
+   */
+  bool CallbackAdapter::add_to_wait_set(rcl_wait_set_t * wait_set)
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+    rcl_ret_t ret = rcl_wait_set_add_guard_condition(wait_set, &gc_, NULL);
+    return RCL_RET_OK == ret;
+  }
+
+
+  // XXX check this against the threading model of the multi-threaded executor.
+  void CallbackAdapter::execute(){
+    std::shared_ptr<CallbackWrapperBase> cb_wrapper = nullptr;
+    // fetch the callback ptr and release the lock without spending time in the callback
+    {
+      std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+      if(!callback_queue_.empty()){
+        cb_wrapper = callback_queue_.front();
+        callback_queue_.pop();
+      }
+    }
+    //the lock is released and the callback is no longer associated with the queue, run it.
+    if(cb_wrapper) {
+      cb_wrapper->call();
+    }
+  }
+
+  void CallbackAdapter::addCallback(const std::shared_ptr<CallbackWrapperBase> &callback){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    callback_queue_.push(callback);
+    rcl_trigger_guard_condition(&gc_);
+  } 
+
+  void CallbackAdapter::addCallback(std::shared_ptr<CallbackWrapperBase> && callback){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    callback_queue_.push(std::move(callback));
+    rcl_trigger_guard_condition(&gc_);
+  }
+
+  void CallbackAdapter::removeAllCallbacks(){
+    std::lock_guard<std::recursive_mutex> lock(queue_mutex_);
+    while(!callback_queue_.empty()){
+      callback_queue_.pop();
+    }
+  }
+
+
+
+
+}  // namespace fuse_core

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -126,9 +126,7 @@ namespace fuse_core
 
   void CallbackAdapter::removeAllCallbacks(){
     std::lock_guard<std::mutex> lock(queue_mutex_);
-    while(!callback_queue_.empty()){
-      callback_queue_.clear();
-    }
+    callback_queue_.clear();
   }
 
 

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -182,8 +182,6 @@ protected:
    *
    * This callback checks if a current optimization cycle is still running. If not, a new optimization cycle is started.
    * If so, we simply wait for the next timer event to start another optimization cycle.
-   *
-   * @param event  The ROS timer event metadata
    */
   void optimizerTimerCallback();
 

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -152,7 +152,7 @@ protected:
                                                     //!< until a new optimization is requested by the main thread
   std::mutex optimization_requested_mutex_;  //!< Required condition variable mutex
   std::thread optimization_thread_;  //!< Thread used to run the optimizer as a background process
-  ros::Timer optimize_timer_;  //!< Trigger an optimization operation at a fixed frequency
+  rclcpp::TimerBase::SharedPtr optimize_timer_;  //!< Trigger an optimization operation at a fixed frequency
   TransactionQueue pending_transactions_;  //!< The set of received transactions that have not been added to the
                                            //!< optimizer yet. Transactions are added by the main thread, and removed
                                            //!< and processed by the optimization thread.
@@ -182,10 +182,8 @@ protected:
    *
    * This callback checks if a current optimization cycle is still running. If not, a new optimization cycle is started.
    * If so, we simply wait for the next timer event to start another optimization cycle.
-   *
-   * @param event  The ROS timer event metadata
    */
-  void optimizerTimerCallback(const ros::TimerEvent& event);
+  void optimizerTimerCallback();
 
   /**
    * @brief Callback fired every time the SensorModel plugin creates a new transaction

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -39,7 +39,8 @@
 #include <fuse_optimizers/fixed_lag_smoother_params.h>
 #include <fuse_optimizers/optimizer.h>
 #include <fuse_optimizers/variable_stamp_index.h>
-#include <ros/ros.h>
+
+#include <rclcpp/rclcpp.hpp>
 #include <std_srvs/Empty.h>
 
 #include <atomic>
@@ -247,8 +248,6 @@ protected:
    *
    * This callback checks if a current optimization cycle is still running. If not, a new optimization cycle is started.
    * If so, we simply wait for the next timer event to start another optimization cycle.
-   *
-   * @param event  The ROS timer event metadata
    */
   void optimizerTimerCallback();
 
@@ -271,7 +270,7 @@ protected:
   bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 
   /**
-   * @brief Thread-safe read-only access to the optimizer start time
+   * @brief Thread-safe read-only access to the timestamp of the first transaction
    */
   rclcpp::Time getStartTime() const
   {

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -39,7 +39,8 @@
 #include <fuse_optimizers/fixed_lag_smoother_params.h>
 #include <fuse_optimizers/optimizer.h>
 #include <fuse_optimizers/variable_stamp_index.h>
-#include <ros/ros.h>
+
+#include <rclcpp/rclcpp.hpp>
 #include <std_srvs/Empty.h>
 
 #include <atomic>
@@ -247,10 +248,8 @@ protected:
    *
    * This callback checks if a current optimization cycle is still running. If not, a new optimization cycle is started.
    * If so, we simply wait for the next timer event to start another optimization cycle.
-   *
-   * @param event  The ROS timer event metadata
    */
-  void optimizerTimerCallback(const ros::TimerEvent& event);
+  void optimizerTimerCallback();
 
   /**
    * @brief Generate motion model constraints for pending transactions and combine them into a single transaction
@@ -271,7 +270,7 @@ protected:
   bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 
   /**
-   * @brief Thread-safe read-only access to the optimizer start time
+   * @brief Thread-safe read-only access to the timestamp of the first transaction
    */
   ros::Time getStartTime() const
   {

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -42,8 +42,7 @@
 #include <fuse_core/sensor_model.h>
 #include <fuse_core/transaction.h>
 #include <pluginlib/class_loader.hpp>
-#include <ros/ros.h>
-// #include <rclcpp/rclcpp.hpp> TODO(CH3): Uncomment when it's time
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
 #include <unordered_map>
@@ -105,9 +104,9 @@ public:
    * @param[in] private_node_handle A node handle in the node's private namespace
    */
   Optimizer(
+    rclcpp::NodeOptions options,
     fuse_core::Graph::UniquePtr graph,
-    const ros::NodeHandle& node_handle = ros::NodeHandle(),
-    const ros::NodeHandle& private_node_handle = ros::NodeHandle("~"));
+    );
 
   /**
    * @brief Destructor
@@ -151,9 +150,6 @@ protected:
   AssociatedMotionModels associated_motion_models_;  //!< Tracks what motion models should be used for each sensor
   fuse_core::Graph::UniquePtr graph_;  //!< The graph object that holds all variables and constraints
 
-  // Ordering ROS objects with callbacks last
-  ros::NodeHandle node_handle_;  //!< Node handle in the public namespace for subscribing and advertising
-  ros::NodeHandle private_node_handle_;  //!< Node handle in the private namespace for reading configuration settings
   pluginlib::ClassLoader<fuse_core::MotionModel> motion_model_loader_;  //!< Pluginlib class loader for MotionModels
   MotionModels motion_models_;  //!< The set of motion models, addressable by name
   pluginlib::ClassLoader<fuse_core::Publisher> publisher_loader_;  //!< Pluginlib class loader for Publishers
@@ -162,8 +158,11 @@ protected:
   SensorModels sensor_models_;  //!< The set of sensor models, addressable by name
 
   diagnostic_updater::Updater diagnostic_updater_;  //!< Diagnostic updater
-  ros::Timer diagnostic_updater_timer_;  //!< Diagnostic updater timer
+  rclcpp::TimerBase::SharedPtr diagnostic_updater_timer_; //!< Diagnostic updater timer
   double diagnostic_updater_timer_period_{ 1.0 };  //!< Diagnostic updater timer period in seconds
+
+  std::shared_ptr<fuse_core::CallbackAdapter> callback_queue_;
+
 
   /**
    * @brief Callback fired every time a SensorModel plugin creates a new transaction
@@ -226,7 +225,7 @@ protected:
     fuse_core::Transaction::ConstSharedPtr transaction,
     fuse_core::Graph::ConstSharedPtr graph);
 
-   /**
+  /**
    * @brief Inject a transaction callback function into the global callback queue
    *
    * @param[in] sensor_name The name of the sensor that produced the Transaction

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -48,14 +48,13 @@ namespace fuse_optimizers
 
 BatchOptimizer::BatchOptimizer(
   rclcpp::NodeOptions options,
-  std::string node_name,
   fuse_core::Graph::UniquePtr graph
 ):
-  fuse_optimizers::Optimizer(options, node_name, std::move(graph)),
+  fuse_optimizers::Optimizer(options, std::move(graph)),
   combined_transaction_(fuse_core::Transaction::make_shared()),
   optimization_request_(false),
-    start_time_(rclcpp::Time::max()),  // NOTE(CH3): ???
-    started_(false)
+  start_time_(rclcpp::Time::max()),
+  started_(false)
 {
   params_.loadFromROS(private_node_handle);
 
@@ -130,15 +129,15 @@ void BatchOptimizer::applyMotionModelsToQueue()
 void BatchOptimizer::optimizationLoop()
 {
   // Optimize constraints until told to exit
-  while (ros::ok())
+  while (rclcpp::ok())
   {
     // Wait for the next signal to start the next optimization cycle
     {
       std::unique_lock<std::mutex> lock(optimization_requested_mutex_);
-      optimization_requested_.wait(lock, [this]{ return optimization_request_ || !ros::ok(); });  // NOLINT
+      optimization_requested_.wait(lock, [this]{ return optimization_request_ || !rclcpp::ok(); });  // NOLINT
     }
     // If a shutdown is requested, exit now.
-    if (!ros::ok())
+    if (!rclcpp::ok())
     {
       break;
     }

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -47,22 +47,22 @@ namespace fuse_optimizers
 {
 
 BatchOptimizer::BatchOptimizer(
-  fuse_core::Graph::UniquePtr graph,
-  const ros::NodeHandle& node_handle,
-  const ros::NodeHandle& private_node_handle) :
-    fuse_optimizers::Optimizer(std::move(graph), node_handle, private_node_handle),
-    combined_transaction_(fuse_core::Transaction::make_shared()),
-    optimization_request_(false),
-    start_time_(ros::TIME_MAX),
-    started_(false)
+  rclcpp::NodeOptions options,
+  fuse_core::Graph::UniquePtr graph
+):
+  fuse_optimizers::Optimizer(options, std::move(graph)),
+  combined_transaction_(fuse_core::Transaction::make_shared()),
+  optimization_request_(false),
+  start_time_(rclcpp::Time::max()),
+  started_(false)
 {
   params_.loadFromROS(private_node_handle);
 
   // Configure a timer to trigger optimizations
-  optimize_timer_ = node_handle_.createTimer(
-    ros::Duration(params_.optimization_period),
-    &BatchOptimizer::optimizerTimerCallback,
-    this);
+  optimize_timer_ = this->create_wall_timer(
+    params_.optimization_period,
+    &BatchOptimizer::optimizerTimerCallback
+  );
 
   // Start the optimization thread
   optimization_thread_ = std::thread(&BatchOptimizer::optimizationLoop, this);
@@ -126,15 +126,15 @@ void BatchOptimizer::applyMotionModelsToQueue()
 void BatchOptimizer::optimizationLoop()
 {
   // Optimize constraints until told to exit
-  while (ros::ok())
+  while (rclcpp::ok())
   {
     // Wait for the next signal to start the next optimization cycle
     {
       std::unique_lock<std::mutex> lock(optimization_requested_mutex_);
-      optimization_requested_.wait(lock, [this]{ return optimization_request_ || !ros::ok(); });  // NOLINT
+      optimization_requested_.wait(lock, [this]{ return optimization_request_ || !rclcpp::ok(); });  // NOLINT
     }
     // If a shutdown is requested, exit now.
-    if (!ros::ok())
+    if (!rclcpp::ok())
     {
       break;
     }
@@ -158,7 +158,7 @@ void BatchOptimizer::optimizationLoop()
   }
 }
 
-void BatchOptimizer::optimizerTimerCallback(const ros::TimerEvent& /*event*/)
+void BatchOptimizer::optimizerTimerCallback()
 {
   // If an "ignition" transaction hasn't been received, then we can't do anything yet.
   if (!started_)

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -126,15 +126,19 @@ void BatchOptimizer::applyMotionModelsToQueue()
 void BatchOptimizer::optimizationLoop()
 {
   // Optimize constraints until told to exit
-  while (rclcpp::ok())
+  while (get_node_base_interface()->get_context()->is_valid())
   {
     // Wait for the next signal to start the next optimization cycle
     {
       std::unique_lock<std::mutex> lock(optimization_requested_mutex_);
-      optimization_requested_.wait(lock, [this]{ return optimization_request_ || !rclcpp::ok(); });  // NOLINT
+      optimization_requested_.wait(
+        lock,
+        [this]{
+          return optimization_request_ || !get_node_base_interface()->get_context()->is_valid();
+        });
     }
     // If a shutdown is requested, exit now.
-    if (!rclcpp::ok())
+    if (!get_node_base_interface()->get_context()->is_valid())
     {
       break;
     }

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -144,6 +144,7 @@ ros::Time FixedLagSmoother::computeLagExpirationTime() const
   auto start_time = getStartTime();
   auto now = timestamp_tracking_.currentStamp();
   // Then carefully subtract the lag duration. ROS Time objects do not handle negative values.
+  // XXX moved to std::Time for timestamps, this hack is no longer necessary
   return (start_time + params_.lag_duration < now) ? now - params_.lag_duration : start_time;
 }
 
@@ -248,7 +249,7 @@ void FixedLagSmoother::optimizationLoop()
       postprocessMarginalization(marginal_transaction_);
       // Note: The marginal transaction will not be applied until the next optimization iteration
       // Log a warning if the optimization took too long
-      auto optimization_complete = ros::Time::now();
+      auto optimization_complete = ros::Time::now();  // XXX use the timestamp tracking to tell the robot time
       if (optimization_complete > optimization_deadline)
       {
         RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 10.0 * 1000,
@@ -259,7 +260,7 @@ void FixedLagSmoother::optimizationLoop()
   }
 }
 
-void FixedLagSmoother::optimizerTimerCallback(const ros::TimerEvent& event)
+void FixedLagSmoother::optimizerTimerCallback()
 {
   // If an "ignition" transaction hasn't been received, then we can't do anything yet.
   if (!started_)

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -37,9 +37,6 @@
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 #include <fuse_optimizers/optimizer.h>
-#include <ros/callback_queue.h>
-#include <ros/init.h>
-#include <ros/node_handle.h>
 
 #include <XmlRpcValue.h>
 
@@ -80,28 +77,30 @@ struct PluginConfig
   XmlRpc::XmlRpcValue config;  //!< The entire configuration, that might have additional optional parameters
 };
 
-Optimizer::Optimizer(
-  fuse_core::Graph::UniquePtr graph,
-  const ros::NodeHandle& node_handle,
-  const ros::NodeHandle& private_node_handle) :
+// TODO(CH3): pass a rclcpp::Context, and a CallbackGroup
+Optimizer::Optimizer(rclcpp::NodeOptions options, fuse_core::Graph::UniquePtr graph) :
+    Node("optimizer_node", options),
     graph_(std::move(graph)),
-    node_handle_(node_handle),
-    private_node_handle_(private_node_handle),
     motion_model_loader_("fuse_core", "fuse_core::MotionModel"),
     publisher_loader_("fuse_core", "fuse_core::Publisher"),
     sensor_model_loader_("fuse_core", "fuse_core::SensorModel"),
-    diagnostic_updater_(node_handle_)
+    diagnostic_updater_(shared_from_this()),
+    callback_queue_(rclcpp::contexts::get_global_default_context())
 {
   // Setup diagnostics updater
-  private_node_handle_.param("diagnostic_updater_timer_period", diagnostic_updater_timer_period_,
-                             diagnostic_updater_timer_period_);
+  // TODO(CH3): private_node_handle_.param("diagnostic_updater_timer_period", diagnostic_updater_timer_period_,
+  //                                       diagnostic_updater_timer_period_);
 
   diagnostic_updater_timer_ = this->create_timer(
     rclcpp::Duration::from_seconds(diagnostic_updater_timer_period_),
     std::bind(&diagnostic_updater::Updater::update, &diagnostic_updater_)
   );
 
-  diagnostic_updater_.add(private_node_handle_.getNamespace(), this, &Optimizer::setDiagnostics);
+  //add a ros1 style callback queue so that transactions can be processed in the optimiser's executor
+  this->get_node_waitables_interface()->add_waitable(
+    callback_queue_, (rclcpp::CallbackGroup::SharedPtr) nullptr);
+
+  diagnostic_updater_.add(this->get_namespace(), this, &Optimizer::setDiagnostics);
   diagnostic_updater_.setHardwareID("fuse");
 
   // Wait for a valid time before loading any of the plugins
@@ -434,15 +433,15 @@ void Optimizer::injectCallback(
   // We are going to insert a call to the derived class's transactionCallback() method into the global callback queue.
   // This returns execution to the sensor's thread quickly by moving the transaction processing to the optimizer's
   // thread. And by using the existing ROS callback queue, we simplify the threading model of the optimizer.
-  ros::getGlobalCallbackQueue()->addCallback(
-    boost::make_shared<fuse_core::CallbackWrapper<void>>(
-      std::bind(&Optimizer::transactionCallback, this, sensor_name, std::move(transaction))),
-    reinterpret_cast<uint64_t>(this));
+
+  auto callback = std::make_shared<fuse_core::CallbackWrapper<void>>(
+      std::bind(&Optimizer::transactionCallback, this, sensor_name, std::move(transaction)));
+  callback_queue_->addCallback(callback, (rclcpp::CallbackGroup::SharedPtr) nullptr);
 }
 
 void Optimizer::clearCallbacks()
 {
-  ros::getGlobalCallbackQueue()->removeByID(reinterpret_cast<uint64_t>(this));
+  callback_queue_->removeAllCallbacks();
 }
 
 void Optimizer::startPlugins()
@@ -489,7 +488,9 @@ void Optimizer::setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat
     return;
   }
 
-  status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Optimization converged");
+  // TODO test for previous convergence success or failure
+
+  status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Optimizer exists");
 
   auto print_key = [](const std::string& result, const auto& entry) { return result + entry.first + ' '; };
 

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -86,7 +86,7 @@ Optimizer::Optimizer(
     publisher_loader_("fuse_core", "fuse_core::Publisher"),
     sensor_model_loader_("fuse_core", "fuse_core::SensorModel"),
     diagnostic_updater_(shared_from_this()),
-    callback_queue_(rclcpp::contexts::default_context::get_global_default_context())
+    callback_queue_(rclcpp::contexts::get_global_default_context())
 {
   // Setup diagnostics updater
   // XXX private_node_handle_.param("diagnostic_updater_timer_period", diagnostic_updater_timer_period_,

--- a/fuse_optimizers/test/example_optimizer.h
+++ b/fuse_optimizers/test/example_optimizer.h
@@ -49,9 +49,10 @@ class ExampleOptimizer : public fuse_optimizers::Optimizer
 public:
   FUSE_SMART_PTR_DEFINITIONS(ExampleOptimizer)
 
-  ExampleOptimizer(fuse_core::Graph::UniquePtr graph, const ros::NodeHandle& node_handle = ros::NodeHandle(),
-                 const ros::NodeHandle& private_node_handle = ros::NodeHandle("~"))
-    : fuse_optimizers::Optimizer(std::move(graph), node_handle, private_node_handle)
+  ExampleOptimizer(
+    rclcpp::NodeOptions options,
+    fuse_core::Graph::UniquePtr graph = fuse_graphs::HashGraph::make_unique()
+  ) : fuse_optimizers::Optimizer(std::move(graph), node_handle, private_node_handle)
   {
   }
 


### PR DESCRIPTION
See: https://github.com/locusrobotics/fuse/issues/276
This depends on: https://github.com/locusrobotics/fuse/pull/283
- When merging this, @methylDragon should check that it doesn't lead to Time regressions...

# Description
This PR ports the ROS 1 nodes to ROS 2 node pointers, and also uses Brett's solution for CallbackWrappers and Waitables to support async behavior.

Whether it works or not remains to be seen, we'll likely need to circle back if we see deadlocks happening.

Some node handles have been replaced with node pointers or node interfaces. A future PR will introduce the concept of a [NodeInterfaceHandle](https://github.com/ros2/rclcpp/pull/2041) and change the signatures to support it.

# PR Layout
Because I was cherry-picking Brett's commits here, I'd recommend reviewing the PR by looking at the merged changes instead of per commit.

# Additional Notes
All subordinate plugins (e.g. sensors, motion models, etc.) now start an internal node using the default global context. We need to first make sure that configuration works first before we try to improve it, so it's a place that's likely to be circled back to.. Hopefully...


Pinging @svwilliams for visibility.