### PR TITLE
fuse -> ROS 2 fuse_loss: Port fuse_loss

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(fuse_core)
 
 # Default to C++17

--- a/fuse_core/include/fuse_core/loss.hpp
+++ b/fuse_core/include/fuse_core/loss.hpp
@@ -42,6 +42,7 @@
 #include <boost/serialization/access.hpp>
 #include <boost/type_index/stl_type_index.hpp>
 #include <fuse_core/fuse_macros.hpp>
+#include <fuse_core/node_interfaces/node_interfaces.hpp>
 #include <fuse_core/serialization.hpp>
 
 /**
@@ -195,7 +196,13 @@ public:
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter
    *                 server.
    */
-  virtual void initialize(const std::string & name) = 0;
+  virtual void initialize(
+    fuse_core::node_interfaces::NodeInterfaces<
+      fuse_core::node_interfaces::Base,
+      fuse_core::node_interfaces::Logging,
+      fuse_core::node_interfaces::Parameters
+    > interfaces,
+    const std::string & name) = 0;
 
   /**
    * @brief Returns a unique name for this loss function type.

--- a/fuse_core/include/fuse_core/parameter.hpp
+++ b/fuse_core/include/fuse_core/parameter.hpp
@@ -281,7 +281,7 @@ inline fuse_core::Loss::SharedPtr loadLossConfig(
   getParamRequired(interfaces, name + "/type", loss_type);
 
   auto loss = fuse_core::createUniqueLoss(loss_type);
-  loss->initialize(interfaces.get_node_base_interface()->get_fully_qualified_name());
+  loss->initialize(interfaces, interfaces.get_node_base_interface()->get_fully_qualified_name());
 
   return loss;
 }

--- a/fuse_core/test/example_loss.hpp
+++ b/fuse_core/test/example_loss.hpp
@@ -57,7 +57,13 @@ public:
   {
   }
 
-  void initialize(const std::string & /*name*/) override {}
+  void initialize(
+    fuse_core::node_interfaces::NodeInterfaces<
+      fuse_core::node_interfaces::Base,
+      fuse_core::node_interfaces::Logging,
+      fuse_core::node_interfaces::Parameters
+    >/*interfaces*/,
+    const std::string & /*name*/) override {}
 
   void print(std::ostream & /*stream = std::cout*/) const override {}
 

--- a/fuse_graphs/test/example_loss.h
+++ b/fuse_graphs/test/example_loss.h
@@ -58,7 +58,13 @@ public:
   {
   }
 
-  void initialize(const std::string& /*name*/) override {}
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > /*interfaces*/,
+  const std::string& /*name*/) override {}
 
   void print(std::ostream& /*stream = std::cout*/) const override {}
 

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -1,36 +1,28 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(fuse_loss)
 
-set(build_depends
-  fuse_core
-  pluginlib
-  roscpp
-)
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CXX_STANDARD_REQUIRED YES)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  ${build_depends}
-)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Werror -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(fuse_core REQUIRED)
+find_package(pluginlib REQUIRED)
 
 find_package(Ceres REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${PROJECT_NAME}
-  CATKIN_DEPENDS
-    ${build_depends}
-  DEPENDS
-    CERES
-)
 
 ###########
 ## Build ##
 ###########
 
-add_compile_options(-Wall -Werror)
-
-add_library(${PROJECT_NAME}
+## fuse_loss library
+add_library(${PROJECT_NAME} SHARED
   src/arctan_loss.cpp
   src/cauchy_loss.cpp
   src/composed_loss.cpp
@@ -46,218 +38,52 @@ add_library(${PROJECT_NAME}
   src/tukey_loss.cpp
   src/welsch_loss.cpp
 )
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
-    include
-    ${catkin_INCLUDE_DIRS}
-    ${CERES_INCLUDE_DIRS}
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${CERES_LIBRARIES}
-)
-set_target_properties(${PROJECT_NAME}
-  PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED YES
-)
-
-#############
-## Install ##
-#############
-
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
-install(
-  FILES fuse_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  Ceres::ceres
+  fuse_core::fuse_core
+  pluginlib::pluginlib
 )
 
 #############
 ## Testing ##
 #############
 
-if(CATKIN_ENABLE_TESTING)
-  find_package(roslint REQUIRED)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
-  find_package(Qt5 REQUIRED COMPONENTS
-    Core
-    Widgets)
-
-  # Find Qwt using FindQwt.cmake copied from:
-  # https://gitlab.kitware.com/cmake/community/-/wikis/contrib/modules/FindQwt
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-  find_package(Qwt REQUIRED)
-
-  # Lint tests
-  set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
-  roslint_cpp()
-  roslint_add_test()
-
-  # Loss function Tests
-  catkin_add_gtest(test_loss_function
-    test/test_loss_function.cpp
-  )
-  add_dependencies(test_loss_function
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_loss_function
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_loss_function
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-  )
-  set_target_properties(test_loss_function
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
-
-  # Composed Loss Tests
-  catkin_add_gtest(test_composed_loss
-    test/test_composed_loss.cpp
-  )
-  add_dependencies(test_composed_loss
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_composed_loss
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_composed_loss
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-  )
-  set_target_properties(test_composed_loss
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
-
-  # Huber Loss Tests
-  catkin_add_gtest(test_huber_loss
-    test/test_huber_loss.cpp
-  )
-  add_dependencies(test_huber_loss
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_huber_loss
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_huber_loss
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-  )
-  set_target_properties(test_huber_loss
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
-
-  # Tukey Loss Tests
-  catkin_add_gtest(test_tukey_loss
-    test/test_tukey_loss.cpp
-  )
-  add_dependencies(test_tukey_loss
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_tukey_loss
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_tukey_loss
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-  )
-  set_target_properties(test_tukey_loss
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
-
-  # Qwt Loss Plot Tests
-  option(BUILD_WITH_PLOT_TESTS "Build with plot tests. These test might fail to run in headless systems." OFF)
-  if(BUILD_WITH_PLOT_TESTS)
-    catkin_add_gtest(test_qwt_loss_plot
-      test/test_qwt_loss_plot.cpp
-    )
-    add_dependencies(test_qwt_loss_plot
-      ${catkin_EXPORTED_TARGETS}
-    )
-    target_include_directories(test_qwt_loss_plot
-      PRIVATE
-        include
-        ${catkin_INCLUDE_DIRS}
-        ${CERES_INCLUDE_DIRS}
-        ${Qt5Core_INCLUDE_DIRS}
-        ${Qt5Widgets_INCLUDE_DIRS}
-        ${QWT_INCLUDE_DIRS}
-    )
-    target_link_libraries(test_qwt_loss_plot
-      ${PROJECT_NAME}
-      ${catkin_LIBRARIES}
-      ${CERES_LIBRARIES}
-      ${Qt5Core_LIBRARIES}
-      ${Qt5Widgets_LIBRARIES}
-      ${QWT_LIBRARIES}
-    )
-    set_target_properties(test_qwt_loss_plot
-      PROPERTIES
-        CXX_STANDARD 14
-        CXX_STANDARD_REQUIRED YES
-    )
-
-    option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
-    if(BUILD_WITH_INTERACTIVE_TESTS)
-      target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
-    endif(BUILD_WITH_INTERACTIVE_TESTS)
-  endif(BUILD_WITH_PLOT_TESTS)
-
-  # Scaled Loss Tests
-  catkin_add_gtest(test_scaled_loss
-    test/test_scaled_loss.cpp
-  )
-  add_dependencies(test_scaled_loss
-    ${catkin_EXPORTED_TARGETS}
-  )
-  target_include_directories(test_scaled_loss
-    PRIVATE
-      include
-      ${catkin_INCLUDE_DIRS}
-      ${CERES_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_scaled_loss
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-  )
-  set_target_properties(test_scaled_loss
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
+  add_subdirectory(test)
 endif()
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-export
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  FILES fuse_plugins.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_export_targets(${PROJECT_NAME}-export HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ament_cmake
+  fuse_core
+  pluginlib
+  Ceres
+)
+
+ament_package()

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(fuse_core REQUIRED)
 find_package(pluginlib REQUIRED)
 
@@ -22,7 +22,7 @@ find_package(Ceres REQUIRED)
 ###########
 
 ## fuse_loss library
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   src/arctan_loss.cpp
   src/cauchy_loss.cpp
   src/composed_loss.cpp
@@ -73,10 +73,7 @@ install(DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
 )
 
-install(
-  FILES fuse_plugins.xml
-  DESTINATION share/${PROJECT_NAME}
-)
+pluginlib_export_plugin_description_file(fuse_core fuse_plugins.xml)
 
 ament_export_targets(${PROJECT_NAME}-export HAS_LIBRARY_TARGET)
 ament_export_dependencies(

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Werror -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/fuse_loss/cmake/FindQWT.cmake
+++ b/fuse_loss/cmake/FindQWT.cmake
@@ -16,15 +16,15 @@
 #=============================================================================
 # Copyright 2010-2013, Julien Schueller
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met: 
-# 
+# modification, are permitted provided that the following conditions are met:
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer. 
+#    list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution. 
+#    and/or other materials provided with the distribution.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -38,75 +38,75 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # The views and conclusions contained in the software and documentation are those
-# of the authors and should not be interpreted as representing official policies, 
+# of the authors and should not be interpreted as representing official policies,
 # either expressed or implied, of the FreeBSD Project.
 #=============================================================================
 
 
-find_path ( QWT_INCLUDE_DIR
+find_path( QWT_INCLUDE_DIR
   NAMES qwt_plot.h
   HINTS ${QT_INCLUDE_DIR}
   PATH_SUFFIXES qwt qwt-qt3 qwt-qt4 qwt-qt5
 )
 
-set ( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )
+set( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )
 
 # version
-set ( _VERSION_FILE ${QWT_INCLUDE_DIR}/qwt_global.h )
-if ( EXISTS ${_VERSION_FILE} )
-  file ( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+QWT_VERSION_STR" )
-  if ( _VERSION_LINE )
-    string ( REGEX REPLACE ".*define[ ]+QWT_VERSION_STR[ ]+\"(.*)\".*" "\\1" QWT_VERSION_STRING "${_VERSION_LINE}" )
-    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" QWT_MAJOR_VERSION "${QWT_VERSION_STRING}" )
-    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" QWT_MINOR_VERSION "${QWT_VERSION_STRING}" )
-    string ( REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\3" QWT_PATCH_VERSION "${QWT_VERSION_STRING}" )
-  endif ()
-endif ()
+set( _VERSION_FILE ${QWT_INCLUDE_DIR}/qwt_global.h )
+if( EXISTS ${_VERSION_FILE} )
+  file( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+QWT_VERSION_STR" )
+  if( _VERSION_LINE )
+    string(REGEX REPLACE ".*define[ ]+QWT_VERSION_STR[ ]+\"(.*)\".*" "\\1" QWT_VERSION_STRING "${_VERSION_LINE}")
+    string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" QWT_MAJOR_VERSION "${QWT_VERSION_STRING}")
+    string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" QWT_MINOR_VERSION "${QWT_VERSION_STRING}")
+    string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\3" QWT_PATCH_VERSION "${QWT_VERSION_STRING}")
+  endif()
+endif()
 
 
 # check version
-set ( _QWT_VERSION_MATCH TRUE )
-if ( Qwt_FIND_VERSION AND QWT_VERSION_STRING )
-  if ( Qwt_FIND_VERSION_EXACT )
-    if ( NOT Qwt_FIND_VERSION VERSION_EQUAL QWT_VERSION_STRING )
-      set ( _QWT_VERSION_MATCH FALSE )
-    endif ()
-  else ()
-    if ( QWT_VERSION_STRING VERSION_LESS Qwt_FIND_VERSION )
-      set ( _QWT_VERSION_MATCH FALSE )
-    endif ()
-  endif ()
-endif ()
+set( _QWT_VERSION_MATCH TRUE )
+if( Qwt_FIND_VERSION AND QWT_VERSION_STRING )
+  if( Qwt_FIND_VERSION_EXACT )
+    if( NOT Qwt_FIND_VERSION VERSION_EQUAL QWT_VERSION_STRING )
+      set( _QWT_VERSION_MATCH FALSE )
+    endif()
+  else()
+    if( QWT_VERSION_STRING VERSION_LESS Qwt_FIND_VERSION )
+      set( _QWT_VERSION_MATCH FALSE )
+    endif()
+  endif()
+endif()
 
 
-find_library ( QWT_LIBRARY
+find_library( QWT_LIBRARY
   NAMES qwt qwt-qt3 qwt-qt4 qwt-qt5
   HINTS ${QT_LIBRARY_DIR}
 )
 
-set ( QWT_LIBRARIES ${QWT_LIBRARY} )
+set( QWT_LIBRARIES ${QWT_LIBRARY} )
 
 
 # try to guess root dir from include dir
-if ( QWT_INCLUDE_DIR )
-  string ( REGEX REPLACE "(.*)/include.*" "\\1" QWT_ROOT_DIR ${QWT_INCLUDE_DIR} )
+if( QWT_INCLUDE_DIR )
+  string(REGEX REPLACE "(.*)/include.*" "\\1" QWT_ROOT_DIR ${QWT_INCLUDE_DIR})
 # try to guess root dir from library dir
-elseif ( QWT_LIBRARY )
-  string ( REGEX REPLACE "(.*)/lib[/|32|64].*" "\\1" QWT_ROOT_DIR ${QWT_LIBRARY} )
-endif ()
+elseif( QWT_LIBRARY )
+  string(REGEX REPLACE "(.*)/lib[/|32|64].*" "\\1" QWT_ROOT_DIR ${QWT_LIBRARY})
+endif()
 
 
 # handle the QUIETLY and REQUIRED arguments
-include ( FindPackageHandleStandardArgs )
-if ( CMAKE_VERSION LESS 2.8.3 )
-  find_package_handle_standard_args( Qwt DEFAULT_MSG QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH )
-else ()
-  find_package_handle_standard_args( Qwt REQUIRED_VARS QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH VERSION_VAR QWT_VERSION_STRING )
-endif ()
+include( FindPackageHandleStandardArgs )
+if( CMAKE_VERSION LESS 2.8.3 )
+  find_package_handle_standard_args( QWT DEFAULT_MSG QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH )
+else()
+  find_package_handle_standard_args( QWT REQUIRED_VARS QWT_LIBRARY QWT_INCLUDE_DIR _QWT_VERSION_MATCH VERSION_VAR QWT_VERSION_STRING )
+endif()
 
 
-mark_as_advanced (
-  QWT_LIBRARY 
+mark_as_advanced(
+  QWT_LIBRARY
   QWT_LIBRARIES
   QWT_INCLUDE_DIR
   QWT_INCLUDE_DIRS

--- a/fuse_loss/include/fuse_loss/arctan_loss.h
+++ b/fuse_loss/include/fuse_loss/arctan_loss.h
@@ -76,9 +76,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/cauchy_loss.h
+++ b/fuse_loss/include/fuse_loss/cauchy_loss.h
@@ -76,9 +76,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/composed_loss.h
+++ b/fuse_loss/include/fuse_loss/composed_loss.h
@@ -81,9 +81,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/dcs_loss.h
+++ b/fuse_loss/include/fuse_loss/dcs_loss.h
@@ -80,9 +80,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/fair_loss.h
+++ b/fuse_loss/include/fuse_loss/fair_loss.h
@@ -80,9 +80,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
+++ b/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
@@ -80,9 +80,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/huber_loss.h
+++ b/fuse_loss/include/fuse_loss/huber_loss.h
@@ -76,9 +76,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -218,7 +218,7 @@ class QwtLossPlot
 {
 public:
   QwtLossPlot(const std::vector<double>& residuals, const HSVColormap& colormap)
-    : residuals_(QVector<double>::fromStdVector(residuals))
+    : residuals_(QVector<double>(residuals.begin(), residuals.end()))
     , loss_evaluator_(residuals)
     , colormap_(colormap)
     , magnifier_(plot_.canvas())
@@ -251,7 +251,7 @@ public:
   {
     QwtPlotCurve* curve = new QwtPlotCurve(name.c_str());
 
-    curve->setSamples(residuals_, QVector<double>::fromStdVector(values));
+    curve->setSamples(residuals_, QVector<double>(values.begin(), values.end()));
 
     curve->setPen(colormap_[curves_.size()]);
     curve->attach(&plot_);

--- a/fuse_loss/include/fuse_loss/scaled_loss.h
+++ b/fuse_loss/include/fuse_loss/scaled_loss.h
@@ -78,9 +78,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/softlone_loss.h
+++ b/fuse_loss/include/fuse_loss/softlone_loss.h
@@ -76,9 +76,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/tolerant_loss.h
+++ b/fuse_loss/include/fuse_loss/tolerant_loss.h
@@ -77,9 +77,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/trivial_loss.h
+++ b/fuse_loss/include/fuse_loss/trivial_loss.h
@@ -74,11 +74,18 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& /*name*/) override
-  {
-  }
+   void initialize(
+     fuse_core::node_interfaces::NodeInterfaces<
+       fuse_core::node_interfaces::Base,
+       fuse_core::node_interfaces::Logging,
+       fuse_core::node_interfaces::Parameters
+     > /*interfaces*/,
+     const std::string& /*name*/) override
+   {
+   }
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/tukey_loss.h
+++ b/fuse_loss/include/fuse_loss/tukey_loss.h
@@ -76,9 +76,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/tukey_loss.h
+++ b/fuse_loss/include/fuse_loss/tukey_loss.h
@@ -79,13 +79,13 @@ public:
    * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-void initialize(
-  fuse_core::node_interfaces::NodeInterfaces<
-    fuse_core::node_interfaces::Base,
-    fuse_core::node_interfaces::Logging,
-    fuse_core::node_interfaces::Parameters
-  > interfaces,
-  const std::string& name) override;
+  void initialize(
+    fuse_core::node_interfaces::NodeInterfaces<
+      fuse_core::node_interfaces::Base,
+      fuse_core::node_interfaces::Logging,
+      fuse_core::node_interfaces::Parameters
+    > interfaces,
+    const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/include/fuse_loss/welsch_loss.h
+++ b/fuse_loss/include/fuse_loss/welsch_loss.h
@@ -80,9 +80,16 @@ public:
    *
    * This will be called on each plugin after construction.
    *
+   * @param[in] interfaces - The node interfaces used to load the parameter
    * @param[in] name A unique name to initialize this plugin instance, such as from the parameter server.
    */
-  void initialize(const std::string& name) override;
+void initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name) override;
 
   /**
    * @brief Print a human-readable description of the loss function to the provided stream.

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -13,10 +13,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>libceres-dev</depend>
-  <depend>fuse_core</depend>
-  <depend>pluginlib</depend>
-  <depend>rclcpp</depend>
+  <build_depend>libceres-dev</build_depend>
+  <build_depend>fuse_core</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>rclcpp</build_depend>
+
+  <exec_depend>libceres-dev</exec_depend>
+  <exec_depend>fuse_core</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
 
   <test_depend>qtbase5-dev</test_depend>
   <test_depend>libqwt-qt5-dev</test_depend>

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -11,7 +11,7 @@
   <author email="swilliams@locusrobotics.com">Stephen Williams</author>
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>libceres-dev</build_depend>
   <build_depend>fuse_core</build_depend>

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -31,7 +31,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <fuse_core plugin="${prefix}/fuse_plugins.xml" />
     <rosdoc config="rosdoc.yaml" />
   </export>
 </package>

--- a/fuse_loss/package.xml
+++ b/fuse_loss/package.xml
@@ -11,18 +11,21 @@
   <author email="swilliams@locusrobotics.com">Stephen Williams</author>
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
   <depend>pluginlib</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
 
   <test_depend>qtbase5-dev</test_depend>
   <test_depend>libqwt-qt5-dev</test_depend>
-  <test_depend>roslint</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <fuse_core plugin="${prefix}/fuse_plugins.xml" />
     <rosdoc config="rosdoc.yaml" />
   </export>

--- a/fuse_loss/src/arctan_loss.cpp
+++ b/fuse_loss/src/arctan_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/arctan_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -49,11 +49,15 @@ ArctanLoss::ArctanLoss(const double a) : a_(a)
 {
 }
 
-void ArctanLoss::initialize(const std::string& name)
+void ArctanLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void ArctanLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/arctan_loss.cpp
+++ b/fuse_loss/src/arctan_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/arctan_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/arctan_loss.cpp
+++ b/fuse_loss/src/arctan_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/arctan_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/cauchy_loss.cpp
+++ b/fuse_loss/src/cauchy_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/cauchy_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/cauchy_loss.cpp
+++ b/fuse_loss/src/cauchy_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/cauchy_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -49,11 +49,15 @@ CauchyLoss::CauchyLoss(const double a) : a_(a)
 {
 }
 
-void CauchyLoss::initialize(const std::string& name)
+void CauchyLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void CauchyLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/cauchy_loss.cpp
+++ b/fuse_loss/src/cauchy_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/cauchy_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/composed_loss.cpp
+++ b/fuse_loss/src/composed_loss.cpp
@@ -31,12 +31,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/composed_loss.h>
 #include <fuse_loss/trivial_loss.h>
 
-#include <fuse_core/parameter.hpp>
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -54,12 +53,16 @@ ComposedLoss::ComposedLoss(const std::shared_ptr<fuse_core::Loss>& f_loss,
 {
 }
 
-void ComposedLoss::initialize(const std::string& name)
+void ComposedLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  f_loss_ = fuse_core::loadLossConfig(private_node_handle, "f_loss");
-  g_loss_ = fuse_core::loadLossConfig(private_node_handle, "g_loss");
+  f_loss_ = fuse_core::loadLossConfig(interfaces, name + ".f_loss");
+  g_loss_ = fuse_core::loadLossConfig(interfaces, name + ".g_loss");
 }
 
 void ComposedLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/composed_loss.cpp
+++ b/fuse_loss/src/composed_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/composed_loss.h>
 #include <fuse_loss/trivial_loss.h>
 

--- a/fuse_loss/src/composed_loss.cpp
+++ b/fuse_loss/src/composed_loss.cpp
@@ -35,7 +35,7 @@
 #include <fuse_loss/trivial_loss.h>
 
 #include <fuse_core/parameter.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/dcs_loss.cpp
+++ b/fuse_loss/src/dcs_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/dcs_loss.h>
 #include <fuse_loss/loss_function.h>
 

--- a/fuse_loss/src/dcs_loss.cpp
+++ b/fuse_loss/src/dcs_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/dcs_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/dcs_loss.cpp
+++ b/fuse_loss/src/dcs_loss.cpp
@@ -31,11 +31,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/dcs_loss.h>
 #include <fuse_loss/loss_function.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -50,11 +50,15 @@ DCSLoss::DCSLoss(const double a) : a_(a)
 {
 }
 
-void DCSLoss::initialize(const std::string& name)
+void DCSLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void DCSLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/fair_loss.cpp
+++ b/fuse_loss/src/fair_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/fair_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/fair_loss.cpp
+++ b/fuse_loss/src/fair_loss.cpp
@@ -31,11 +31,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/fair_loss.h>
 #include <fuse_loss/loss_function.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -50,11 +50,15 @@ FairLoss::FairLoss(const double a) : a_(a)
 {
 }
 
-void FairLoss::initialize(const std::string& name)
+void FairLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void FairLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/fair_loss.cpp
+++ b/fuse_loss/src/fair_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/fair_loss.h>
 #include <fuse_loss/loss_function.h>
 

--- a/fuse_loss/src/geman_mcclure_loss.cpp
+++ b/fuse_loss/src/geman_mcclure_loss.cpp
@@ -31,11 +31,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/geman_mcclure_loss.h>
 #include <fuse_loss/loss_function.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -50,11 +50,15 @@ GemanMcClureLoss::GemanMcClureLoss(const double a) : a_(a)
 {
 }
 
-void GemanMcClureLoss::initialize(const std::string& name)
+void GemanMcClureLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void GemanMcClureLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/geman_mcclure_loss.cpp
+++ b/fuse_loss/src/geman_mcclure_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/geman_mcclure_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/geman_mcclure_loss.cpp
+++ b/fuse_loss/src/geman_mcclure_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/geman_mcclure_loss.h>
 #include <fuse_loss/loss_function.h>
 

--- a/fuse_loss/src/huber_loss.cpp
+++ b/fuse_loss/src/huber_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/huber_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/huber_loss.cpp
+++ b/fuse_loss/src/huber_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/huber_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/huber_loss.cpp
+++ b/fuse_loss/src/huber_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/huber_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -49,11 +49,15 @@ HuberLoss::HuberLoss(const double a) : a_(a)
 {
 }
 
-void HuberLoss::initialize(const std::string& name)
+void HuberLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void HuberLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/scaled_loss.cpp
+++ b/fuse_loss/src/scaled_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/scaled_loss.h>
 
 #include <fuse_core/parameter.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/scaled_loss.cpp
+++ b/fuse_loss/src/scaled_loss.cpp
@@ -35,7 +35,6 @@
 
 #include <fuse_core/parameter.hpp>
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -51,13 +50,16 @@ ScaledLoss::ScaledLoss(const double a, const std::shared_ptr<fuse_core::Loss>& l
 {
 }
 
-void ScaledLoss::initialize(const std::string& name)
+void ScaledLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
-
-  loss_ = fuse_core::loadLossConfig(private_node_handle, "loss");
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
+  loss_ = fuse_core::loadLossConfig(interfaces, name + ".loss");
 }
 
 void ScaledLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/softlone_loss.cpp
+++ b/fuse_loss/src/softlone_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/softlone_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/softlone_loss.cpp
+++ b/fuse_loss/src/softlone_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/softlone_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/softlone_loss.cpp
+++ b/fuse_loss/src/softlone_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/softlone_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -49,11 +49,15 @@ SoftLOneLoss::SoftLOneLoss(const double a) : a_(a)
 {
 }
 
-void SoftLOneLoss::initialize(const std::string& name)
+void SoftLOneLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void SoftLOneLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/tolerant_loss.cpp
+++ b/fuse_loss/src/tolerant_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/tolerant_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -50,12 +50,16 @@ TolerantLoss::TolerantLoss(const double a, const double b)
 {
 }
 
-void TolerantLoss::initialize(const std::string& name)
+void TolerantLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
-  private_node_handle.param("b", b_, b_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
+  b_ = fuse_core::getParam(interfaces, name + ".b", b_);
 }
 
 void TolerantLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/tolerant_loss.cpp
+++ b/fuse_loss/src/tolerant_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/tolerant_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/tolerant_loss.cpp
+++ b/fuse_loss/src/tolerant_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/tolerant_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/trivial_loss.cpp
+++ b/fuse_loss/src/trivial_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/trivial_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/trivial_loss.cpp
+++ b/fuse_loss/src/trivial_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/trivial_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>

--- a/fuse_loss/src/trivial_loss.cpp
+++ b/fuse_loss/src/trivial_loss.cpp
@@ -31,10 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/trivial_loss.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -36,7 +36,6 @@
 #include <fuse_core/ceres_macros.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -51,11 +50,15 @@ TukeyLoss::TukeyLoss(const double a) : a_(a)
 {
 }
 
-void TukeyLoss::initialize(const std::string& name)
+void TukeyLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void TukeyLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -35,7 +35,7 @@
 
 #include <fuse_core/ceres_macros.hpp>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -34,6 +34,7 @@
 #include <fuse_loss/tukey_loss.h>
 
 #include <fuse_core/ceres_macros.hpp>
+#include <fuse_core/parameter.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/fuse_loss/src/welsch_loss.cpp
+++ b/fuse_loss/src/welsch_loss.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_core/parameter.h>
+#include <fuse_core/parameter.hpp>
 #include <fuse_loss/welsch_loss.h>
 #include <fuse_loss/loss_function.h>
 

--- a/fuse_loss/src/welsch_loss.cpp
+++ b/fuse_loss/src/welsch_loss.cpp
@@ -31,11 +31,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/parameter.h>
 #include <fuse_loss/welsch_loss.h>
 #include <fuse_loss/loss_function.h>
 
 #include <pluginlib/class_list_macros.hpp>
-#include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>
 
@@ -50,11 +50,15 @@ WelschLoss::WelschLoss(const double a) : a_(a)
 {
 }
 
-void WelschLoss::initialize(const std::string& name)
+void WelschLoss::initialize(
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Logging,
+    fuse_core::node_interfaces::Parameters
+  > interfaces,
+  const std::string& name)
 {
-  ros::NodeHandle private_node_handle(name);
-
-  private_node_handle.param("a", a_, a_);
+  a_ = fuse_core::getParam(interfaces, name + ".a", a_);
 }
 
 void WelschLoss::print(std::ostream& stream) const

--- a/fuse_loss/src/welsch_loss.cpp
+++ b/fuse_loss/src/welsch_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/welsch_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/test/CMakeLists.txt
+++ b/fuse_loss/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 # CORE GTESTS ======================================================================================
-# Might have to link Ceres
 ament_add_gtest(test_loss_function test_loss_function.cpp)
 target_link_libraries(test_loss_function ${PROJECT_NAME})
 

--- a/fuse_loss/test/CMakeLists.txt
+++ b/fuse_loss/test/CMakeLists.txt
@@ -21,7 +21,7 @@ if(BUILD_WITH_PLOT_TESTS)
 
   # Find Qwt using FindQwt.cmake copied from:
   # https://gitlab.kitware.com/cmake/community/-/wikis/contrib/modules/FindQwt
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
   find_package(QWT REQUIRED)
 
   ament_add_gtest(test_qwt_loss_plot test_qwt_loss_plot.cpp)

--- a/fuse_loss/test/CMakeLists.txt
+++ b/fuse_loss/test/CMakeLists.txt
@@ -1,0 +1,46 @@
+# CORE GTESTS ======================================================================================
+# Might have to link Ceres
+ament_add_gtest(test_loss_function test_loss_function.cpp)
+target_link_libraries(test_loss_function ${PROJECT_NAME})
+
+ament_add_gtest(test_composed_loss test_composed_loss.cpp)
+target_link_libraries(test_composed_loss ${PROJECT_NAME})
+
+ament_add_gtest(test_huber_loss test_huber_loss.cpp)
+target_link_libraries(test_huber_loss ${PROJECT_NAME})
+
+ament_add_gtest(test_tukey_loss test_tukey_loss.cpp)
+target_link_libraries(test_tukey_loss ${PROJECT_NAME})
+
+ament_add_gtest(test_scaled_loss test_scaled_loss.cpp)
+target_link_libraries(test_scaled_loss ${PROJECT_NAME})
+
+# Qwt Loss Plot Tests
+option(BUILD_WITH_PLOT_TESTS "Build with plot tests. These test might fail to run in headless systems." OFF)
+if(BUILD_WITH_PLOT_TESTS)
+  find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
+
+  # Find Qwt using FindQwt.cmake copied from:
+  # https://gitlab.kitware.com/cmake/community/-/wikis/contrib/modules/FindQwt
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(Qwt REQUIRED)
+
+  ament_add_gtest(test_qwt_loss_plot test_qwt_loss_plot.cpp)
+  target_link_libraries(test_qwt_loss_plot ${PROJECT_NAME})
+  target_include_directories(test_qwt_loss_plot
+    PRIVATE
+      ${Qt5Core_INCLUDE_DIRS}
+      ${Qt5Widgets_INCLUDE_DIRS}
+      ${QWT_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_qwt_loss_plot
+    ${Qt5Core_LIBRARIES}
+    ${Qt5Widgets_LIBRARIES}
+    ${QWT_LIBRARIES}
+  )
+
+  option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
+  if(BUILD_WITH_INTERACTIVE_TESTS)
+    target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
+  endif(BUILD_WITH_INTERACTIVE_TESTS)
+endif(BUILD_WITH_PLOT_TESTS)

--- a/fuse_loss/test/CMakeLists.txt
+++ b/fuse_loss/test/CMakeLists.txt
@@ -22,7 +22,7 @@ if(BUILD_WITH_PLOT_TESTS)
   # Find Qwt using FindQwt.cmake copied from:
   # https://gitlab.kitware.com/cmake/community/-/wikis/contrib/modules/FindQwt
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-  find_package(Qwt REQUIRED)
+  find_package(QWT REQUIRED)
 
   ament_add_gtest(test_qwt_loss_plot test_qwt_loss_plot.cpp)
   target_link_libraries(test_qwt_loss_plot ${PROJECT_NAME})
@@ -41,5 +41,5 @@ if(BUILD_WITH_PLOT_TESTS)
   option(BUILD_WITH_INTERACTIVE_TESTS "Build with interactive tests" OFF)
   if(BUILD_WITH_INTERACTIVE_TESTS)
     target_compile_definitions(test_qwt_loss_plot PUBLIC INTERACTIVE_TESTS)
-  endif(BUILD_WITH_INTERACTIVE_TESTS)
-endif(BUILD_WITH_PLOT_TESTS)
+  endif()
+endif()

--- a/fuse_loss/test/test_composed_loss.cpp
+++ b/fuse_loss/test/test_composed_loss.cpp
@@ -330,9 +330,3 @@ TEST(ComposedLoss, Serialization)
     EXPECT_EQ(expected_rho[i], actual_rho[i]);
   }
 }
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/fuse_loss/test/test_huber_loss.cpp
+++ b/fuse_loss/test/test_huber_loss.cpp
@@ -182,9 +182,3 @@ TEST(HuberLoss, Serialization)
   EXPECT_GT(1.0, rho[1]);
   EXPECT_GT(0.0, rho[2]);
 }
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/fuse_loss/test/test_loss_function.cpp
+++ b/fuse_loss/test/test_loss_function.cpp
@@ -166,9 +166,3 @@ TEST(LossFunction, WelschLoss)
   ASSERT_NEAR(rho[1], 1.0, 1e-6);
   ASSERT_NEAR(rho[2], -1 / (a * a), 1e-6);
 }
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/fuse_loss/test/test_qwt_loss_plot.cpp
+++ b/fuse_loss/test/test_qwt_loss_plot.cpp
@@ -49,6 +49,7 @@
 
 #include <QApplication>
 
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -194,12 +195,11 @@ TEST_F(QwtLossPlotTest, PlotLossQt)
 
 #ifdef INTERACTIVE_TESTS
   // Run application:
+  // NOTE(CH3): This will block indefinitely until the test windows are closed!
+  //            Since the tests are meant to be interactive you MUST close the windows for them to
+  //            pass!!
+  std::cout << "Interactive test active. If test does a timeout, and you did not manually close the"
+            << "windows that popped up, the timeout is expected!" << std::endl;
   app.exec();
 #endif
-}
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/fuse_loss/test/test_scaled_loss.cpp
+++ b/fuse_loss/test/test_scaled_loss.cpp
@@ -211,9 +211,3 @@ TEST(ScaledLoss, Serialization)
   EXPECT_GT(a, rho[1]);
   EXPECT_GT(0.0, rho[2]);
 }
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/fuse_loss/test/test_tukey_loss.cpp
+++ b/fuse_loss/test/test_tukey_loss.cpp
@@ -204,9 +204,3 @@ TEST(TukeyLoss, Serialization)
   EXPECT_NEAR(0.0, rho[1], 1e-6);
   EXPECT_NEAR(0.0, rho[2], 1e-6);
 }
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -77,7 +77,7 @@ struct Acceleration2DParams : public ParameterBase
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
-      loss = fuse_core::loadLossConfig(nh, "loss");
+      loss = fuse_core::loadLossConfig(interfaces, "loss");
     }
 
     bool disable_checks { false };

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -100,9 +100,9 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("orientation_target_frame", orientation_target_frame);
       nh.getParam("twist_target_frame", twist_target_frame);
 
-      pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
-      angular_velocity_loss = fuse_core::loadLossConfig(nh, "angular_velocity_loss");
-      linear_acceleration_loss = fuse_core::loadLossConfig(nh, "linear_acceleration_loss");
+      pose_loss = fuse_core::loadLossConfig(interfaces, "pose_loss");
+      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, "angular_velocity_loss");
+      linear_acceleration_loss = fuse_core::loadLossConfig(interfaces, "linear_acceleration_loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -99,9 +99,9 @@ struct Odometry2DParams : public ParameterBase
             fuse_core::getCovarianceDiagonalParam<3>(nh, "twist_covariance_offset_diagonal", 0.0);
       }
 
-      pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");
-      linear_velocity_loss = fuse_core::loadLossConfig(nh, "linear_velocity_loss");
-      angular_velocity_loss = fuse_core::loadLossConfig(nh, "angular_velocity_loss");
+      pose_loss = fuse_core::loadLossConfig(interfaces, "pose_loss");
+      linear_velocity_loss = fuse_core::loadLossConfig(interfaces, "linear_velocity_loss");
+      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, "angular_velocity_loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -91,7 +91,7 @@ struct Pose2DParams : public ParameterBase
         }
       }
 
-      loss = fuse_core::loadLossConfig(nh, "loss");
+      loss = fuse_core::loadLossConfig(interfaces, "loss");
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -79,8 +79,8 @@ struct Twist2DParams : public ParameterBase
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
 
-      linear_loss = fuse_core::loadLossConfig(nh, "linear_loss");
-      angular_loss = fuse_core::loadLossConfig(nh, "angular_loss");
+      linear_loss = fuse_core::loadLossConfig(interfaces, "linear_loss");
+      angular_loss = fuse_core::loadLossConfig(interfaces, "angular_loss");
     }
 
     bool disable_checks { false };

--- a/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
+++ b/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
@@ -112,7 +112,7 @@ struct Unicycle2DIgnitionParams : public ParameterBase
         initial_state.swap(state_vector);
       }
 
-      loss = fuse_core::loadLossConfig(nh, "loss");
+      loss = fuse_core::loadLossConfig(interfaces, "loss");
     }
 
 


### PR DESCRIPTION
See: https://github.com/locusrobotics/fuse/issues/276

# Description

This PR ports the entirety of fuse_loss, including:
- CMakeLists and packages
- Source code
- Tests

It makes minor changes to fuse_core to support the loss changes.
Also note that some changes to fuse_model were made (that won't allow it to get built, but are put in for posterity.)

Other stuff like docs are in other PRs

# Notes
- This PR is branched off the branch from https://github.com/locusrobotics/fuse/pull/286
	- i.e. https://github.com/locusrobotics/fuse/pull/286 should be merged FIRST (otherwise merging this will merge 286 as well)

Pinging @svwilliams for visibility.