### PR TITLE
Update devel to build on Ubuntu Jammy (22.04)

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -135,7 +135,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -161,7 +161,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_orientation_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -187,7 +187,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_orientation_3d_stamped_euler_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -211,7 +211,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_pose_2d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -235,7 +235,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_pose_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -257,7 +257,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_marginal_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -280,7 +280,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_marginalize_variables
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -304,7 +304,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_normal_delta_pose_2d
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -328,7 +328,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_normal_prior_pose_2d
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -352,7 +352,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -376,7 +376,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_pose_2d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -400,7 +400,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_pose_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -419,7 +419,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_uuid_ordering
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -436,7 +436,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable_constraints
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -458,7 +458,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_normal_delta_pose_2d
         PROPERTIES
-          CXX_STANDARD 14
+          CXX_STANDARD 17
           CXX_STANDARD_REQUIRED YES
       )
     endif()
@@ -477,7 +477,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_normal_prior_pose_2d
         PROPERTIES
-          CXX_STANDARD 14
+          CXX_STANDARD 17
           CXX_STANDARD_REQUIRED YES
       )
     endif()

--- a/fuse_constraints/src/absolute_constraint.cpp
+++ b/fuse_constraints/src/absolute_constraint.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_constraints/absolute_constraint.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/absolute_orientation_3d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_prior_orientation_3d_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/src/absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/absolute_orientation_3d_stamped_euler_constraint.h>
 
 #include <fuse_constraints/normal_prior_orientation_3d_euler_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_2d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_prior_pose_2d.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/absolute_pose_3d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/absolute_pose_3d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_prior_pose_3d_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -35,7 +35,7 @@
 
 #include <fuse_constraints/marginal_cost_function.h>
 #include <fuse_core/constraint.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <Eigen/Core>

--- a/fuse_constraints/src/relative_constraint.cpp
+++ b/fuse_constraints/src/relative_constraint.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_constraints/relative_constraint.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/relative_orientation_3d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_delta_orientation_3d_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_2d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/relative_pose_2d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_delta_pose_2d.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/src/relative_pose_3d_stamped_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_constraints/relative_pose_3d_stamped_constraint.h>
 
 #include <fuse_constraints/normal_delta_pose_3d_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -94,7 +94,7 @@ target_link_libraries(fuse_echo
 )
 set_target_properties(fuse_echo
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -154,7 +154,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_motion_model
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -180,7 +180,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_publisher
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -206,7 +206,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_sensor_model
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -231,7 +231,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_callback_wrapper
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -256,7 +256,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_constraint
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -281,7 +281,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_eigen
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -298,7 +298,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_local_parameterization
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -323,7 +323,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_loss
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -347,7 +347,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_message_buffer
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -372,7 +372,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_timestamp_manager
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -398,7 +398,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_transaction
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -423,7 +423,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_parameter
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -439,7 +439,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_throttled_callback
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -463,7 +463,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_util
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -488,7 +488,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_uuid
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -513,7 +513,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_core/include/fuse_core/graph_deserializer.h
+++ b/fuse_core/include/fuse_core/graph_deserializer.h
@@ -38,7 +38,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/variable.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 
 namespace fuse_core

--- a/fuse_core/include/fuse_core/loss_loader.h
+++ b/fuse_core/include/fuse_core/loss_loader.h
@@ -35,7 +35,7 @@
 #define FUSE_CORE_LOSS_LOADER_H
 
 #include <fuse_core/loss.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <string>
 

--- a/fuse_core/include/fuse_core/transaction_deserializer.h
+++ b/fuse_core/include/fuse_core/transaction_deserializer.h
@@ -38,7 +38,7 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 
 namespace fuse_core

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -109,7 +109,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_hash_graph
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -135,7 +135,7 @@ if(CATKIN_ENABLE_TESTING)
     )
     set_target_properties(benchmark_create_problem
       PROPERTIES
-        CXX_STANDARD 14
+        CXX_STANDARD 17
         CXX_STANDARD_REQUIRED YES
     )
   endif()

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -34,7 +34,7 @@
 #include <fuse_graphs/hash_graph.h>
 
 #include <fuse_core/uuid.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -123,7 +123,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_loss_function
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -147,7 +147,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_composed_loss
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -171,7 +171,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_huber_loss
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -195,7 +195,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_tukey_loss
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -227,7 +227,7 @@ if(CATKIN_ENABLE_TESTING)
     )
     set_target_properties(test_qwt_loss_plot
       PROPERTIES
-        CXX_STANDARD 14
+        CXX_STANDARD 17
         CXX_STANDARD_REQUIRED YES
     )
 
@@ -257,7 +257,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_scaled_loss
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_loss/src/arctan_loss.cpp
+++ b/fuse_loss/src/arctan_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/arctan_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/cauchy_loss.cpp
+++ b/fuse_loss/src/cauchy_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/cauchy_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/composed_loss.cpp
+++ b/fuse_loss/src/composed_loss.cpp
@@ -35,7 +35,7 @@
 #include <fuse_loss/trivial_loss.h>
 
 #include <fuse_core/parameter.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/dcs_loss.cpp
+++ b/fuse_loss/src/dcs_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/dcs_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/fair_loss.cpp
+++ b/fuse_loss/src/fair_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/fair_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/geman_mcclure_loss.cpp
+++ b/fuse_loss/src/geman_mcclure_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/geman_mcclure_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/huber_loss.cpp
+++ b/fuse_loss/src/huber_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/huber_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/scaled_loss.cpp
+++ b/fuse_loss/src/scaled_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/scaled_loss.h>
 
 #include <fuse_core/parameter.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/softlone_loss.cpp
+++ b/fuse_loss/src/softlone_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/softlone_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/tolerant_loss.cpp
+++ b/fuse_loss/src/tolerant_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/tolerant_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/trivial_loss.cpp
+++ b/fuse_loss/src/trivial_loss.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_loss/trivial_loss.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/tukey_loss.cpp
+++ b/fuse_loss/src/tukey_loss.cpp
@@ -35,7 +35,7 @@
 
 #include <fuse_core/ceres_macros.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_loss/src/welsch_loss.cpp
+++ b/fuse_loss/src/welsch_loss.cpp
@@ -34,7 +34,7 @@
 #include <fuse_loss/welsch_loss.h>
 #include <fuse_loss/loss_function.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/node_handle.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -113,7 +113,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -164,7 +164,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -180,7 +180,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_predict
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -197,7 +197,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_state_cost_function
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -223,7 +223,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_graph_ignition
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -239,7 +239,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_ignition
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -254,7 +254,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_sensor_proc
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -275,7 +275,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_unicycle_2d_state_cost_function
         PROPERTIES
-          CXX_STANDARD 14
+          CXX_STANDARD 17
           CXX_STANDARD_REQUIRED YES
       )
     endif()

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -38,7 +38,7 @@
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/AccelWithCovarianceStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 

--- a/fuse_models/src/graph_ignition.cpp
+++ b/fuse_models/src/graph_ignition.cpp
@@ -36,7 +36,7 @@
 
 #include <std_srvs/Empty.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/empty.hpp>

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -40,7 +40,7 @@
 #include <geometry_msgs/AccelWithCovarianceStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -40,7 +40,7 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 #include <memory>

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -41,7 +41,7 @@
 
 #include <geometry_msgs/AccelWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf2_2d/tf2_2d.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/buffer.h>

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -38,7 +38,7 @@
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 #include <memory>

--- a/fuse_models/src/transaction.cpp
+++ b/fuse_models/src/transaction.cpp
@@ -34,7 +34,7 @@
 
 #include <fuse_models/transaction.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 // Register this sensor model with ROS as a plugin.

--- a/fuse_models/src/twist_2d.cpp
+++ b/fuse_models/src/twist_2d.cpp
@@ -38,7 +38,7 @@
 #include <fuse_core/uuid.h>
 
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -48,7 +48,7 @@
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <tf2/utils.h>
 

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -50,7 +50,7 @@
 #include <fuse_variables/stamped.h>
 
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <std_srvs/Empty.h>
 #include <tf2/convert.h>
 #include <tf2/LinearMath/Quaternion.h>

--- a/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
+++ b/fuse_models/src/unicycle_2d_state_kinematic_constraint.cpp
@@ -39,7 +39,7 @@
 #include <fuse_variables/position_2d_stamped.h>
 #include <fuse_variables/velocity_angular_2d_stamped.h>
 #include <fuse_variables/velocity_linear_2d_stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <Eigen/Dense>

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -72,7 +72,7 @@ target_link_libraries(batch_optimizer_node
 )
 set_target_properties(batch_optimizer_node
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -94,7 +94,7 @@ target_link_libraries(fixed_lag_smoother_node
 )
 set_target_properties(fixed_lag_smoother_node
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -153,7 +153,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable_stamp_index
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -177,7 +177,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_optimizer
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -209,7 +209,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_fixed_lag_ignition
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_optimizers/include/fuse_optimizers/optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/optimizer.h
@@ -41,7 +41,7 @@
 #include <fuse_core/publisher.h>
 #include <fuse_core/sensor_model.h>
 #include <fuse_core/transaction.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/ros.h>
 
 #include <string>

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -114,7 +114,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_path_2d_publisher
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -137,7 +137,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_pose_2d_publisher
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -158,7 +158,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_stamped_variable_synchronizer
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -41,7 +41,7 @@
 #include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <nav_msgs/Path.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -42,7 +42,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TransformStamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -41,7 +41,7 @@
 #include <fuse_core/transaction_deserializer.h>
 #include <fuse_msgs/SerializedGraph.h>
 #include <fuse_msgs/SerializedTransaction.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
 

--- a/fuse_tutorials/CMakeLists.txt
+++ b/fuse_tutorials/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -72,7 +72,7 @@ target_link_libraries(range_sensor_simulator
 )
 set_target_properties(range_sensor_simulator
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 

--- a/fuse_tutorials/src/beacon_publisher.cpp
+++ b/fuse_tutorials/src/beacon_publisher.cpp
@@ -37,7 +37,7 @@
 #include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
 #include <fuse_variables/point_2d_landmark.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>

--- a/fuse_tutorials/src/range_constraint.cpp
+++ b/fuse_tutorials/src/range_constraint.cpp
@@ -34,7 +34,7 @@
 #include <fuse_tutorials/range_constraint.h>
 
 #include <fuse_tutorials/range_cost_functor.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 #include <ceres/autodiff_cost_function.h>

--- a/fuse_tutorials/src/range_sensor_model.cpp
+++ b/fuse_tutorials/src/range_sensor_model.cpp
@@ -40,7 +40,7 @@
 #include <fuse_tutorials/range_constraint.h>
 #include <fuse_variables/point_2d_landmark.h>
 #include <fuse_variables/position_2d_stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -120,7 +120,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_angular_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -144,7 +144,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_angular_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -168,7 +168,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_linear_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -192,7 +192,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_linear_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -215,7 +215,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_fixed_size_variable
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -239,7 +239,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_load_device_id
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -263,7 +263,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_orientation_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -287,7 +287,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_orientation_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -311,7 +311,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_2d_fixed_landmark
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -335,7 +335,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_2d_landmark
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -359,7 +359,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_3d_fixed_landmark
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -383,7 +383,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_3d_landmark
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -407,7 +407,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_position_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -431,7 +431,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_position_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -455,7 +455,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_angular_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -479,7 +479,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_angular_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -503,7 +503,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_linear_2d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -527,7 +527,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_linear_3d_stamped
     PROPERTIES
-      CXX_STANDARD 14
+      CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_variables/src/acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_2d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_angular_3d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_2d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/src/acceleration_linear_3d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -37,7 +37,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -37,7 +37,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/point_2d_fixed_landmark.cpp
+++ b/fuse_variables/src/point_2d_fixed_landmark.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_variables/src/point_2d_landmark.cpp
+++ b/fuse_variables/src/point_2d_landmark.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_variables/src/point_3d_fixed_landmark.cpp
+++ b/fuse_variables/src/point_3d_fixed_landmark.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_variables/src/point_3d_landmark.cpp
+++ b/fuse_variables/src/point_3d_landmark.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_core/variable.h>
 #include <fuse_variables/fixed_size_variable.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <boost/serialization/export.hpp>
 

--- a/fuse_variables/src/position_2d_stamped.cpp
+++ b/fuse_variables/src/position_2d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/position_3d_stamped.cpp
+++ b/fuse_variables/src/position_3d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_2d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_angular_3d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_2d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_variables/src/velocity_linear_3d_stamped.cpp
+++ b/fuse_variables/src/velocity_linear_3d_stamped.cpp
@@ -36,7 +36,7 @@
 #include <fuse_core/uuid.h>
 #include <fuse_variables/fixed_size_variable.h>
 #include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/time.h>
 
 #include <boost/serialization/export.hpp>

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -73,6 +73,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 

--- a/fuse_viz/src/serialized_graph_display.cpp
+++ b/fuse_viz/src/serialized_graph_display.cpp
@@ -322,5 +322,5 @@ void SerializedGraphDisplay::processMessage(const fuse_msgs::SerializedGraph::Co
 
 }  // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz::SerializedGraphDisplay, rviz::Display)


### PR DESCRIPTION
This updates the C++ version to 2017 and suppresses a few warnings from included libraries.
I'm also grabbing the pluginlib .hpp commit from Lucas Walter <wsacul@gmail.com>
This should compile with ROS Noetic on Ubuntu 20.04 and 22.04. However, because Ubuntu 22.04 is not an officially supported OS for ROS Noetic, I have created a noetic-devel branch that does not include this change.