### PR TITLE
Fix SerializedPublisher not being able to read it's parameters

### DIFF
--- a/fuse_core/include/fuse_core/parameter.hpp
+++ b/fuse_core/include/fuse_core/parameter.hpp
@@ -49,6 +49,9 @@
 namespace fuse_core
 {
 
+// Helper function to get a namespace string with a '.' suffix, but only if not empty
+std::string joinParameterName(const std::string & left, const std::string & right);
+
 // NOTE(CH3): Some of these basically mimic the behavior from rclcpp's node.hpp, but for interfaces
 
 /**

--- a/fuse_core/src/parameter.cpp
+++ b/fuse_core/src/parameter.cpp
@@ -83,4 +83,21 @@ detail::list_parameter_override_prefixes(
   }
   return output_names;
 }
+
+std::string joinParameterName(const std::string & left, const std::string & right)
+{
+  if (left.empty()) {
+    return right;
+  }
+  if (right.empty()) {
+    return left;
+  }
+  if ('.' != left.back() && '.' != right.front() ) {
+    return left + '.' + right;
+  }
+  if ('.' == left.back() && '.' == right.front()) {
+    return left + right.substr(1);
+  }
+  return left + right;
+}
 }  // namespace fuse_core

--- a/fuse_core/test/test_parameter.cpp
+++ b/fuse_core/test/test_parameter.cpp
@@ -95,3 +95,13 @@ TEST(parameter, list_parameter_override_prefixes)
     EXPECT_NE(matches.end(), matches.find("baz"));
   }
 }
+
+TEST(parameter, joinParameterName)
+{
+  EXPECT_EQ("foo.bar", fuse_core::joinParameterName("foo", "bar"));
+  EXPECT_EQ("foo.bar", fuse_core::joinParameterName("foo.", "bar"));
+  EXPECT_EQ("foo.bar", fuse_core::joinParameterName("foo", ".bar"));
+  EXPECT_EQ("foo.bar", fuse_core::joinParameterName("foo.", ".bar"));
+  EXPECT_EQ("foo", fuse_core::joinParameterName("foo", ""));
+  EXPECT_EQ("bar", fuse_core::joinParameterName("", "bar"));
+}

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -69,17 +69,27 @@ void SerializedPublisher::initialize(
 void SerializedPublisher::onInit()
 {
   // Configure the publisher
-  frame_id_ = fuse_core::getParam(interfaces_, "frame_id", frame_id_);
+  frame_id_ = fuse_core::getParam(
+    interfaces_,
+    fuse_core::joinParameterName(name_, "frame_id"), frame_id_);
 
   bool latch = false;
-  latch = fuse_core::getParam(interfaces_, "latch", latch);
+  latch = fuse_core::getParam(
+    interfaces_,
+    fuse_core::joinParameterName(name_, "latch"), latch);
 
   rclcpp::Duration graph_throttle_period{0, 0};
-  fuse_core::getPositiveParam(interfaces_, "graph_throttle_period", graph_throttle_period, false);
+  fuse_core::getPositiveParam(
+    interfaces_,
+    fuse_core::joinParameterName(name_, "graph_throttle_period"),
+    graph_throttle_period, false);
 
   bool graph_throttle_use_wall_time{false};
   graph_throttle_use_wall_time =
-    fuse_core::getParam(interfaces_, "graph_throttle_use_wall_time", graph_throttle_use_wall_time);
+    fuse_core::getParam(
+      interfaces_,
+      fuse_core::joinParameterName(name_, "graph_throttle_use_wall_time"),
+      graph_throttle_use_wall_time);
 
   graph_publisher_throttled_callback_.setThrottlePeriod(graph_throttle_period);
 


### PR DESCRIPTION
Part of #276 

This fixes `SerializedPublisher` not being able to read it's parameters in ROS 2.

@svwilliams FYI

here's an updated fuse_simple_tutorial.yaml that shows how to pass parameters to it

```yaml
state_estimator:
  ros__parameters:
    # Fixed-lag smoother configuration
    optimization_frequency: 20.0
    transaction_timeout: 0.01
    lag_duration: 0.5

    motion_models:
      unicycle_motion_model:
        type: fuse_models::Unicycle2D

    unicycle_motion_model:
      #                         x      y      yaw    vx     vy     vyaw   ax   ay
      process_noise_diagonal: [0.100, 0.100, 0.100, 0.100, 0.100, 0.100, 0.1, 0.1]

    sensor_models:
      initial_localization_sensor:
        type: fuse_models::Unicycle2DIgnition
        motion_models: [unicycle_motion_model]
        ignition: true
      odometry_sensor:
        type: fuse_models::Odometry2D
        motion_models: [unicycle_motion_model]
      imu_sensor:
        type: fuse_models::Imu2D
        motion_models: [unicycle_motion_model]

    initial_localization_sensor:
      publish_on_startup: true
      #                x      y      yaw    vx     vy     vyaw    ax     ay
      initial_state: [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
      initial_sigma: [0.100, 0.100, 0.100, 0.100, 0.100, 0.100, 0.100, 0.100]

    odometry_sensor:
      topic: "odom"
      twist_target_frame: "base_footprint"
      linear_velocity_dimensions: ['x', 'y']
      angular_velocity_dimensions: ['yaw']

    imu_sensor:
      topic: "imu"
      angular_velocity_dimensions: ['yaw']
      linear_acceleration_dimensions: ['x', 'y']
      twist_target_frame: "base_footprint"

    publishers:
      filtered_publisher:
        type: fuse_models::Odometry2DPublisher
      serialized_publisher:
        type: fuse_publishers::SerializedPublisher

    filtered_publisher:
      topic: "odom_filtered"
      base_link_frame_id: "base_footprint"
      odom_frame_id: "odom"
      map_frame_id: "map"
      world_frame_id: "odom"
      publish_tf: true
      publish_frequency: 10.0

    serialized_publisher:
      frame_id: "odom"
```