### PR TITLE
fuse -> ROS 2 fuse_core: Fix Async

### DIFF
--- a/fuse_core/include/fuse_core/async_publisher.hpp
+++ b/fuse_core/include/fuse_core/async_publisher.hpp
@@ -50,8 +50,8 @@ namespace fuse_core
 {
 
 /**
- * @brief A publisher base class that provides node handles attached to an internal callback queue
- *        serviced by a local thread (or threads) using a spinner.
+ * @brief A publisher base class that provides an internal callback queue attached to a ROS 2 Node
+ *        serviced by a local executor.
  *
  * This allows publishers derived from this base class to operate similarly to a stand alone node
  * -- any subscription or service callbacks will be executed within an independent thread. The
@@ -59,8 +59,7 @@ namespace fuse_core
  *  - a default constructor is required (because this is a plugin)
  *  - subscriptions, services, parameter server interactions, etc. should be placed in the onInit()
  *    call instead of in the constructor
- *  - a global node handle and private node handle have already been created and attached to a local
- *    callback queue
+ *  - a node has already been created and attached to a local callback queue
  *  - a special callback, notifyCallback(), will be fired every time the optimizer completes an
  *    optimization cycle
  */
@@ -77,10 +76,10 @@ public:
   /**
    * @brief Initialize the AsyncPublisher object
    *
-   * This will store the provided name and graph object, and create a global and private node
-   * handle that both use an internal callback queue serviced by a local thread. The
-   * AsyncPublisher::onInit() method will be called from here, once the node handles are
-   * properly configured.
+   * This will store the provided name and graph object, and create an internal node for this
+   * instance that will use an internal callback queue serviced by a local thread. The
+   * AsyncPublisher::onInit() method will be called from here, once the internal node is properly
+   * configured.
    *
    * @param[in] name A unique name to give this plugin instance
    */
@@ -120,9 +119,9 @@ public:
    *
    * This implementation inserts a call to onStart() into this publisher's callback queue. This
    * method then blocks until the call to onStart() has completed. This is meant to simplify
-   * thread synchronization. If this publisher uses a single-threaded spinner, then all
+   * thread synchronization. If this publisher uses a single-threaded executor, then all
    * callbacks will fire sequentially and no semaphores are needed. If this publisher uses a
-   * multithreaded spinner, then normal multithreading rules apply and data accessed in more
+   * multithreaded executor, then normal multithreading rules apply and data accessed in more
    * than one place should be guarded.
    */
   void start() override;
@@ -139,7 +138,7 @@ public:
    *
    * This implementation inserts a call to onStop() into this publisher's callback queue. This
    * method then blocks until the call to onStop() has completed. This is meant to simplify
-   * thread synchronization. If this publisher uses a single-threaded spinner, then all
+   * thread synchronization. If this publisher uses a single-threaded executor, then all
    * callbacks will fire sequentially and no semaphores are needed. If this publisher uses a
    * multithreaded spinner, then normal multithreading rules apply and data accessed in more
    * than one place should be guarded.
@@ -153,15 +152,16 @@ protected:
   std::string name_;  //!< The unique name for this publisher instance
   rclcpp::Node::SharedPtr node_;  //!< The node for this publisher
 
-  //! A single/multi-threaded spinner assigned to the local callback queue
+  //! A single/multi-threaded executor assigned to the local callback queue
   rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;
   size_t executor_thread_count_;
   std::thread spinner_;  //!< Internal thread for spinning the executor
+  std::atomic<bool> initialized_ = false;  //!< True if instance has been fully initialized
 
   /**
    * @brief Constructor
    *
-   * Constructs a new publisher with node handles, a local callback queue, and thread spinner.
+   * Constructs a new publisher with a local node, a local callback queue, and internal executor.
    *
    * @param[in] thread_count The number of threads used to service the local callback queue
    */

--- a/fuse_core/include/fuse_core/async_sensor_model.hpp
+++ b/fuse_core/include/fuse_core/async_sensor_model.hpp
@@ -47,22 +47,22 @@ namespace fuse_core
 {
 
 /**
- * @brief A sensor model base class that provides node handles and a private callback queue.
+ * @brief A sensor model base class that provides an internal node and an internal callback queue.
  *
  * A sensor model plugin is responsible for generating new constraints, packaging them in a
  * fuse_core::Transaction object, and passing them along to the optimizer. The asynchronous
- * sensor model plugin is designed similar to the nodelet plugin, attempting to be as generic and
+ * sensor model plugin is designed similar to a nodelet plugin, attempting to be as generic and
  * easy to use as a standard ROS node.
  *
  * There are a few notable differences between the asynchronous sensor model plugin and a
  * standard ROS node. First and most obvious, the sensor model is designed as a plugin, with all
  * of the stipulations and requirements that come with all ROS plugins (must be derived from a
  * known base class, will be default constructed). Second, the base AsyncSensorModel class
- * provides a global and private node handle, both hooked to a local callback queue and local
- * spinner. This makes it act like a full ROS node -- subscriptions trigger message callbacks,
+ * provides an internal node that is hooked to a local callback queue and local executor on
+ * init. This makes it act like a full ROS node -- subscriptions trigger message callbacks,
  * callbacks will fire sequentially, etc. However, authors of derived sensor models should be
- * aware of this fact and avoid creating additional node handles, or at least take care when
- * creating new node handles and additional callback queues. Finally, instead of publishing the
+ * aware of this fact and avoid creating additional sub-nodes, or at least take care when
+ * creating new sub-nodes and additional callback queues. Finally, instead of publishing the
  * generated constraints using a ROS publisher, the asynchronous sensor model provides a
  * "sendTransaction()" method that should be called whenever the sensor is ready to send a
  * fuse_core::Transaction object to the Optimizer. Under the hood, this executes the
@@ -103,9 +103,9 @@ public:
    * This method will be called by the optimizer, in the optimizer's thread, after each Graph
    * update is complete. This implementation repackages the provided \p graph, and inserts a
    * call to onGraphUpdate() into this sensor's callback queue. This is meant to simplify
-   * thread synchronization. If this sensor uses a single-threaded spinner, then all callbacks
+   * thread synchronization. If this sensor uses a single-threaded executor, then all callbacks
    * will fire sequentially and no semaphores are needed. If this sensor uses a multi-threaded
-   * spinner, then normal multithreading rules apply and data accessed in more than one place
+   * executor, then normal multithreading rules apply and data accessed in more than one place
    * should be guarded.
    *
    * @param[in] graph A read-only pointer to the graph object, allowing queries to be performed
@@ -118,9 +118,9 @@ public:
    *        reading from the parameter server.
    *
    * This will be called for each plugin after construction and after the ROS node has been
-   * initialized. The provided private node handle will be in a namespace based on the plugin's
-   * name. This should prevent conflicts and allow the same plugin to be used multiple times
-   * with different settings and topics.
+   * initialized. The provided node will be in a namespace based on the plugin's name. This should
+   * prevent conflicts and allow the same plugin to be used multiple times with different settings
+   * and topics.
    *
    * @param[in] name                 A unique name to give this plugin instance
    * @param[in] transaction_callback The function to call every time a transaction is published
@@ -162,9 +162,9 @@ public:
    *
    * This implementation inserts a call to onStart() into this sensor model's callback queue.
    * This method then blocks until the call to onStart() has completed. This is meant to
-   * simplify thread synchronization. If this sensor model uses a single-threaded spinner, then
+   * simplify thread synchronization. If this sensor model uses a single-threaded executor, then
    * all callbacks will fire sequentially and no semaphores are needed. If this sensor model
-   * uses a multithreaded spinner, then normal multithreading rules apply and data accessed in
+   * uses a multithreaded executor, then normal multithreading rules apply and data accessed in
    * more than one place should be guarded.
    */
   void start() override;
@@ -180,9 +180,9 @@ public:
    *
    * This implementation inserts a call to onStop() into this sensor model's callback queue.
    * This method then blocks until the call to onStop() has completed. This is meant to
-   * simplify thread synchronization. If this sensor model uses a single-threaded spinner, then
+   * simplify thread synchronization. If this sensor model uses a single-threaded executor, then
    * all callbacks will fire sequentially and no semaphores are needed. If this sensor model
-   * uses a multithreaded spinner, then normal multithreading rules apply and data accessed in
+   * uses a multithreaded executor, then normal multithreading rules apply and data accessed in
    * more than one place should be guarded.
    */
   void stop() override;
@@ -194,18 +194,19 @@ protected:
   std::string name_;  //!< The unique name for this sensor model instance
   rclcpp::Node::SharedPtr node_;  //!< The node for this sensor model
 
-  //! A single/multi-threaded spinner assigned to the local callback queue
+  //! A single/multi-threaded executor assigned to the local callback queue
   rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;
 
   //! The function to be executed every time a Transaction is "published"
   TransactionCallback transaction_callback_;
   size_t executor_thread_count_;
   std::thread spinner_;  //!< Internal thread for spinning the executor
+  std::atomic<bool> initialized_ = false;  //!< True if instance has been fully initialized
 
   /**
    * @brief Constructor
    *
-   * Construct a new sensor model and create a local callback queue and thread spinner.
+   * Construct a new sensor model and create a local callback queue and internal executor.
    *
    * @param[in] thread_count The number of threads used to service the local callback queue
    */
@@ -234,7 +235,7 @@ protected:
    * @brief Perform any required initialization for the sensor model
    *
    * This could include things like reading from the parameter server or subscribing to topics.
-   * The class's node handles will be properly initialized before onInit() is called. Spinning
+   * The class's node will be properly initialized before onInit() is called. Spinning
    * of the callback queue will not begin until after the call to onInit() completes.
    *
    * Derived sensor models classes must implement this function, because otherwise I'm not sure

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -188,6 +188,8 @@ public:
 
   void removeAllCallbacks();
 
+  void triggerGuardCondition();
+
 private:
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable
 

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>eigen</depend>
   <depend>libceres-dev</depend>
   <depend>libgoogle-glog-dev</depend>

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -53,6 +53,13 @@ AsyncPublisher::~AsyncPublisher()
 
 void AsyncPublisher::initialize(const std::string & name)
 {
+  if (initialized_) {
+    RCLCPP_WARN_STREAM(
+      node_->get_logger(),
+      "Calling initialize on an already initialized AsyncPublisher!");
+    return;
+  }
+
   // Initialize internal state
   name_ = name;
   std::string node_namespace = "";
@@ -69,7 +76,10 @@ void AsyncPublisher::initialize(const std::string & name)
   executor_options.context = ros_context;
   executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(
     executor_options,
-    executor_thread_count_);
+    executor_thread_count_,
+    false,
+    std::chrono::milliseconds(1000)  // Timeout if stuck on waitable
+  );
 
   callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
   node_->get_node_waitables_interface()->add_waitable(
@@ -78,19 +88,48 @@ void AsyncPublisher::initialize(const std::string & name)
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
-  executor_->add_node(node_);
-
   // TODO(CH3): Remove this if the internal node is removed
-  spinner_ = std::thread(
-    [&]() {
-      executor_->spin();
-    });
+  executor_->add_node(node_);
+  spinner_ = std::thread([&]() {executor_->spin();});
+
+  // We must first ensure that the callback queue is "active" before we can be confident in using it
+  // outside of this initialize method...
+  std::mutex mtx;
+  std::condition_variable cv;
+
+  callback_queue_->addCallback(
+    std::make_shared<CallbackWrapper<void>>(
+      [&]() {
+        // NOTE(CH3): Causes random deadlocks if left in
+        //            Also technically unecessary because of wait_for used below
+        // std::unique_lock lk(mtx);
+        initialized_ = true;
+        cv.notify_one();
+      }));
+  // Wait a tiny while for the callback to be added
+  // Without this the condition variable ALWAYS times out on the first loop
+  rclcpp::sleep_for(std::chrono::milliseconds(1));
+
+  // ...And so we continually trigger the callback_queue's guard condition until it is serviced.
+  while (!initialized_) {
+    std::unique_lock lk(mtx);
+    callback_queue_->triggerGuardCondition();
+    cv.wait_for(lk, std::chrono::milliseconds(100));
+
+    if (!initialized_) {
+      RCLCPP_WARN_STREAM(
+        node_->get_logger(),
+        "Waiting for callback queue to be added to node waitables...");
+    }
+  }
 }
 
 void AsyncPublisher::notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph)
 {
   // Insert a call to the `notifyCallback` method into the internal callback queue.
   // This minimizes the time spent by the optimizer's thread calling this function.
+  // rclcpp::sleep_for(std::chrono::milliseconds(1000));
+
   auto callback = std::make_shared<CallbackWrapper<void>>(
     std::bind(&AsyncPublisher::notifyCallback, this, std::move(transaction), std::move(graph)));
   callback_queue_->addCallback(callback);

--- a/fuse_core/src/async_sensor_model.cpp
+++ b/fuse_core/src/async_sensor_model.cpp
@@ -62,6 +62,13 @@ void AsyncSensorModel::initialize(
   const std::string & name,
   TransactionCallback transaction_callback)
 {
+  if (initialized_) {
+    RCLCPP_WARN_STREAM(
+      node_->get_logger(),
+      "Calling initialize on an already initialized AsyncSensorModel!");
+    return;
+  }
+
   // Initialize internal state
   name_ = name;
   std::string node_namespace = "";
@@ -78,7 +85,10 @@ void AsyncSensorModel::initialize(
   executor_options.context = ros_context;
   executor_ = rclcpp::executors::MultiThreadedExecutor::make_shared(
     executor_options,
-    executor_thread_count_);
+    executor_thread_count_,
+    false,
+    std::chrono::milliseconds(1000)  // Timeout if stuck on waitable
+  );
 
   callback_queue_ = std::make_shared<CallbackAdapter>(ros_context);
   node_->get_node_waitables_interface()->add_waitable(
@@ -89,14 +99,41 @@ void AsyncSensorModel::initialize(
   // Call the derived onInit() function to perform implementation-specific initialization
   onInit();
 
-  // Start the async spinner to service the local callback queue
-  executor_->add_node(node_);
-
   // TODO(CH3): Remove this if the internal node is removed
-  spinner_ = std::thread(
-    [&]() {
-      executor_->spin();
-    });
+  executor_->add_node(node_);
+  spinner_ = std::thread([&]() {executor_->spin();});
+
+  // We must first ensure that the callback queue is "active" before we can be confident in using it
+  // outside of this initialize method...
+  std::mutex mtx;
+  std::condition_variable cv;
+
+  callback_queue_->addCallback(
+    std::make_shared<CallbackWrapper<void>>(
+      [&]() {
+        // NOTE(CH3): Causes random deadlocks if left in
+        //            Also technically unecessary because of wait_for used below
+        // std::unique_lock lk(mtx);
+
+        initialized_ = true;
+        cv.notify_one();
+      }));
+  // Wait a tiny while for the callback to be added
+  // Without this the condition variable ALWAYS times out on the first loop
+  rclcpp::sleep_for(std::chrono::milliseconds(1));
+
+  // ...And so we continually trigger the callback_queue's guard condition until it is serviced.
+  while (!initialized_) {
+    std::unique_lock lk(mtx);
+    callback_queue_->triggerGuardCondition();
+    cv.wait_for(lk, std::chrono::milliseconds(100));
+
+    if (!initialized_) {
+      RCLCPP_WARN_STREAM(
+        node_->get_logger(),
+        "Waiting for callback queue to be added to node waitables...");
+    }
+  }
 }
 
 void AsyncSensorModel::graphCallback(Graph::ConstSharedPtr graph)

--- a/fuse_core/test/test_async_motion_model.cpp
+++ b/fuse_core/test/test_async_motion_model.cpp
@@ -43,7 +43,7 @@ class MyMotionModel : public fuse_core::AsyncMotionModel
 {
 public:
   MyMotionModel()
-  : fuse_core::AsyncMotionModel(1),
+  : fuse_core::AsyncMotionModel(0),
     initialized(false)
   {
   }
@@ -59,7 +59,7 @@ public:
 
   void onGraphUpdate(fuse_core::Graph::ConstSharedPtr /*graph*/) override
   {
-    rclcpp::sleep_for(std::chrono::milliseconds(1000));
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
     graph_received = true;
   }
 
@@ -76,12 +76,12 @@ public:
 class TestAsyncMotionModel : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
+  void SetUp()
   {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase()
+  void TearDown()
   {
     rclcpp::shutdown();
   }
@@ -89,9 +89,13 @@ public:
 
 TEST_F(TestAsyncMotionModel, OnInit)
 {
-  MyMotionModel motion_model;
-  motion_model.initialize("my_motion_model");
-  EXPECT_TRUE(motion_model.initialized);
+  for (int i = 0; i < 500; i++) {
+    MyMotionModel motion_model;
+    motion_model.initialize("my_motion_model_" + std::to_string(i));
+    EXPECT_TRUE(motion_model.initialized);
+
+    rclcpp::sleep_for(std::chrono::milliseconds(1));  // Too fast causes problems
+  }
 }
 
 TEST_F(TestAsyncMotionModel, OnGraphUpdate)
@@ -104,15 +108,20 @@ TEST_F(TestAsyncMotionModel, OnGraphUpdate)
   // MyMotionModel's async spinner. There is a time delay there. So, this call should return almost
   // immediately, then we have to wait a bit before the "graph_received" flag gets flipped.
   fuse_core::Graph::ConstSharedPtr graph;  // nullptr is ok as we don't actually use it
-  motion_model.graphCallback(graph);
-  EXPECT_FALSE(motion_model.graph_received);
-
   auto clock = rclcpp::Clock(RCL_SYSTEM_TIME);
-  rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10.0);
-  while (!motion_model.graph_received && clock.now() < wait_time_elapsed) {
-    rclcpp::sleep_for(std::chrono::milliseconds(100));
+
+  // Test for multiple cycles of graphCallback to be sure
+  for (int i = 0; i < 50; i++) {
+    motion_model.graph_received = false;
+    motion_model.graphCallback(graph);
+    EXPECT_FALSE(motion_model.graph_received);
+
+    rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10);
+    while (!motion_model.graph_received && clock.now() < wait_time_elapsed) {
+      rclcpp::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(motion_model.graph_received);
   }
-  EXPECT_TRUE(motion_model.graph_received);
 }
 
 TEST_F(TestAsyncMotionModel, ApplyCallback)

--- a/fuse_core/test/test_async_publisher.cpp
+++ b/fuse_core/test/test_async_publisher.cpp
@@ -45,7 +45,7 @@ class MyPublisher : public fuse_core::AsyncPublisher
 {
 public:
   MyPublisher()
-  : fuse_core::AsyncPublisher(1),
+  : fuse_core::AsyncPublisher(0),
     callback_processed(false),
     initialized(false)
   {
@@ -57,7 +57,7 @@ public:
     fuse_core::Transaction::ConstSharedPtr /*transaction*/,
     fuse_core::Graph::ConstSharedPtr /*graph*/)
   {
-    rclcpp::sleep_for(std::chrono::milliseconds(1000));
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
     callback_processed = true;
   }
 
@@ -73,12 +73,12 @@ public:
 class TestAsyncPublisher : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
+  void SetUp()
   {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase()
+  void TearDown()
   {
     rclcpp::shutdown();
   }
@@ -86,9 +86,13 @@ public:
 
 TEST_F(TestAsyncPublisher, OnInit)
 {
-  MyPublisher publisher;
-  publisher.initialize("my_publisher");
-  EXPECT_TRUE(publisher.initialized);
+  for (int i = 0; i < 500; i++) {
+    MyPublisher publisher;
+    publisher.initialize("my_publisher_" + std::to_string(i));
+    EXPECT_TRUE(publisher.initialized);
+
+    rclcpp::sleep_for(std::chrono::milliseconds(1));  // Too fast causes problems
+  }
 }
 
 TEST_F(TestAsyncPublisher, notifyCallback)
@@ -102,14 +106,18 @@ TEST_F(TestAsyncPublisher, notifyCallback)
   // immediately, then we have to wait a bit before the "callback_processed" flag gets flipped.
   fuse_core::Transaction::ConstSharedPtr transaction;  // nullptr is ok as we don't actually use it
   fuse_core::Graph::ConstSharedPtr graph;  // nullptr is ok as we don't actually use it
-  publisher.notify(transaction, graph);
-  EXPECT_FALSE(publisher.callback_processed);
-
   auto clock = rclcpp::Clock(RCL_SYSTEM_TIME);
 
-  rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10.0);
-  while (!publisher.callback_processed && clock.now() < wait_time_elapsed) {
-    rclcpp::sleep_for(std::chrono::milliseconds(100));
+  // Test for multiple cycles of notify to be sure
+  for (int i = 0; i < 50; i++) {
+    publisher.callback_processed = false;
+    publisher.notify(transaction, graph);
+    EXPECT_FALSE(publisher.callback_processed);
+
+    rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10);
+    while (!publisher.callback_processed && clock.now() < wait_time_elapsed) {
+      rclcpp::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(publisher.callback_processed);
   }
-  EXPECT_TRUE(publisher.callback_processed);
 }

--- a/fuse_core/test/test_async_sensor_model.cpp
+++ b/fuse_core/test/test_async_sensor_model.cpp
@@ -57,7 +57,7 @@ class MySensor : public fuse_core::AsyncSensorModel
 {
 public:
   MySensor()
-  : fuse_core::AsyncSensorModel(1),
+  : fuse_core::AsyncSensorModel(0),
     initialized(false)
   {
   }
@@ -71,7 +71,7 @@ public:
 
   void onGraphUpdate(fuse_core::Graph::ConstSharedPtr /*graph*/) override
   {
-    rclcpp::sleep_for(std::chrono::milliseconds(1000));
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
     graph_received = true;
   }
 
@@ -82,12 +82,12 @@ public:
 class TestAsyncSensorModel : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
+  void SetUp()
   {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase()
+  void TearDown()
   {
     rclcpp::shutdown();
   }
@@ -95,9 +95,13 @@ public:
 
 TEST_F(TestAsyncSensorModel, OnInit)
 {
-  MySensor sensor;
-  sensor.initialize("my_sensor", &transactionCallback);
-  EXPECT_TRUE(sensor.initialized);
+  for (int i = 0; i < 500; i++) {
+    MySensor sensor;
+    sensor.initialize("my_sensor_" + std::to_string(i), &transactionCallback);
+    EXPECT_TRUE(sensor.initialized);
+
+    rclcpp::sleep_for(std::chrono::milliseconds(1));  // Too fast causes problems
+  }
 }
 
 TEST_F(TestAsyncSensorModel, OnGraphUpdate)
@@ -110,14 +114,19 @@ TEST_F(TestAsyncSensorModel, OnGraphUpdate)
   // There is a time delay there. So, this call should return almost immediately, then we have to
   // wait a bit before the "received_graph" flag gets flipped.
   fuse_core::Graph::ConstSharedPtr graph;  // nullptr is ok as we don't actually use it
-  sensor.graphCallback(graph);
-  EXPECT_FALSE(sensor.graph_received);
   auto clock = rclcpp::Clock(RCL_SYSTEM_TIME);
-  rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10.0);
-  while (!sensor.graph_received && clock.now() < wait_time_elapsed) {
-    rclcpp::sleep_for(std::chrono::milliseconds(100));
+
+  // Test for multiple cycles of graphCallback to be sure
+  for (int i = 0; i < 50; i++) {
+    sensor.graph_received = false;
+    sensor.graphCallback(graph);
+    EXPECT_FALSE(sensor.graph_received);
+    rclcpp::Time wait_time_elapsed = clock.now() + rclcpp::Duration::from_seconds(10);
+    while (!sensor.graph_received && clock.now() < wait_time_elapsed) {
+      rclcpp::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(sensor.graph_received);
   }
-  EXPECT_TRUE(sensor.graph_received);
 }
 
 TEST_F(TestAsyncSensorModel, SendTransaction)


### PR DESCRIPTION
See: https://github.com/locusrobotics/fuse/issues/276

# Description
There are several outstanding issues with the async model used in fuse_core:
1. There's a chance for the destructor to get called before the internal spinner thread reaches the spin() call, causing the executor to mask the `executor->cancel()` call and spin forever.
2. If a new callback is added before the internal spinner attaches the waitable, the executor only wakes up once when there are actually two waitables to execute. That is, despite two guard condition triggers for two waitables, the executor only services one waitable.
3. For some reason, using an internal executor with 2 or more threads causes the waitables to never get picked up. I suspect this is because of (2). That is, because of (2) the waitable that adds the callback queue never gets served (the guard condition never gets added to the waitset).

I'm a little iffy on if that's what's happening with (2), but regardless, the solutions implemented in this PR fix both issues.

The solution is to keep triggering the guard condition on hooking of the callback queues until the callback queues are serviced.

I also edited the tests to be a ~~little bit~~ a lot stricter and now test for multiple callback additions and initializations.
The tests now feature async classes with executor thread count of 0 (which means the number of threads will equal the number of CPU cores), as troublesome a case as possible to test, to ensure my solutions are as robust as possible.

I had to do this because a lot of the issues seem to be race condition related and come up extremely rarely.

# Notes
There was an alternative solution that I explored (which also worked), which was to use the [timeout argument](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp#L33) for the multi-threaded executor. This removes any chance of the multi-threaded executor deadlocking on waitables, [but at the cost of free spinning at the rate of the timeout](https://github.com/ros2/rclcpp/blob/d119157948720f5888d47898e1c59b56fe1f86c5/rclcpp/src/rclcpp/executor.cpp#L912).

If we encounter deadlock or threading issues down the line, we might have to use that solution instead.

- Sometimes the initialize still deadlocks (and we're stuck in the waiting for the `initialized_` atomic to become true. I can't reproduce it though... Is there a chance for callbacks to get dropped??
- I'm also kinda iffy about all the random sleep_for dotted around the init, but it's the only way to avoid the warning printouts most of the time

# Update
EDIT: I pulled out all the stops and used all the solutions I found, all at once. I do not think I understand the problem enough to come up with an elegant solution, as for some reason all the "good practices" (like locking on threads that notify condition variables), or relying on condition variable waits instead of sleeps all result in deadlocks or weird behavior like atomic flags not getting set when the block that sets them ostensibly runs (???).

The solution I've devised combines the use of condition variables and manual guard condition triggers (just for `initialize()`!!), and also a lower frequency executor wakeup.

- The manual guard condition triggers should resolve the problem where the executor misses either the first callback, or the callback that adds the callback_queue to the node's waitables
- The lower frequency executor wakeup then resolves the issue where for some reason the initialization callback doesn't run
- Finally,
  - I had to remove the lock acquisition on the initialization callback because for some reason it causes a deadlock
  - And I had to add a small sleep because otherwise sometimes the atomic doesn't get set even though the callback gets run (????)
  - And I had to throttle the tests a tiny bit, because again, for some reason, spinning up and shutting down multithreaded executors too rapidly (**sequentially**) causes something to break (???)

On the other hand, I'm able to spin up and down a massive amount of async instances sequentially now, when before it'd randomly block indefinitely, so it might just be good enough (I updated the tests to check for that case specifically.)? I have yet to see it fail, but I am not confident that it will never fail, since I never understood why it failed in the first place.

Some refinement might be helpful though, maybe I'm just not seeing something obvious.

Pinging @svwilliams for visibility.