### PR TITLE
Print graph & transaction on optimization failure

### DIFF
--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -223,19 +223,25 @@ void FixedLagSmoother::optimizationLoop()
       // Optimize the entire graph
       summary_ = graph_->optimize(params_.solver_options);
 
-      // Optimization is complete. Notify all the things about the graph changes.
-      const auto new_transaction_stamp = new_transaction->stamp();
-      notify(std::move(new_transaction), graph_->clone());
-
       // Abort if optimization failed. Not converging is not a failure because the solution found is usable.
       if (!summary_.IsSolutionUsable())
       {
+        std::ostringstream oss;
+        oss << "Graph:\n";
+        graph_->print(oss);
+        oss << "\nTransaction:\n";
+        new_transaction->print(oss);
+
         ROS_FATAL_STREAM("Optimization failed after updating the graph with the transaction with timestamp "
-                         << new_transaction_stamp << ". Leaving optimization loop and requesting node shutdown...");
+                         << new_transaction->stamp() << ". Leaving optimization loop and requesting node shutdown...\n"
+                         << oss.str());
         ROS_INFO_STREAM(summary_.FullReport());
         ros::requestShutdown();
         break;
       }
+
+      // Optimization is complete and succeeded. Notify all the things about the graph changes.
+      notify(std::move(new_transaction), graph_->clone());
 
       // Compute a transaction that marginalizes out those variables.
       lag_expiration_ = computeLagExpirationTime();


### PR DESCRIPTION
### Context

I got into an issue where the optimization failed. I've not been able to find the root cause. If it happens again, the graph and transaction at the time of failure would be extremely useful.

### Motivation

Note that when the optimization fails we shutdown the node, so even if we notify the fuse publishers, there's no guarantee they have time to actually publish the graph and transaction. Even in that case, I usually throttle the graph publication because it has a significant overhead. I can re-create the graphs later, using the transactions, but that's a bit tedious. If we get the graph and transaction printed right away in the FATAL log message, I hope we can easily figure out the root cause, which I believe it's related to the transaction callback logic and a corner case with the transactions timestamps that we're stilling failing to handle properly.