### PR TITLE
Fix rviz dependency

### DIFF
--- a/fuse_tutorials/package.xml
+++ b/fuse_tutorials/package.xml
@@ -31,7 +31,7 @@
   <exec_depend>fuse_variables</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rviz</exec_depend>
+  <exec_depend>rviz2</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
`bloom` was unhappy because it couldn't find the `rviz` dependency. The package is now called `rviz2`:

https://github.com/ros/rosdistro/blob/ead725a32836272f66d80d96efb587fa63374511/rolling/distribution.yaml#L5386