### PR TITLE
Use getParameterName and namespace parameters for publishers

### DIFF
--- a/fuse_core/include/fuse_core/ceres_options.hpp
+++ b/fuse_core/include/fuse_core/ceres_options.hpp
@@ -233,7 +233,7 @@ void loadCovarianceOptionsFromROS(
     node_interfaces::Parameters
   > interfaces,
   ceres::Covariance::Options & covariance_options,
-  const std::string & namespace_string = std::string());
+  const std::string & ns = std::string());
 
 /**
  * @brief Populate a ceres::Problem::Options object with information from the parameter server
@@ -248,7 +248,7 @@ void loadProblemOptionsFromROS(
     node_interfaces::Parameters
   > interfaces,
   ceres::Problem::Options & problem_options,
-  const std::string & namespace_string = std::string());
+  const std::string & ns = std::string());
 
 /**
  * @brief Populate a ceres::Solver::Options object with information from the parameter server
@@ -265,7 +265,7 @@ void loadSolverOptionsFromROS(
     node_interfaces::Parameters
   > interfaces,
   ceres::Solver::Options & solver_options,
-  const std::string & namespace_string = std::string());
+  const std::string & ns = std::string());
 
 }  // namespace fuse_core
 

--- a/fuse_core/src/ceres_options.cpp
+++ b/fuse_core/src/ceres_options.cpp
@@ -52,13 +52,6 @@
 namespace fuse_core
 {
 
-// Helper function to get a namespace string with a '.' suffix, but only if not empty
-static std::string get_well_formatted_param_namespace_string(std::string ns)
-{
-  return ns.empty() || ns.back() == '.' ? ns : ns + ".";
-}
-
-
 void loadCovarianceOptionsFromROS(
   node_interfaces::NodeInterfaces<
     node_interfaces::Base,
@@ -66,21 +59,19 @@ void loadCovarianceOptionsFromROS(
     node_interfaces::Parameters
   > interfaces,
   ceres::Covariance::Options & covariance_options,
-  const std::string & namespace_string)
+  const std::string & ns)
 {
   rcl_interfaces::msg::ParameterDescriptor tmp_descr;
-
-  std::string ns = get_well_formatted_param_namespace_string(namespace_string);
 
   // The sparse_linear_algebra_library_type field was added to ceres::Covariance::Options in version
   // 1.13.0, see https://github.com/ceres-solver/ceres-
   // solver/commit/14d8297cf968e421c5db4e3fb0543b3b111155d7
   covariance_options.sparse_linear_algebra_library_type = fuse_core::declareCeresParam(
-    interfaces, ns + "sparse_linear_algebra_library_type",
+    interfaces, fuse_core::joinParameterName(ns, "sparse_linear_algebra_library_type"),
     covariance_options.sparse_linear_algebra_library_type);
   covariance_options.algorithm_type =
     fuse_core::declareCeresParam(
-    interfaces, ns + "algorithm_type",
+    interfaces, fuse_core::joinParameterName(ns, "algorithm_type"),
     covariance_options.algorithm_type);
 
   tmp_descr.description = (
@@ -92,7 +83,8 @@ void loadCovarianceOptionsFromROS(
     "Where min_sigma and max_sigma are the minimum and maximum singular values of J respectively.");
   covariance_options.min_reciprocal_condition_number = fuse_core::getParam(
     interfaces,
-    ns + "min_reciprocal_condition_number", covariance_options.min_reciprocal_condition_number,
+    fuse_core::joinParameterName(ns, "min_reciprocal_condition_number"),
+    covariance_options.min_reciprocal_condition_number,
     tmp_descr
   );
 
@@ -100,14 +92,15 @@ void loadCovarianceOptionsFromROS(
     "The number of singular dimensions to tolerate (-1 unbounded) no effect on `SPARSE_QR`";
   covariance_options.null_space_rank = fuse_core::getParam(
     interfaces,
-    ns + "null_space_rank", covariance_options.null_space_rank, tmp_descr
+    fuse_core::joinParameterName(ns, "null_space_rank"),
+    covariance_options.null_space_rank, tmp_descr
   );
 
   tmp_descr.description =
     "Number of threads to be used for evaluating the Jacobian and estimation of covariance";
   covariance_options.num_threads = fuse_core::getParam(
     interfaces,
-    ns + "num_threads", covariance_options.num_threads, tmp_descr
+    fuse_core::joinParameterName(ns, "num_threads"), covariance_options.num_threads, tmp_descr
   );
 
   tmp_descr.description = (
@@ -116,23 +109,25 @@ void loadCovarianceOptionsFromROS(
     "functions)");
   covariance_options.apply_loss_function = fuse_core::getParam(
     interfaces,
-    ns + "apply_loss_function", covariance_options.apply_loss_function, tmp_descr
+    fuse_core::joinParameterName(ns, "apply_loss_function"),
+    covariance_options.apply_loss_function,
+    tmp_descr
   );
 }
 
 void loadProblemOptionsFromROS(
   node_interfaces::NodeInterfaces<node_interfaces::Parameters> interfaces,
   ceres::Problem::Options & problem_options,
-  const std::string & namespace_string)
+  const std::string & ns)
 {
   rcl_interfaces::msg::ParameterDescriptor tmp_descr;
-
-  std::string ns = get_well_formatted_param_namespace_string(namespace_string);
 
   tmp_descr.description = "trades memory for faster Problem::RemoveResidualBlock()";
   problem_options.enable_fast_removal = fuse_core::getParam(
     interfaces,
-    ns + "enable_fast_removal", problem_options.enable_fast_removal, tmp_descr
+    fuse_core::joinParameterName(ns, "enable_fast_removal"),
+    problem_options.enable_fast_removal,
+    tmp_descr
   );
 
   tmp_descr.description = (
@@ -147,7 +142,9 @@ void loadProblemOptionsFromROS(
     "you are doing");
   problem_options.disable_all_safety_checks = fuse_core::getParam(
     interfaces,
-    ns + "disable_all_safety_checks", problem_options.disable_all_safety_checks, tmp_descr
+    fuse_core::joinParameterName(ns, "disable_all_safety_checks"),
+    problem_options.disable_all_safety_checks,
+    tmp_descr
   );
 }
 
@@ -158,31 +155,35 @@ void loadSolverOptionsFromROS(
     node_interfaces::Parameters
   > interfaces,
   ceres::Solver::Options & solver_options,
-  const std::string & namespace_string)
+  const std::string & ns)
 {
   rcl_interfaces::msg::ParameterDescriptor tmp_descr;
 
-  std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
   // Minimizer options
-  solver_options.minimizer_type =
-    fuse_core::declareCeresParam(interfaces, ns + "minimizer_type", solver_options.minimizer_type);
+  solver_options.minimizer_type = fuse_core::declareCeresParam(
+    interfaces, fuse_core::joinParameterName(ns, "minimizer_type"), solver_options.minimizer_type);
   solver_options.line_search_direction_type = fuse_core::declareCeresParam(
-    interfaces, ns + "line_search_direction_type", solver_options.line_search_direction_type);
-  solver_options.line_search_type =
-    fuse_core::declareCeresParam(
-    interfaces, ns + "line_search_type",
-    solver_options.line_search_type);
+    interfaces,
+    fuse_core::joinParameterName(ns, "line_search_direction_type"),
+    solver_options.line_search_direction_type
+  );
+  solver_options.line_search_type = fuse_core::declareCeresParam(
+    interfaces,
+    fuse_core::joinParameterName(ns, "line_search_type"),
+    solver_options.line_search_type
+  );
   solver_options.nonlinear_conjugate_gradient_type = fuse_core::declareCeresParam(
-    interfaces, ns + "nonlinear_conjugate_gradient_type",
-    solver_options.nonlinear_conjugate_gradient_type);
+    interfaces,
+    fuse_core::joinParameterName(ns, "nonlinear_conjugate_gradient_type"),
+    solver_options.nonlinear_conjugate_gradient_type
+  );
 
   tmp_descr.description = (
     "The rank of the LBFGS hessian approximation. See: Nocedal, J. (1980). 'Updating Quasi-Newton "
     "Matrices with Limited Storage'. Mathematics of Computation 35 (151): 773-782.");
   solver_options.max_lbfgs_rank = fuse_core::getParam(
     interfaces,
-    ns + "max_lbfgs_rank",
+    fuse_core::joinParameterName(ns, "max_lbfgs_rank"),
     solver_options.max_lbfgs_rank,
     tmp_descr
   );
@@ -196,7 +197,7 @@ void loadSolverOptionsFromROS(
     "use_approximate_eigenvalue_bfgs_scaling to true enables this scaling.");
   solver_options.use_approximate_eigenvalue_bfgs_scaling = fuse_core::getParam(
     interfaces,
-    ns + "use_approximate_eigenvalue_bfgs_scaling",
+    fuse_core::joinParameterName(ns, "use_approximate_eigenvalue_bfgs_scaling"),
     solver_options.use_approximate_eigenvalue_bfgs_scaling,
     tmp_descr
   );
@@ -206,14 +207,14 @@ void loadSolverOptionsFromROS(
     "BISECTION, QUADRATIC and CUBIC.");
   solver_options.line_search_interpolation_type = fuse_core::declareCeresParam(
     interfaces,
-    ns + "line_search_interpolation_type",
+    fuse_core::joinParameterName(ns, "line_search_interpolation_type"),
     solver_options.line_search_interpolation_type);
 
   tmp_descr.description =
     "If during the line search, the step_size falls below this value, it is truncated to zero.";
   solver_options.min_line_search_step_size = fuse_core::getParam(
     interfaces,
-    ns + "min_line_search_step_size",
+    fuse_core::joinParameterName(ns, "min_line_search_step_size"),
     solver_options.min_line_search_step_size,
     tmp_descr
   );
@@ -230,7 +231,7 @@ void loadSolverOptionsFromROS(
     "f(step_size) <= f(0) + sufficient_decrease * f'(0) * step_size");
   solver_options.line_search_sufficient_function_decrease = fuse_core::getParam(
     interfaces,
-    ns + "line_search_sufficient_function_decrease",
+    fuse_core::joinParameterName(ns, "line_search_sufficient_function_decrease"),
     solver_options.line_search_sufficient_function_decrease,
     tmp_descr
   );
@@ -243,7 +244,7 @@ void loadSolverOptionsFromROS(
     "0 < max_step_contraction < min_step_contraction < 1");
   solver_options.max_line_search_step_contraction = fuse_core::getParam(
     interfaces,
-    ns + "max_line_search_step_contraction",
+    fuse_core::joinParameterName(ns, "max_line_search_step_contraction"),
     solver_options.max_line_search_step_contraction,
     tmp_descr
   );
@@ -256,7 +257,7 @@ void loadSolverOptionsFromROS(
     "0 < max_step_contraction < min_step_contraction < 1");
   solver_options.min_line_search_step_contraction = fuse_core::getParam(
     interfaces,
-    ns + "min_line_search_step_contraction",
+    fuse_core::joinParameterName(ns, "min_line_search_step_contraction"),
     solver_options.min_line_search_step_contraction,
     tmp_descr
   );
@@ -273,7 +274,7 @@ void loadSolverOptionsFromROS(
     "optimization problems. ");
   solver_options.max_num_line_search_step_size_iterations = fuse_core::getParam(
     interfaces,
-    ns + "max_num_line_search_step_size_iterations",
+    fuse_core::joinParameterName(ns, "max_num_line_search_step_size_iterations"),
     solver_options.max_num_line_search_step_size_iterations,
     tmp_descr
   );
@@ -286,7 +287,7 @@ void loadSolverOptionsFromROS(
     "in the validity of the approximations used. ");
   solver_options.max_num_line_search_direction_restarts = fuse_core::getParam(
     interfaces,
-    ns + "max_num_line_search_direction_restarts",
+    fuse_core::joinParameterName(ns, "max_num_line_search_direction_restarts"),
     solver_options.max_num_line_search_direction_restarts,
     tmp_descr
   );
@@ -305,7 +306,7 @@ void loadSolverOptionsFromROS(
     "w.r.t step_size (d f / d step_size).");
   solver_options.line_search_sufficient_curvature_decrease = fuse_core::getParam(
     interfaces,
-    ns + "line_search_sufficient_curvature_decrease",
+    fuse_core::joinParameterName(ns, "line_search_sufficient_curvature_decrease"),
     solver_options.line_search_sufficient_curvature_decrease,
     tmp_descr
   );
@@ -321,15 +322,18 @@ void loadSolverOptionsFromROS(
     "By definition for expansion, max_step_expansion > 1.0.");
   solver_options.max_line_search_step_expansion = fuse_core::getParam(
     interfaces,
-    ns + "max_line_search_step_expansion",
+    fuse_core::joinParameterName(ns, "max_line_search_step_expansion"),
     solver_options.max_line_search_step_expansion,
     tmp_descr
   );
 
   solver_options.trust_region_strategy_type = fuse_core::declareCeresParam(
-    interfaces, ns + "trust_region_strategy_type", solver_options.trust_region_strategy_type);
+    interfaces,
+    fuse_core::joinParameterName(ns, "trust_region_strategy_type"),
+    solver_options.trust_region_strategy_type
+  );
   solver_options.dogleg_type = fuse_core::declareCeresParam(
-    interfaces, ns + "dogleg_type", solver_options.dogleg_type);
+    interfaces, fuse_core::joinParameterName(ns, "dogleg_type"), solver_options.dogleg_type);
 
 
   tmp_descr.description = (
@@ -337,7 +341,7 @@ void loadSolverOptionsFromROS(
     "Gould & Toint in 'Trust Region Methods', Section 10.1");
   solver_options.use_nonmonotonic_steps = fuse_core::getParam(
     interfaces,
-    ns + "use_nonmonotonic_steps",
+    fuse_core::joinParameterName(ns, "use_nonmonotonic_steps"),
     solver_options.use_nonmonotonic_steps,
     tmp_descr
   );
@@ -346,7 +350,7 @@ void loadSolverOptionsFromROS(
     "The window size used by the step selection algorithm to accept non-monotonic steps";
   solver_options.max_consecutive_nonmonotonic_steps = fuse_core::getParam(
     interfaces,
-    ns + "max_consecutive_nonmonotonic_steps",
+    fuse_core::joinParameterName(ns, "max_consecutive_nonmonotonic_steps"),
     solver_options.max_consecutive_nonmonotonic_steps,
     tmp_descr
   );
@@ -355,7 +359,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "Maximum number of iterations for which the solver should run";
   solver_options.max_num_iterations = fuse_core::getParam(
     interfaces,
-    ns + "max_num_iterations",
+    fuse_core::joinParameterName(ns, "max_num_iterations"),
     solver_options.max_num_iterations,
     tmp_descr
   );
@@ -363,7 +367,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "Maximum amount of time for which the solver should run";
   solver_options.max_solver_time_in_seconds = fuse_core::getParam(
     interfaces,
-    ns + "max_solver_time_in_seconds",
+    fuse_core::joinParameterName(ns, "max_solver_time_in_seconds"),
     solver_options.max_solver_time_in_seconds,
     tmp_descr
   );
@@ -371,7 +375,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "Number of threads used by Ceres for evaluating the cost and jacobians";
   solver_options.num_threads = fuse_core::getParam(
     interfaces,
-    ns + "num_threads",
+    fuse_core::joinParameterName(ns, "num_threads"),
     solver_options.num_threads,
     tmp_descr
   );
@@ -381,7 +385,7 @@ void loadSolverOptionsFromROS(
     "reciprocal of this number is the initial regularization parameter");
   solver_options.initial_trust_region_radius = fuse_core::getParam(
     interfaces,
-    ns + "initial_trust_region_radius",
+    fuse_core::joinParameterName(ns, "initial_trust_region_radius"),
     solver_options.initial_trust_region_radius,
     tmp_descr
   );
@@ -389,7 +393,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "The trust region radius is not allowed to grow beyond this value";
   solver_options.max_trust_region_radius = fuse_core::getParam(
     interfaces,
-    ns + "max_trust_region_radius",
+    fuse_core::joinParameterName(ns, "max_trust_region_radius"),
     solver_options.max_trust_region_radius,
     tmp_descr
   );
@@ -398,7 +402,7 @@ void loadSolverOptionsFromROS(
     "The solver terminates when the trust region becomes smaller than this value";
   solver_options.min_trust_region_radius = fuse_core::getParam(
     interfaces,
-    ns + "min_trust_region_radius",
+    fuse_core::joinParameterName(ns, "min_trust_region_radius"),
     solver_options.min_trust_region_radius,
     tmp_descr
   );
@@ -407,7 +411,7 @@ void loadSolverOptionsFromROS(
     "Lower threshold for relative decrease before a trust-region step is accepted";
   solver_options.min_relative_decrease = fuse_core::getParam(
     interfaces,
-    ns + "min_relative_decrease",
+    fuse_core::joinParameterName(ns, "min_relative_decrease"),
     solver_options.min_relative_decrease,
     tmp_descr
   );
@@ -417,7 +421,7 @@ void loadSolverOptionsFromROS(
     "This is the lower bound on the values of this diagonal matrix");
   solver_options.min_lm_diagonal = fuse_core::getParam(
     interfaces,
-    ns + "min_lm_diagonal",
+    fuse_core::joinParameterName(ns, "min_lm_diagonal"),
     solver_options.min_lm_diagonal,
     tmp_descr
   );
@@ -427,7 +431,7 @@ void loadSolverOptionsFromROS(
     "This is the upper bound on the values of this diagonal matrix");
   solver_options.max_lm_diagonal = fuse_core::getParam(
     interfaces,
-    ns + "max_lm_diagonal",
+    fuse_core::joinParameterName(ns, "max_lm_diagonal"),
     solver_options.max_lm_diagonal,
     tmp_descr
   );
@@ -439,7 +443,7 @@ void loadSolverOptionsFromROS(
     " This parameter sets the number of consecutive retries before the minimizer gives up");
   solver_options.max_num_consecutive_invalid_steps = fuse_core::getParam(
     interfaces,
-    ns + "max_num_consecutive_invalid_steps",
+    fuse_core::joinParameterName(ns, "max_num_consecutive_invalid_steps"),
     solver_options.max_num_consecutive_invalid_steps,
     tmp_descr
   );
@@ -448,7 +452,7 @@ void loadSolverOptionsFromROS(
     "Minimizer terminates when: (new_cost - old_cost) < function_tolerance * old_cost;";
   solver_options.function_tolerance = fuse_core::getParam(
     interfaces,
-    ns + "function_tolerance",
+    fuse_core::joinParameterName(ns, "function_tolerance"),
     solver_options.function_tolerance,
     tmp_descr
   );
@@ -459,7 +463,7 @@ void loadSolverOptionsFromROS(
     "This value should typically be 1e-4 * function_tolerance");
   solver_options.gradient_tolerance = fuse_core::getParam(
     interfaces,
-    ns + "gradient_tolerance",
+    fuse_core::joinParameterName(ns, "gradient_tolerance"),
     solver_options.gradient_tolerance,
     tmp_descr
   );
@@ -468,29 +472,29 @@ void loadSolverOptionsFromROS(
     "Minimizer terminates when: |step|_2 <= parameter_tolerance * ( |x|_2 +  parameter_tolerance)";
   solver_options.parameter_tolerance = fuse_core::getParam(
     interfaces,
-    ns + "parameter_tolerance",
+    fuse_core::joinParameterName(ns, "parameter_tolerance"),
     solver_options.parameter_tolerance,
     tmp_descr
   );
 
   solver_options.linear_solver_type =
     fuse_core::declareCeresParam(
-    interfaces, ns + "linear_solver_type",
+    interfaces, fuse_core::joinParameterName(ns, "linear_solver_type"),
     solver_options.linear_solver_type);
   solver_options.preconditioner_type =
     fuse_core::declareCeresParam(
-    interfaces, ns + "preconditioner_type",
+    interfaces, fuse_core::joinParameterName(ns, "preconditioner_type"),
     solver_options.preconditioner_type);
   solver_options.visibility_clustering_type =
     fuse_core::declareCeresParam(
-    interfaces, ns + "visibility_clustering_type",
+    interfaces, fuse_core::joinParameterName(ns, "visibility_clustering_type"),
     solver_options.visibility_clustering_type);
   solver_options.dense_linear_algebra_library_type =
     fuse_core::declareCeresParam(
-    interfaces, ns + "dense_linear_algebra_library_type",
+    interfaces, fuse_core::joinParameterName(ns, "dense_linear_algebra_library_type"),
     solver_options.dense_linear_algebra_library_type);
   solver_options.sparse_linear_algebra_library_type = fuse_core::declareCeresParam(
-    interfaces, ns + "sparse_linear_algebra_library_type",
+    interfaces, fuse_core::joinParameterName(ns, "sparse_linear_algebra_library_type"),
     solver_options.sparse_linear_algebra_library_type);
 
   // No parameter is loaded for: std::shared_ptr<ParameterBlockOrdering> linear_solver_ordering;
@@ -500,7 +504,7 @@ void loadSolverOptionsFromROS(
     "Enabling this option tells ITERATIVE_SCHUR to use an explicitly computed Schur complement.";
   solver_options.use_explicit_schur_complement = fuse_core::getParam(
     interfaces,
-    ns + "use_explicit_schur_complement",
+    fuse_core::joinParameterName(ns, "use_explicit_schur_complement"),
     solver_options.use_explicit_schur_complement,
     tmp_descr
   );
@@ -513,7 +517,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "This settings only affects the SPARSE_NORMAL_CHOLESKY solver.";
   solver_options.dynamic_sparsity = fuse_core::getParam(
     interfaces,
-    ns + "dynamic_sparsity",
+    fuse_core::joinParameterName(ns, "dynamic_sparsity"),
     solver_options.dynamic_sparsity,
     tmp_descr
   );
@@ -531,7 +535,7 @@ void loadSolverOptionsFromROS(
     "of this accuracy back.");
   solver_options.use_mixed_precision_solves = fuse_core::getParam(
     interfaces,
-    ns + "use_mixed_precision_solves",
+    fuse_core::joinParameterName(ns, "use_mixed_precision_solves"),
     solver_options.use_mixed_precision_solves,
     tmp_descr
   );
@@ -540,7 +544,7 @@ void loadSolverOptionsFromROS(
     "Number steps of the iterative refinement process to run when computing the Gauss-Newton step.";
   solver_options.max_num_refinement_iterations = fuse_core::getParam(
     interfaces,
-    ns + "max_num_refinement_iterations",
+    fuse_core::joinParameterName(ns, "max_num_refinement_iterations"),
     solver_options.max_num_refinement_iterations,
     tmp_descr
   );
@@ -551,7 +555,7 @@ void loadSolverOptionsFromROS(
     "Enable the use of the non-linear generalization of Ruhe & Wedin's Algorithm II";
   solver_options.use_inner_iterations = fuse_core::getParam(
     interfaces,
-    ns + "use_inner_iterations",
+    fuse_core::joinParameterName(ns, "use_inner_iterations"),
     solver_options.use_inner_iterations,
     tmp_descr
   );
@@ -566,7 +570,7 @@ void loadSolverOptionsFromROS(
     "iterations is disabled.");
   solver_options.inner_iteration_tolerance = fuse_core::getParam(
     interfaces,
-    ns + "inner_iteration_tolerance",
+    fuse_core::joinParameterName(ns, "inner_iteration_tolerance"),
     solver_options.inner_iteration_tolerance,
     tmp_descr
   );
@@ -574,7 +578,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "Minimum number of iterations used by the linear iterative solver";
   solver_options.min_linear_solver_iterations = fuse_core::getParam(
     interfaces,
-    ns + "min_linear_solver_iterations",
+    fuse_core::joinParameterName(ns, "min_linear_solver_iterations"),
     solver_options.min_linear_solver_iterations,
     tmp_descr
   );
@@ -582,7 +586,7 @@ void loadSolverOptionsFromROS(
   tmp_descr.description = "Maximum number of iterations used by the linear iterative solver";
   solver_options.max_linear_solver_iterations = fuse_core::getParam(
     interfaces,
-    ns + "max_linear_solver_iterations",
+    fuse_core::joinParameterName(ns, "max_linear_solver_iterations"),
     solver_options.max_linear_solver_iterations,
     tmp_descr
   );
@@ -592,7 +596,7 @@ void loadSolverOptionsFromROS(
     "relative accuracy with which the Newton step is computed");
   solver_options.eta = fuse_core::getParam(
     interfaces,
-    ns + "eta",
+    fuse_core::joinParameterName(ns, "eta"),
     solver_options.eta,
     tmp_descr
   );
@@ -603,26 +607,29 @@ void loadSolverOptionsFromROS(
     "linear solver. This improves the numerical conditioning of the normal equations");
   solver_options.jacobi_scaling = fuse_core::getParam(
     interfaces,
-    ns + "jacobi_scaling",
+    fuse_core::joinParameterName(ns, "jacobi_scaling"),
     solver_options.jacobi_scaling,
     tmp_descr
   );
 
   // Logging options
-  solver_options.logging_type =
-    fuse_core::declareCeresParam(interfaces, ns + "logging_type", solver_options.logging_type);
+  solver_options.logging_type = fuse_core::declareCeresParam(
+    interfaces, fuse_core::joinParameterName(ns, "logging_type"), solver_options.logging_type);
 
   tmp_descr.description = "If logging_type is not SILENT, sends the logging output to STDOUT";
   solver_options.minimizer_progress_to_stdout = fuse_core::getParam(
     interfaces,
-    ns + "minimizer_progress_to_stdout",
+    fuse_core::joinParameterName(ns, "minimizer_progress_to_stdout"),
     solver_options.minimizer_progress_to_stdout,
     tmp_descr
   );
   fuse_core::getParam<std::vector<int64_t>>(
-    interfaces, ns + "trust_region_minimizer_iterations_to_dump", std::vector<int64_t>());
+    interfaces,
+    fuse_core::joinParameterName(ns, "trust_region_minimizer_iterations_to_dump"),
+    std::vector<int64_t>()
+  );
   std::vector<int64_t> iterations_to_dump_tmp = interfaces.get_node_parameters_interface()
-    ->get_parameter(ns + "trust_region_minimizer_iterations_to_dump")
+    ->get_parameter(fuse_core::joinParameterName(ns, "trust_region_minimizer_iterations_to_dump"))
     .get_value<std::vector<int64_t>>();
   if (!iterations_to_dump_tmp.empty()) {
     solver_options.trust_region_minimizer_iterations_to_dump.reserve(iterations_to_dump_tmp.size());
@@ -640,14 +647,14 @@ void loadSolverOptionsFromROS(
     "CONSOLE.");
   solver_options.trust_region_problem_dump_directory = fuse_core::getParam(
     interfaces,
-    ns + "trust_region_problem_dump_directory",
+    fuse_core::joinParameterName(ns, "trust_region_problem_dump_directory"),
     solver_options.trust_region_problem_dump_directory,
     tmp_descr
   );
   solver_options.trust_region_problem_dump_format_type =
     fuse_core::declareCeresParam(
     interfaces,
-    ns + "trust_region_problem_dump_format_type",
+    fuse_core::joinParameterName(ns, "trust_region_problem_dump_format_type"),
     solver_options.trust_region_problem_dump_format_type
     );
 
@@ -657,7 +664,7 @@ void loadSolverOptionsFromROS(
     "and analytic gradients differ substantially)");
   solver_options.check_gradients = fuse_core::getParam(
     interfaces,
-    ns + "check_gradients",
+    fuse_core::joinParameterName(ns, "check_gradients"),
     solver_options.check_gradients,
     tmp_descr
   );
@@ -667,7 +674,7 @@ void loadSolverOptionsFromROS(
     "cost term is dumped");
   solver_options.gradient_check_relative_precision = fuse_core::getParam(
     interfaces,
-    ns + "gradient_check_relative_precision",
+    fuse_core::joinParameterName(ns, "gradient_check_relative_precision"),
     solver_options.gradient_check_relative_precision,
     tmp_descr
   );
@@ -676,7 +683,7 @@ void loadSolverOptionsFromROS(
     "Solver::Options::check_gradients is true.");
   solver_options.gradient_check_numeric_derivative_relative_step_size = fuse_core::getParam(
     interfaces,
-    ns + "gradient_check_numeric_derivative_relative_step_size",
+    fuse_core::joinParameterName(ns, "gradient_check_numeric_derivative_relative_step_size"),
     solver_options.gradient_check_numeric_derivative_relative_step_size,
     tmp_descr
   );
@@ -688,7 +695,7 @@ void loadSolverOptionsFromROS(
     "termination");
   solver_options.update_state_every_iteration = fuse_core::getParam(
     interfaces,
-    ns + "update_state_every_iteration",
+    fuse_core::joinParameterName(ns, "update_state_every_iteration"),
     solver_options.update_state_every_iteration,
     tmp_descr
   );

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -59,7 +59,7 @@ struct Acceleration2DParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -67,23 +67,21 @@ struct Acceleration2DParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
+      indices = loadSensorConfig<fuse_variables::AccelerationLinear2DStamped>(interfaces, fuse_core::joinParameterName(ns, "dimensions"));
 
-      indices = loadSensorConfig<fuse_variables::AccelerationLinear2DStamped>(interfaces, ns + "dimensions");
+      disable_checks = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "disable_checks"), disable_checks);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_timeout"), tf_timeout, false);
 
-      disable_checks = fuse_core::getParam(interfaces, ns + "disable_checks", disable_checks);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-      fuse_core::getPositiveParam(interfaces, ns + "tf_timeout", tf_timeout, false);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "throttle_period"), throttle_period, false);
+      throttle_use_wall_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "throttle_use_wall_time"), throttle_use_wall_time);
 
-      fuse_core::getPositiveParam(interfaces, ns + "throttle_period", throttle_period, false);
-      throttle_use_wall_time = fuse_core::getParam(interfaces, ns + "throttle_use_wall_time", throttle_use_wall_time);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "target_frame"), target_frame);
 
-      fuse_core::getParamRequired(interfaces, ns + "topic", topic);
-      fuse_core::getParamRequired(interfaces, ns + "target_frame", target_frame);
-
-      loss = fuse_core::loadLossConfig(interfaces, ns + "loss");
+      loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "loss"));
     }
 
     bool disable_checks { false };

--- a/fuse_models/include/fuse_models/parameters/graph_ignition_params.h
+++ b/fuse_models/include/fuse_models/parameters/graph_ignition_params.h
@@ -55,7 +55,7 @@ public:
    * @brief Method for loading parameter values from ROS.
    *
    * @param[in] interfaces - The node interfaces with which to load parameters
-   * @param[in] namespace_string - The parameter namespace to use
+   * @param[in] ns - The parameter namespace to use
    */
   void loadFromROS(
     fuse_core::node_interfaces::NodeInterfaces<
@@ -63,14 +63,12 @@ public:
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters
     > interfaces,
-    const std::string& namespace_string)
+    const std::string& ns)
   {
-    std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
-    queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-    reset_service = fuse_core::getParam(interfaces, ns + "reset_service", reset_service);
-    set_graph_service = fuse_core::getParam(interfaces, ns + "set_graph_service", set_graph_service);
-    topic = fuse_core::getParam(interfaces, ns + "topic", topic);
+    queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+    reset_service = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "reset_service"), reset_service);
+    set_graph_service = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "set_graph_service"), set_graph_service);
+    topic = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
   }
 
   /**

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -62,7 +62,7 @@ struct Imu2DParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -70,46 +70,44 @@ struct Imu2DParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
       angular_velocity_indices =
-        loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, ns + "angular_velocity_dimensions");
+        loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, fuse_core::joinParameterName(ns, "angular_velocity_dimensions"));
       linear_acceleration_indices =
-        loadSensorConfig<fuse_variables::AccelerationLinear2DStamped>(interfaces, ns + "linear_acceleration_dimensions");
-      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, ns + "orientation_dimensions");
+        loadSensorConfig<fuse_variables::AccelerationLinear2DStamped>(interfaces, fuse_core::joinParameterName(ns, "linear_acceleration_dimensions"));
+      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, fuse_core::joinParameterName(ns, "orientation_dimensions"));
 
-      differential = fuse_core::getParam(interfaces, ns + "differential", differential);
-      disable_checks = fuse_core::getParam(interfaces, ns + "disable_checks", disable_checks);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
+      differential = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "differential"), differential);
+      disable_checks = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "disable_checks"), disable_checks);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
       fuse_core::getPositiveParam(interfaces, "tf_timeout", tf_timeout, false);
 
       fuse_core::getPositiveParam(interfaces, "throttle_period", throttle_period, false);
-      throttle_use_wall_time = fuse_core::getParam(interfaces, ns + "throttle_use_wall_time", throttle_use_wall_time);
+      throttle_use_wall_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "throttle_use_wall_time"), throttle_use_wall_time);
 
-      remove_gravitational_acceleration = fuse_core::getParam(interfaces, ns + "remove_gravitational_acceleration", remove_gravitational_acceleration);
-      gravitational_acceleration = fuse_core::getParam(interfaces, ns + "gravitational_acceleration", gravitational_acceleration);
-      fuse_core::getParamRequired(interfaces, ns + "topic", topic);
+      remove_gravitational_acceleration = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "remove_gravitational_acceleration"), remove_gravitational_acceleration);
+      gravitational_acceleration = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "gravitational_acceleration"), gravitational_acceleration);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
 
       if (differential)
       {
-        independent = fuse_core::getParam(interfaces, ns + "independent", independent);
-        use_twist_covariance = fuse_core::getParam(interfaces, ns + "use_twist_covariance", use_twist_covariance);
+        independent = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "independent"), independent);
+        use_twist_covariance = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "use_twist_covariance"), use_twist_covariance);
 
         minimum_pose_relative_covariance =
-            fuse_core::getCovarianceDiagonalParam<3>(interfaces, ns + "minimum_pose_relative_covariance_diagonal", 0.0);
+            fuse_core::getCovarianceDiagonalParam<3>(interfaces, fuse_core::joinParameterName(ns, "minimum_pose_relative_covariance_diagonal"), 0.0);
         twist_covariance_offset =
-            fuse_core::getCovarianceDiagonalParam<3>(interfaces, ns + "twist_covariance_offset_diagonal", 0.0);
+            fuse_core::getCovarianceDiagonalParam<3>(interfaces, fuse_core::joinParameterName(ns, "twist_covariance_offset_diagonal"), 0.0);
       }
 
-      acceleration_target_frame = fuse_core::getParam(interfaces, ns + "acceleration_target_frame", acceleration_target_frame);
-      orientation_target_frame = fuse_core::getParam(interfaces, ns + "orientation_target_frame", orientation_target_frame);
-      twist_target_frame = fuse_core::getParam(interfaces, ns + "twist_target_frame", twist_target_frame);
+      acceleration_target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "acceleration_target_frame"), acceleration_target_frame);
+      orientation_target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "orientation_target_frame"), orientation_target_frame);
+      twist_target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "twist_target_frame"), twist_target_frame);
 
-      pose_loss = fuse_core::loadLossConfig(interfaces, ns + "pose_loss");
-      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, ns + "angular_velocity_loss");
-      linear_acceleration_loss = fuse_core::loadLossConfig(interfaces, ns + "linear_acceleration_loss");
+      pose_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "pose_loss"));
+      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "angular_velocity_loss"));
+      linear_acceleration_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "linear_acceleration_loss"));
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -63,7 +63,7 @@ struct Odometry2DParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -71,44 +71,42 @@ struct Odometry2DParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
-      position_indices = loadSensorConfig<fuse_variables::Position2DStamped>(interfaces, ns + "position_dimensions");
-      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, ns + "orientation_dimensions");
+      position_indices = loadSensorConfig<fuse_variables::Position2DStamped>(interfaces, fuse_core::joinParameterName(ns, "position_dimensions"));
+      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, fuse_core::joinParameterName(ns, "orientation_dimensions"));
       linear_velocity_indices =
-        loadSensorConfig<fuse_variables::VelocityLinear2DStamped>(interfaces, ns + "linear_velocity_dimensions");
+        loadSensorConfig<fuse_variables::VelocityLinear2DStamped>(interfaces, fuse_core::joinParameterName(ns, "linear_velocity_dimensions"));
       angular_velocity_indices =
-        loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, ns + "angular_velocity_dimensions");
+        loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, fuse_core::joinParameterName(ns, "angular_velocity_dimensions"));
 
-      differential = fuse_core::getParam(interfaces, ns + "differential", differential);
-      disable_checks = fuse_core::getParam(interfaces, ns + "disable_checks", disable_checks);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-      fuse_core::getPositiveParam(interfaces, ns + "tf_timeout", tf_timeout, false);
+      differential = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "differential"), differential);
+      disable_checks = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "disable_checks"), disable_checks);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_timeout"), tf_timeout, false);
 
-      fuse_core::getPositiveParam(interfaces, ns + "throttle_period", throttle_period, false);
-      throttle_use_wall_time = fuse_core::getParam(interfaces, ns + "throttle_use_wall_time", throttle_use_wall_time);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "throttle_period"), throttle_period, false);
+      throttle_use_wall_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "throttle_use_wall_time"), throttle_use_wall_time);
 
-      fuse_core::getParamRequired(interfaces, ns + "topic", topic);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
 
-      twist_target_frame = fuse_core::getParam(interfaces, ns + "twist_target_frame", twist_target_frame);
-      pose_target_frame = fuse_core::getParam(interfaces, ns + "pose_target_frame", pose_target_frame);
+      twist_target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "twist_target_frame"), twist_target_frame);
+      pose_target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "pose_target_frame"), pose_target_frame);
 
       if (differential)
       {
-        independent = fuse_core::getParam(interfaces, ns + "independent", independent);
-        use_twist_covariance = fuse_core::getParam(interfaces, ns + "use_twist_covariance", use_twist_covariance);
+        independent = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "independent"), independent);
+        use_twist_covariance = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "use_twist_covariance"), use_twist_covariance);
 
         minimum_pose_relative_covariance =
-            fuse_core::getCovarianceDiagonalParam<3>(interfaces, ns + "minimum_pose_relative_covariance_diagonal", 0.0);
+            fuse_core::getCovarianceDiagonalParam<3>(interfaces, fuse_core::joinParameterName(ns, "minimum_pose_relative_covariance_diagonal"), 0.0);
         twist_covariance_offset =
-            fuse_core::getCovarianceDiagonalParam<3>(interfaces, ns + "twist_covariance_offset_diagonal", 0.0);
+            fuse_core::getCovarianceDiagonalParam<3>(interfaces, fuse_core::joinParameterName(ns, "twist_covariance_offset_diagonal"), 0.0);
       }
 
-      pose_loss = fuse_core::loadLossConfig(interfaces, ns + "pose_loss");
-      linear_velocity_loss = fuse_core::loadLossConfig(interfaces, ns + "linear_velocity_loss");
-      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, ns + "angular_velocity_loss");
+      pose_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "pose_loss"));
+      linear_velocity_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "linear_velocity_loss"));
+      angular_velocity_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "angular_velocity_loss"));
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -68,7 +68,7 @@ public:
    * @brief Method for loading parameter values from ROS.
    *
    * @param[in] interfaces - The node interfaces with which to load parameters
-   * @param[in] namespace_string - The parameter namespace to use
+   * @param[in] ns - The parameter namespace to use
    */
   void loadFromROS(
     fuse_core::node_interfaces::NodeInterfaces<
@@ -76,32 +76,30 @@ public:
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters
     > interfaces,
-    const std::string& namespace_string)
+    const std::string& ns)
   {
-    std::string ns = get_well_formatted_param_namespace_string(namespace_string);
+    publish_tf = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "publish_tf"), publish_tf);
+    invert_tf = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "invert_tf"), invert_tf);
+    predict_to_current_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "predict_to_current_time"), predict_to_current_time);
+    predict_with_acceleration = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "predict_with_acceleration"), predict_with_acceleration);
+    publish_frequency = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "publish_frequency"), publish_frequency);
 
-    publish_tf = fuse_core::getParam(interfaces, ns + "publish_tf", publish_tf);
-    invert_tf = fuse_core::getParam(interfaces, ns + "invert_tf", invert_tf);
-    predict_to_current_time = fuse_core::getParam(interfaces, ns + "predict_to_current_time", predict_to_current_time);
-    predict_with_acceleration = fuse_core::getParam(interfaces, ns + "predict_with_acceleration", predict_with_acceleration);
-    publish_frequency = fuse_core::getParam(interfaces, ns + "publish_frequency", publish_frequency);
+    process_noise_covariance = fuse_core::getCovarianceDiagonalParam<8>(interfaces, fuse_core::joinParameterName(ns, "process_noise_diagonal"), 0.0);
+    scale_process_noise = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "scale_process_noise"), scale_process_noise);
+    velocity_norm_min = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "velocity_norm_min"), velocity_norm_min);
 
-    process_noise_covariance = fuse_core::getCovarianceDiagonalParam<8>(interfaces, ns + "process_noise_diagonal", 0.0);
-    scale_process_noise = fuse_core::getParam(interfaces, ns + "scale_process_noise", scale_process_noise);
-    velocity_norm_min = fuse_core::getParam(interfaces, ns + "velocity_norm_min", velocity_norm_min);
+    fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "covariance_throttle_period"), covariance_throttle_period, false);
 
-    fuse_core::getPositiveParam(interfaces, ns + "covariance_throttle_period", covariance_throttle_period, false);
+    fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_cache_time"), tf_cache_time, false);
+    fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_timeout"), tf_timeout, false);
 
-    fuse_core::getPositiveParam(interfaces, ns + "tf_cache_time", tf_cache_time, false);
-    fuse_core::getPositiveParam(interfaces, ns + "tf_timeout", tf_timeout, false);
+    queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
 
-    queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-
-    map_frame_id = fuse_core::getParam(interfaces, ns + "map_frame_id", map_frame_id);
-    odom_frame_id = fuse_core::getParam(interfaces, ns + "odom_frame_id", odom_frame_id);
-    base_link_frame_id = fuse_core::getParam(interfaces, ns + "base_link_frame_id", base_link_frame_id);
-    base_link_output_frame_id = fuse_core::getParam(interfaces, ns + "base_link_output_frame_id", base_link_output_frame_id);
-    world_frame_id = fuse_core::getParam(interfaces, ns + "world_frame_id", world_frame_id);
+    map_frame_id = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "map_frame_id"), map_frame_id);
+    odom_frame_id = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "odom_frame_id"), odom_frame_id);
+    base_link_frame_id = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "base_link_frame_id"), base_link_frame_id);
+    base_link_output_frame_id = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "base_link_output_frame_id"), base_link_output_frame_id);
+    world_frame_id = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "world_frame_id"), world_frame_id);
 
     const bool frames_valid =
       map_frame_id != odom_frame_id &&
@@ -122,8 +120,8 @@ public:
       assert(frames_valid);
     }
 
-    topic = fuse_core::getParam(interfaces, ns + "topic", topic);
-    acceleration_topic = fuse_core::getParam(interfaces, ns + "acceleration_topic", acceleration_topic);
+    topic = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
+    acceleration_topic = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "acceleration_topic"), acceleration_topic);
 
     fuse_core::loadCovarianceOptionsFromROS(interfaces, covariance_options, "covariance_options");
   }

--- a/fuse_models/include/fuse_models/parameters/parameter_base.h
+++ b/fuse_models/include/fuse_models/parameters/parameter_base.h
@@ -57,7 +57,7 @@ struct ParameterBase
    * @brief Method for loading parameter values from ROS.
    *
    * @param[in] interfaces - The node interfaces with which to load parameters
-   * @param[in] namespace_string - The parameter namespace to use
+   * @param[in] ns - The parameter namespace to use
    */
   virtual void loadFromROS(
     fuse_core::node_interfaces::NodeInterfaces<
@@ -65,14 +65,8 @@ struct ParameterBase
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters
     > interfaces,
-    const std::string& namespace_string) = 0;
+    const std::string& ns) = 0;
 };
-
-// Helper function to get a namespace string with a '.' suffix, but only if not empty
-inline std::string get_well_formatted_param_namespace_string(std::string ns)
-{
-  return ns.empty() || ns.back() == '.' ? ns : ns + ".";
-}
 
 /**
  * @brief Utility method to load a sensor configuration, i.e. the dimension indices

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -61,7 +61,7 @@ struct Pose2DParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -69,36 +69,34 @@ struct Pose2DParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
+      position_indices = loadSensorConfig<fuse_variables::Position2DStamped>(interfaces, fuse_core::joinParameterName(ns, "position_dimensions"));
+      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, fuse_core::joinParameterName(ns, "orientation_dimensions"));
 
-      position_indices = loadSensorConfig<fuse_variables::Position2DStamped>(interfaces, ns + "position_dimensions");
-      orientation_indices = loadSensorConfig<fuse_variables::Orientation2DStamped>(interfaces, ns + "orientation_dimensions");
+      differential = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "differential"), differential);
+      disable_checks = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "disable_checks"), disable_checks);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_timeout"), tf_timeout, false);
 
-      differential = fuse_core::getParam(interfaces, ns + "differential", differential);
-      disable_checks = fuse_core::getParam(interfaces, ns + "disable_checks", disable_checks);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-      fuse_core::getPositiveParam(interfaces, ns + "tf_timeout", tf_timeout, false);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "throttle_period"), throttle_period, false);
+      throttle_use_wall_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "throttle_use_wall_time"), throttle_use_wall_time);
 
-      fuse_core::getPositiveParam(interfaces, ns + "throttle_period", throttle_period, false);
-      throttle_use_wall_time = fuse_core::getParam(interfaces, ns + "throttle_use_wall_time", throttle_use_wall_time);
-
-      fuse_core::getParamRequired(interfaces, ns + "topic", topic);
-      target_frame = fuse_core::getParam(interfaces, ns + "target_frame", target_frame);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
+      target_frame = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "target_frame"), target_frame);
 
       if (differential)
       {
-        independent = fuse_core::getParam(interfaces, ns + "independent", independent);
+        independent = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "independent"), independent);
 
         if (!independent)
         {
           minimum_pose_relative_covariance =
-              fuse_core::getCovarianceDiagonalParam<3>(interfaces, ns + "minimum_pose_relative_covariance_diagonal", 0.0);
+              fuse_core::getCovarianceDiagonalParam<3>(interfaces, fuse_core::joinParameterName(ns, "minimum_pose_relative_covariance_diagonal"), 0.0);
         }
       }
 
-      loss = fuse_core::loadLossConfig(interfaces, ns + "loss");
+      loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "loss"));
     }
 
     bool differential { false };

--- a/fuse_models/include/fuse_models/parameters/transaction_params.h
+++ b/fuse_models/include/fuse_models/parameters/transaction_params.h
@@ -57,7 +57,7 @@ public:
    * @brief Method for loading parameter values from ROS.
    *
    * @param[in] interfaces - The node interfaces with which to load parameters
-   * @param[in] namespace_string - The parameter namespace to use
+   * @param[in] ns - The parameter namespace to use
    */
   void loadFromROS(
     fuse_core::node_interfaces::NodeInterfaces<
@@ -65,12 +65,10 @@ public:
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters
     > interfaces,
-    const std::string& namespace_string)
+    const std::string& ns)
   {
-    std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
-    queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-    fuse_core::getParamRequired(interfaces, ns + "topic", topic);
+    queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+    fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
   }
 
   int queue_size{ 10 };

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -61,7 +61,7 @@ struct Twist2DParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -69,25 +69,23 @@ struct Twist2DParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
+      linear_indices = loadSensorConfig<fuse_variables::VelocityLinear2DStamped>(interfaces, fuse_core::joinParameterName(ns, "linear_dimensions"));
+      angular_indices = loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, fuse_core::joinParameterName(ns, "angular_dimensions"));
 
-      linear_indices = loadSensorConfig<fuse_variables::VelocityLinear2DStamped>(interfaces, ns + "linear_dimensions");
-      angular_indices = loadSensorConfig<fuse_variables::VelocityAngular2DStamped>(interfaces, ns + "angular_dimensions");
+      disable_checks = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "disable_checks"), disable_checks);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "tf_timeout"), tf_timeout, false);
 
-      disable_checks = fuse_core::getParam(interfaces, ns + "disable_checks", disable_checks);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-      fuse_core::getPositiveParam(interfaces, ns + "tf_timeout", tf_timeout, false);
+      fuse_core::getPositiveParam(interfaces, fuse_core::joinParameterName(ns, "throttle_period"), throttle_period, false);
+      throttle_use_wall_time = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "throttle_use_wall_time"), throttle_use_wall_time);
 
-      fuse_core::getPositiveParam(interfaces, ns + "throttle_period", throttle_period, false);
-      throttle_use_wall_time = fuse_core::getParam(interfaces, ns + "throttle_use_wall_time", throttle_use_wall_time);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
+      fuse_core::getParamRequired(interfaces, fuse_core::joinParameterName(ns, "target_frame"), target_frame);
 
-      fuse_core::getParamRequired(interfaces, ns + "topic", topic);
-      fuse_core::getParamRequired(interfaces, ns + "target_frame", target_frame);
-
-      linear_loss = fuse_core::loadLossConfig(interfaces, ns + "linear_loss");
-      angular_loss = fuse_core::loadLossConfig(interfaces, ns + "angular_loss");
+      linear_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "linear_loss"));
+      angular_loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "angular_loss"));
     }
 
     bool disable_checks { false };

--- a/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
+++ b/fuse_models/include/fuse_models/parameters/unicycle_2d_ignition_params.h
@@ -61,7 +61,7 @@ struct Unicycle2DIgnitionParams : public ParameterBase
      * @brief Method for loading parameter values from ROS.
      *
      * @param[in] interfaces - The node interfaces with which to load parameters
-     * @param[in] namespace_string - The parameter namespace to use
+     * @param[in] ns - The parameter namespace to use
      */
     void loadFromROS(
       fuse_core::node_interfaces::NodeInterfaces<
@@ -69,19 +69,17 @@ struct Unicycle2DIgnitionParams : public ParameterBase
         fuse_core::node_interfaces::Logging,
         fuse_core::node_interfaces::Parameters
       > interfaces,
-      const std::string& namespace_string)
+      const std::string& ns)
     {
-      std::string ns = get_well_formatted_param_namespace_string(namespace_string);
-
-      publish_on_startup = fuse_core::getParam(interfaces, ns + "publish_on_startup", publish_on_startup);
-      queue_size = fuse_core::getParam(interfaces, ns + "queue_size", queue_size);
-      reset_service = fuse_core::getParam(interfaces, ns + "reset_service", reset_service);
-      set_pose_service = fuse_core::getParam(interfaces, ns + "set_pose_service", set_pose_service);
-      set_pose_deprecated_service = fuse_core::getParam(interfaces, ns + "set_pose_deprecated_service", set_pose_deprecated_service);
-      topic = fuse_core::getParam(interfaces, ns + "topic", topic);
+      publish_on_startup = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "publish_on_startup"), publish_on_startup);
+      queue_size = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "queue_size"), queue_size);
+      reset_service = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "reset_service"), reset_service);
+      set_pose_service = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "set_pose_service"), set_pose_service);
+      set_pose_deprecated_service = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "set_pose_deprecated_service"), set_pose_deprecated_service);
+      topic = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "topic"), topic);
 
       std::vector<double> sigma_vector;
-      sigma_vector = fuse_core::getParam(interfaces, ns + "initial_sigma", sigma_vector);
+      sigma_vector = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "initial_sigma"), sigma_vector);
       if (!sigma_vector.empty())
       {
         if (sigma_vector.size() != 8)
@@ -103,7 +101,7 @@ struct Unicycle2DIgnitionParams : public ParameterBase
       }
 
       std::vector<double> state_vector;
-      state_vector = fuse_core::getParam(interfaces, ns + "initial_state", state_vector);
+      state_vector = fuse_core::getParam(interfaces, fuse_core::joinParameterName(ns, "initial_state"), state_vector);
       if (!state_vector.empty())
       {
         if (state_vector.size() != 8)
@@ -123,7 +121,7 @@ struct Unicycle2DIgnitionParams : public ParameterBase
         initial_state.swap(state_vector);
       }
 
-      loss = fuse_core::loadLossConfig(interfaces, ns + "loss");
+      loss = fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "loss"));
     }
 
 

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -208,10 +208,8 @@ void Unicycle2D::onInit()
   logger_ = interfaces_.get_node_logging_interface()->get_logger();
   clock_ = interfaces_.get_node_clock_interface()->get_clock();
 
-  std::string ns = fuse_models::parameters::get_well_formatted_param_namespace_string(name_);
-
   std::vector<double> process_noise_diagonal;
-  process_noise_diagonal = fuse_core::getParam(interfaces_, ns + "process_noise_diagonal", process_noise_diagonal);
+  process_noise_diagonal = fuse_core::getParam(interfaces_, fuse_core::joinParameterName(name_, "process_noise_diagonal"), process_noise_diagonal);
 
   if (process_noise_diagonal.size() != 8)
   {
@@ -220,13 +218,13 @@ void Unicycle2D::onInit()
 
   process_noise_covariance_ = fuse_core::Vector8d(process_noise_diagonal.data()).asDiagonal();
 
-  scale_process_noise_ = fuse_core::getParam(interfaces_, ns + "scale_process_noise", scale_process_noise_);
-  velocity_norm_min_ = fuse_core::getParam(interfaces_, ns + "velocity_norm_min", velocity_norm_min_);
+  scale_process_noise_ = fuse_core::getParam(interfaces_, fuse_core::joinParameterName(name_, "scale_process_noise"), scale_process_noise_);
+  velocity_norm_min_ = fuse_core::getParam(interfaces_, fuse_core::joinParameterName(name_, "velocity_norm_min"), velocity_norm_min_);
 
-  disable_checks_ = fuse_core::getParam(interfaces_, ns + "disable_checks", disable_checks_);
+  disable_checks_ = fuse_core::getParam(interfaces_, fuse_core::joinParameterName(name_, "disable_checks"), disable_checks_);
 
   double buffer_length = 3.0;
-  buffer_length = fuse_core::getParam(interfaces_, ns + "buffer_length", buffer_length);
+  buffer_length = fuse_core::getParam(interfaces_, fuse_core::joinParameterName(name_, "buffer_length"), buffer_length);
 
   if (buffer_length < 0.0)
   {

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -77,16 +77,19 @@ void Path2DPublisher::onInit()
 {
   // Configure the publisher
   std::string device_str;
-  device_str = fuse_core::getParam(interfaces_, "device_id", device_str);
+  device_str = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "device_id"), device_str);
   if (device_str != "") {
     device_id_ = fuse_core::uuid::from_string(device_str);
   } else {
-    device_str = fuse_core::getParam(interfaces_, "device_name", device_str);
+    device_str = fuse_core::getParam(
+      interfaces_, fuse_core::joinParameterName(name_, "device_name"), device_str);
     if (device_str != "") {
       device_id_ = fuse_core::uuid::generate(device_str);
     }
   }
-  frame_id_ = fuse_core::getParam(interfaces_, "frame_id", frame_id_);
+  frame_id_ = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "frame_id"), frame_id_);
 
   // Advertise the topic
   rclcpp::PublisherOptions pub_options;

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -129,21 +129,27 @@ void Pose2DPublisher::onInit()
   tf_publisher_ = std::make_shared<tf2_ros::TransformBroadcaster>(interfaces_);
 
   // Read configuration from the parameter server
-  base_frame_ = fuse_core::getParam(interfaces_, "base_frame", std::string("base_link"));
-  map_frame_ = fuse_core::getParam(interfaces_, "map_frame", std::string("map"));
-  odom_frame_ = fuse_core::getParam(interfaces_, "odom_frame", std::string("odom"));
+  base_frame_ = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "base_frame"), std::string("base_link"));
+  map_frame_ = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "map_frame"), std::string("map"));
+  odom_frame_ = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "odom_frame"), std::string("odom"));
 
   std::string device_str;
-  device_str = fuse_core::getParam(interfaces_, "device_id", device_str);
+  device_str = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "device_id"), device_str);
   if (device_str != "") {
     device_id_ = fuse_core::uuid::from_string(device_str);
   } else {
-    device_str = fuse_core::getParam(interfaces_, "device_name", device_str);
+    device_str = fuse_core::getParam(
+      interfaces_, fuse_core::joinParameterName(name_, "device_name"), device_str);
     if (device_str != "") {
       device_id_ = fuse_core::uuid::generate(device_str);
     }
   }
-  publish_to_tf_ = fuse_core::getParam(interfaces_, "publish_to_tf", false);
+  publish_to_tf_ = fuse_core::getParam(
+    interfaces_, fuse_core::joinParameterName(name_, "publish_to_tf"), false);
 
   // Configure tf, if requested
   if (publish_to_tf_) {
@@ -151,7 +157,8 @@ void Pose2DPublisher::onInit()
     if (use_tf_lookup_) {
       double tf_cache_time;
       double default_tf_cache_time = 10.0;
-      tf_cache_time = fuse_core::getParam(interfaces_, "tf_cache_time", default_tf_cache_time);
+      tf_cache_time = fuse_core::getParam(
+        interfaces_, fuse_core::joinParameterName(name_, "tf_cache_time"), default_tf_cache_time);
       if (tf_cache_time <= 0) {
         RCLCPP_WARN_STREAM(
           logger_,
@@ -162,7 +169,8 @@ void Pose2DPublisher::onInit()
 
       double tf_timeout;
       double default_tf_timeout = 0.1;
-      tf_timeout = fuse_core::getParam(interfaces_, "tf_timeout", default_tf_timeout);
+      tf_timeout = fuse_core::getParam(
+        interfaces_, fuse_core::joinParameterName(name_, "tf_timeout"), default_tf_timeout);
       if (tf_timeout <= 0) {
         RCLCPP_WARN_STREAM(
           logger_,
@@ -214,7 +222,7 @@ void Pose2DPublisher::onStart()
     // We pull the param again on each start so the publisher can technically get set to a different
     // publish frequency
     tf_publish_frequency = fuse_core::getParam(
-      interfaces_, "tf_publish_frequency",
+      interfaces_, fuse_core::joinParameterName(name_, "tf_publish_frequency"),
       default_tf_publish_frequency);
     if (tf_publish_frequency <= 0) {
       RCLCPP_WARN_STREAM(

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -85,11 +85,10 @@ void SerializedPublisher::onInit()
     graph_throttle_period, false);
 
   bool graph_throttle_use_wall_time{false};
-  graph_throttle_use_wall_time =
-    fuse_core::getParam(
-      interfaces_,
-      fuse_core::joinParameterName(name_, "graph_throttle_use_wall_time"),
-      graph_throttle_use_wall_time);
+  graph_throttle_use_wall_time = fuse_core::getParam(
+    interfaces_,
+    fuse_core::joinParameterName(name_, "graph_throttle_use_wall_time"),
+    graph_throttle_use_wall_time);
 
   graph_publisher_throttled_callback_.setThrottlePeriod(graph_throttle_period);
 

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -213,7 +213,7 @@ TEST_F(Path2DPublisherTestFixture, PublishPath)
   options.arguments(
   {
     "--ros-args",
-    "-p", "frame_id:=test_map"});
+    "-p", "test_publisher.frame_id:=test_map"});
   auto node = rclcpp::Node::make_shared("test_path_2d_publisher_node", options);
   executor_->add_node(node);
 

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -228,10 +228,10 @@ TEST_F(Pose2DPublisherTestFixture, PublishPose)
   options.arguments(
   {
     "--ros-args",
-    "-p", "map_frame:=test_map",
-    "-p", "odom_frame:=test_odom",
-    "-p", "base_frame:=test_base",
-    "-p", "publish_to_tf:=false"});
+    "-p", "test_publisher.map_frame:=test_map",
+    "-p", "test_publisher.odom_frame:=test_odom",
+    "-p", "test_publisher.base_frame:=test_base",
+    "-p", "test_publisher.publish_to_tf:=false"});
   auto node = rclcpp::Node::make_shared("test_pose_2d_publisher_node", options);
   executor_->add_node(node);
 
@@ -270,10 +270,10 @@ TEST_F(Pose2DPublisherTestFixture, PublishPoseWithCovariance)
   options.arguments(
   {
     "--ros-args",
-    "-p", "map_frame:=test_map",
-    "-p", "odom_frame:=test_odom",
-    "-p", "base_frame:=test_base",
-    "-p", "publish_to_tf:=false"});
+    "-p", "test_publisher.map_frame:=test_map",
+    "-p", "test_publisher.odom_frame:=test_odom",
+    "-p", "test_publisher.base_frame:=test_base",
+    "-p", "test_publisher.publish_to_tf:=false"});
   auto node = rclcpp::Node::make_shared("test_pose_2d_publisher_node", options);
   executor_->add_node(node);
 
@@ -328,10 +328,10 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithoutOdom)
   options.arguments(
   {
     "--ros-args",
-    "-p", "map_frame:=test_map",
-    "-p", "odom_frame:=test_base",
-    "-p", "base_frame:=test_base",
-    "-p", "publish_to_tf:=true"});
+    "-p", "test_publisher.map_frame:=test_map",
+    "-p", "test_publisher.odom_frame:=test_base",
+    "-p", "test_publisher.base_frame:=test_base",
+    "-p", "test_publisher.publish_to_tf:=true"});
   auto node = rclcpp::Node::make_shared("test_pose_2d_publisher_node", options);
   executor_->add_node(node);
 
@@ -376,10 +376,10 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithOdom)
   options.arguments(
   {
     "--ros-args",
-    "-p", "map_frame:=test_map",
-    "-p", "odom_frame:=test_odom",
-    "-p", "base_frame:=test_base",
-    "-p", "publish_to_tf:=true"});
+    "-p", "test_publisher.map_frame:=test_map",
+    "-p", "test_publisher.odom_frame:=test_odom",
+    "-p", "test_publisher.base_frame:=test_base",
+    "-p", "test_publisher.publish_to_tf:=true"});
   auto node = rclcpp::Node::make_shared("test_pose_2d_publisher_node", options);
   executor_->add_node(node);
 


### PR DESCRIPTION
Part of #276

With the merge of #311, a new method was introduced to join parameter names together.

Also, it surfaced an inconsistency in how the publishers in fuse_publishers read their parameters. So I brought them in-line with the way SerializedPublisher was doing it following #311

In the ROS 1 code, private node handles were used to load the parameters, so by right they should be namespaced. This PR fixes that issue.

Pinging @svwilliams for visibility.