### PR TITLE
Add fixed lag smoother test

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -212,4 +212,34 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD 17
       CXX_STANDARD_REQUIRED YES
   )
+
+  # Fixed-lag Smoother test
+  add_rostest_gtest(test_fixed_lag_smoother
+    test/fixed_lag_smoother.test
+    test/test_fixed_lag_smoother.cpp
+  )
+  add_dependencies(test_fixed_lag_smoother
+    fixed_lag_smoother_node
+  )
+  target_include_directories(test_fixed_lag_smoother
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${fuse_models_INCLUDE_DIRS}
+      ${geometry_msgs_INCLUDE_DIRS}
+      ${nav_msgs_INCLUDE_DIRS}
+      ${rostest_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_fixed_lag_smoother
+    ${catkin_LIBRARIES}
+    ${fuse_models_LIBRARIES}
+    ${geometry_msgs_LIBRARIES}
+    ${nav_msgs_LIBRARIES}
+    ${rostest_LIBRARIES}
+  )
+  set_target_properties(test_fixed_lag_smoother
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
 endif()

--- a/fuse_optimizers/test/fixed_lag_smoother.test
+++ b/fuse_optimizers/test/fixed_lag_smoother.test
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="fixed_lag" pkg="fuse_optimizers" type="fixed_lag_smoother_node" output="screen">
+    <rosparam subst_value="true">
+      optimization_frequency: 2.0
+      transaction_timeout: 5.0
+      lag_duration: 5.0
+
+      motion_models:
+        unicycle_motion_model:
+          type: fuse_models::Unicycle2D
+
+      sensor_models:
+        unicycle_ignition_sensor:
+          type: fuse_models::Unicycle2DIgnition
+          motion_models: [unicycle_motion_model]
+          ignition: true
+        pose_sensor:
+          type: fuse_models::Pose2D
+          motion_models: [unicycle_motion_model]
+
+      publishers:
+        odometry_publisher:
+          type: fuse_models::Odometry2DPublisher
+
+      unicycle_motion_model:
+        buffer_length: 5.0
+        process_noise_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+      unicycle_ignition_sensor:
+        publish_on_startup: false
+        initial_state: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        initial_sigma: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+      pose_sensor:
+        differential: true
+        topic: relative_pose
+        position_dimensions: ['x', 'y']
+        orientation_dimensions: ['yaw']
+
+      odometry_publisher:
+        topic: odom
+        world_frame_id: map
+        publish_tf: false
+    </rosparam>
+  </node>
+
+  <test test-name="FixedLagSmoother" pkg="fuse_optimizers" type="test_fixed_lag_smoother" />
+</launch>

--- a/fuse_optimizers/test/test_fixed_lag_smoother.cpp
+++ b/fuse_optimizers/test/test_fixed_lag_smoother.cpp
@@ -1,0 +1,101 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_models/SetPose.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+
+TEST(FixedLagIgnition, SetInitialStateToPiOrientation)
+{
+  // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
+  ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
+
+  auto node_handle = ros::NodeHandle();
+  auto relative_pose_publisher = node_handle.advertise<geometry_msgs::PoseWithCovarianceStamped>("/relative_pose", 1);
+
+  // Wait for the optimizer to be ready
+  ASSERT_TRUE(ros::service::waitForService("/fixed_lag/set_pose", ros::Duration(1.0)));
+  ASSERT_TRUE(ros::service::waitForService("/fixed_lag/reset", ros::Duration(1.0)));
+
+  // Set the initial pose to something far away from zero
+  fuse_models::SetPose::Request req;
+  req.pose.header.frame_id = "map";
+  req.pose.header.stamp = ros::Time(1, 0);
+  req.pose.pose.pose.position.x = 100.1;
+  req.pose.pose.pose.position.y = 100.2;
+  req.pose.pose.pose.position.z = 0.0;
+  req.pose.pose.pose.orientation.x = 0.0;
+  req.pose.pose.pose.orientation.y = 0.0;
+  req.pose.pose.pose.orientation.z = 1.0; // yaw = pi rad
+  req.pose.pose.pose.orientation.w = 0.0;
+  req.pose.pose.covariance[0] = 1.0;
+  req.pose.pose.covariance[7] = 1.0;
+  req.pose.pose.covariance[35] = 1.0;
+  fuse_models::SetPose::Response res;
+  ros::service::call("/fixed_lag/set_pose", req, res);
+  ASSERT_TRUE(res.success);
+
+  // Wait for the optimizer to process all queued transactions
+  ros::Time result_timeout = ros::Time::now() + ros::Duration(3.0);
+  auto odom_msg = nav_msgs::Odometry::ConstPtr();
+  while ((!odom_msg || odom_msg->header.stamp != ros::Time(3, 0)) &&
+         (ros::Time::now() < result_timeout))
+  {
+    odom_msg = ros::topic::waitForMessage<nav_msgs::Odometry>("/odom", ros::Duration(1.0));
+  }
+  ASSERT_TRUE(static_cast<bool>(odom_msg));
+  ASSERT_EQ(odom_msg->header.stamp, ros::Time(1, 0));
+
+  // If we did our job correctly, the initial variable values should be the same as the service call state, give or
+  // take the motion model forward prediction.
+  EXPECT_NEAR(100.1, odom_msg->pose.pose.position.x, 0.1);
+  EXPECT_NEAR(100.2, odom_msg->pose.pose.position.y, 0.1);
+  EXPECT_NEAR(1.0, std::abs(odom_msg->pose.pose.orientation.z), 0.1);  // pi == -pi
+  EXPECT_NEAR(0.0, odom_msg->pose.pose.orientation.w, 0.1);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "fixed_lag_smoother_test");
+  auto spinner = ros::AsyncSpinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}


### PR DESCRIPTION
Add fixed lag smoother test to test `set_pose` with orientation equal to `pi`, which is failing to be optimized with this error:
```bash
E20230628 15:01:20.425174 436794 trust_region_minimizer.cc:97] Terminating: Number of consecutive invalid steps more than Solver::Options::max_num_consecutive_invalid_steps: 5
```

Full test output error:
```bash
build/fuse_optimizers$ make run_tests_fuse_optimizers_rostest_test_fixed_lag_smoother.test
...
[ INFO] [/fixed_lag] [1687986631.450961780]: Received a set_pose request (stamp: 1.000000000, x: 100.1, y: 100.2, yaw: 3.14159)
WARNING: Logging before InitGoogleLogging() is written to STDERR
E20230628 17:10:31.922817 460509 trust_region_minimizer.cc:97] Terminating: Number of consecutive invalid steps more than Solver::Options::max_num_consecutive_invalid_steps: 5
[FATAL] [/fixed_lag] [1687986631.923664848]: Optimization failed after updating the graph with the transaction with timestamp 1.000000000. Leaving optimization loop and requesting node shutdown...
Graph:
HashGraph
  constraints:
   - fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: d9b80224-7a7f-400b-8861-df56ff803f44
  variable: 68206cae-31ec-59a8-be15-f76649ad0557
  mean: 0
  sqrt_info: 10

   - fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 45925eab-c9c4-4f62-90ff-e8f159df0382
  variable: bc1b435d-b576-5103-9214-1db9b4646b2f
  mean: 0 0
  sqrt_info: 10  0
 0 10

   - fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: c02eeb3e-0cc4-4f59-90c5-d34f443d2712
  variable: b09b83b7-cb28-5243-8c6f-242bc2586105
  mean: 0 0
  sqrt_info: 10  0
 0 10

   - fuse_constraints::AbsoluteOrientation2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 4153b9c5-a5f3-4165-8b32-e05aee60a249
  variable: e6881748-8a90-5837-b2c5-2d36a74417f9
  mean: 3.14159
  sqrt_info: 1

   - fuse_constraints::AbsolutePosition2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 169b2316-85c1-439d-8e14-1aa6a0329115
  variable: 574f418d-ebfb-595e-9432-1b463dc9d659
  mean: 100.1 100.2
  sqrt_info: 1 0
0 1

  variables:
   - fuse_variables::AccelerationLinear2DStamped:
  uuid: bc1b435d-b576-5103-9214-1db9b4646b2f
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 0
  - y: 0

     on_hold: false
   - fuse_variables::VelocityAngular2DStamped:
  uuid: 68206cae-31ec-59a8-be15-f76649ad0557
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 1
  data:
  - yaw: 0

     on_hold: false
   - fuse_variables::VelocityLinear2DStamped:
  uuid: b09b83b7-cb28-5243-8c6f-242bc2586105
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 0
  - y: 0

     on_hold: false
   - fuse_variables::Orientation2DStamped:
  uuid: e6881748-8a90-5837-b2c5-2d36a74417f9
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 1
  data:
  - yaw: 3.14159

     on_hold: false
   - fuse_variables::Position2DStamped:
  uuid: 574f418d-ebfb-595e-9432-1b463dc9d659
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 100.1
  - y: 100.2

     on_hold: false

Transaction:
Stamp: 1.000000000
Involved Timestamps:
 - 1.000000000
Added Variables:
 - fuse_variables::Position2DStamped:
  uuid: 574f418d-ebfb-595e-9432-1b463dc9d659
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 100.1
  - y: 100.2

 - fuse_variables::Orientation2DStamped:
  uuid: e6881748-8a90-5837-b2c5-2d36a74417f9
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 1
  data:
  - yaw: 3.14159

 - fuse_variables::VelocityLinear2DStamped:
  uuid: b09b83b7-cb28-5243-8c6f-242bc2586105
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 0
  - y: 0

 - fuse_variables::VelocityAngular2DStamped:
  uuid: 68206cae-31ec-59a8-be15-f76649ad0557
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 1
  data:
  - yaw: 0

 - fuse_variables::AccelerationLinear2DStamped:
  uuid: bc1b435d-b576-5103-9214-1db9b4646b2f
  stamp: 1.000000000
  device_id: 00000000-0000-0000-0000-000000000000
  size: 2
  data:
  - x: 0
  - y: 0

Added Constraints:
 - fuse_constraints::AbsolutePosition2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 169b2316-85c1-439d-8e14-1aa6a0329115
  variable: 574f418d-ebfb-595e-9432-1b463dc9d659
  mean: 100.1 100.2
  sqrt_info: 1 0
0 1

 - fuse_constraints::AbsoluteOrientation2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 4153b9c5-a5f3-4165-8b32-e05aee60a249
  variable: e6881748-8a90-5837-b2c5-2d36a74417f9
  mean: 3.14159
  sqrt_info: 1

 - fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: c02eeb3e-0cc4-4f59-90c5-d34f443d2712
  variable: b09b83b7-cb28-5243-8c6f-242bc2586105
  mean: 0 0
  sqrt_info: 10  0
 0 10

 - fuse_constraints::AbsoluteVelocityAngular2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: d9b80224-7a7f-400b-8861-df56ff803f44
  variable: 68206cae-31ec-59a8-be15-f76649ad0557
  mean: 0
  sqrt_info: 10

 - fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint
  source: unicycle_ignition_sensor
  uuid: 45925eab-c9c4-4f62-90ff-e8f159df0382
  variable: bc1b435d-b576-5103-9214-1db9b4646b2f
  mean: 0 0
  sqrt_info: 10  0
 0 10

Removed Variables:
Removed Constraints:

[ INFO] [/fixed_lag] [1687986631.924233109]: 
Solver Summary (v 2.0.0-eigen-(3.4.0)-lapack-suitesparse-(5.13.0)-cxsparse-(3.2.0)-eigensparse-no_openmp)

                                     Original                  Reduced
Parameter blocks                            5                        5
Parameters                                  8                        8
Residual blocks                             5                        5
Residuals                                   8                        8

Minimizer                        TRUST_REGION

Sparse linear algebra library    SUITE_SPARSE
Trust region strategy     LEVENBERG_MARQUARDT

                                        Given                     Used
Linear solver          SPARSE_NORMAL_CHOLESKY   SPARSE_NORMAL_CHOLESKY
Threads                                     1                        1
Linear solver ordering              AUTOMATIC                        5

Cost:
Initial                          0.000000e+00

Minimizer iterations                        5
Successful steps                            1
Unsuccessful steps                          4

Time (in seconds):
Preprocessor                         0.000283

  Residual only evaluation           0.000000 (0)
  Jacobian & residual evaluation     0.000015 (1)
  Linear solver                      0.000108 (5)
Minimizer                            0.000331

Postprocessor                        0.000011
Total                                0.000625

Termination:                          FAILURE (Number of consecutive invalid steps more than Solver::Options::max_num_consecutive_invalid_steps: 5)

[Testcase: testFixedLagSmoother] ... ok

[ROSTEST]-----------------------------------------------------------------------

[fuse_optimizers.rosunit-FixedLagSmoother/SetInitialStateToPiOrientation][FAILURE]
/home/efernandez/NIX/devel/colcon_workspace/src/fuse/fuse_optimizers/test/test_fixed_lag_smoother.cpp:80
Value of: static_cast<bool>(odom_msg)
  Actual: false
Expected: true
--------------------------------------------------------------------------------
```

A fix for this would be required before merging this!