### PR TITLE
[RST-7809] Fix optimization errors when the orientation is initialized at +PI

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -139,6 +139,32 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
+  # Absolute Orientation 2D Stamped Constraint Tests
+  catkin_add_gtest(test_absolute_orientation_2d_stamped_constraint
+    test/test_absolute_orientation_2d_stamped_constraint.cpp
+  )
+  add_dependencies(test_absolute_orientation_2d_stamped_constraint
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_absolute_orientation_2d_stamped_constraint
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${CERES_INCLUDE_DIRS}
+      ${EIGEN3_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_absolute_orientation_2d_stamped_constraint
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${CERES_LIBRARIES}
+    ${EIGEN3_LIBRARIES}
+  )
+  set_target_properties(test_absolute_orientation_2d_stamped_constraint
+    PROPERTIES
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED YES
+  )
+
   # Absolute Orientation 3D Stamped Constraint Tests
   catkin_add_gtest(test_absolute_orientation_3d_stamped_constraint
     test/test_absolute_orientation_3d_stamped_constraint.cpp

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -378,7 +378,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   auto variable = fuse_variables::Orientation2DStamped::make_shared(
     ros::Time(1234, 5678),
     fuse_core::uuid::generate("tiktok"));
-  variable->yaw() = 0.7;
+  variable->setYaw(0.7);
   // Create an absolute constraint
   fuse_core::Vector1d mean;
   mean << 7.0;
@@ -408,7 +408,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
   // Check
-  EXPECT_NEAR(7.0 - 2 * M_PI, variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(7.0 - 2 * M_PI, variable->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double*, const double*> > covariance_blocks;
   covariance_blocks.emplace_back(variable->data(), variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
@@ -1,0 +1,368 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_constraints/absolute_constraint.h>
+#include <fuse_core/eigen.h>
+#include <fuse_core/eigen_gtest.h>
+#include <fuse_core/serialization.h>
+#include <fuse_core/uuid.h>
+#include <fuse_variables/orientation_2d_stamped.h>
+#include <geometry_msgs/Quaternion.h>
+
+#include <ceres/covariance.h>
+#include <ceres/problem.h>
+#include <ceres/solver.h>
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+using fuse_constraints::AbsoluteOrientation2DStampedConstraint;
+using fuse_variables::Orientation2DStamped;
+
+
+TEST(AbsoluteOrientation2DStampedConstraint, Constructor)
+{
+  // Construct a constraint just to make sure it compiles.
+  Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  fuse_core::Vector1d mean;
+  mean << 1.0;
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  EXPECT_NO_THROW(AbsoluteOrientation2DStampedConstraint constraint("test", orientation_variable, mean, cov));
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, Covariance)
+{
+  // Verify the covariance <--> sqrt information conversions are correct
+  Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("mo"));
+  fuse_core::Vector1d mean;
+  mean << 1.0;
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  AbsoluteOrientation2DStampedConstraint constraint("test", orientation_variable, mean, cov);
+
+  // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
+  fuse_core::Matrix1d expected_sqrt_info;
+  expected_sqrt_info <<  1.0;
+  fuse_core::Matrix1d expected_cov = cov;
+
+  // Compare
+  EXPECT_MATRIX_NEAR(expected_cov, constraint.covariance(), 1.0e-9);
+  EXPECT_MATRIX_NEAR(expected_sqrt_info, constraint.sqrtInformation(), 1.0e-9);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
+{
+  // Optimize a single pose and single constraint, verify the expected value and covariance are generated.
+  // Create the variables
+  auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(1.0);
+
+  // Create an absolute orientation constraint
+  fuse_core::Vector1d mean;
+  mean << 1.0;
+
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
+    "test",
+    *orientation_variable,
+    mean,
+    cov);
+
+  // Build the problem
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+  ceres::Problem problem(problem_options);
+  problem.AddParameterBlock(
+    orientation_variable->data(),
+    orientation_variable->size(),
+    orientation_variable->localParameterization());
+
+  std::vector<double*> parameter_blocks;
+  parameter_blocks.push_back(orientation_variable->data());
+  problem.AddResidualBlock(
+    constraint->costFunction(),
+    constraint->lossFunction(),
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
+
+  // Check
+  EXPECT_NEAR(1.0, orientation_variable->getYaw(), 1.0e-3);
+
+  // Compute the covariance
+  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
+  ceres::Covariance::Options cov_options;
+  ceres::Covariance covariance(cov_options);
+  covariance.Compute(covariance_blocks, &problem);
+  fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
+  covariance.GetCovarianceBlockInTangentSpace(
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+
+  // Define the expected covariance
+  fuse_core::Matrix1d expected_covariance;
+  expected_covariance << 1.0;
+  EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
+{
+  // Optimize a single orientation at zero and single constraint, verify the expected value and covariance are
+  // generated.
+
+  // Create the variables
+  auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(0.0);
+
+  // Create an absolute orientation constraint
+  fuse_core::Vector1d mean;
+  mean << 0.0;
+
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
+    "test",
+    *orientation_variable,
+    mean,
+    cov);
+
+  // Build the problem
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+  ceres::Problem problem(problem_options);
+  problem.AddParameterBlock(
+    orientation_variable->data(),
+    orientation_variable->size(),
+    orientation_variable->localParameterization());
+
+  std::vector<double*> parameter_blocks;
+  parameter_blocks.push_back(orientation_variable->data());
+  problem.AddResidualBlock(
+    constraint->costFunction(),
+    constraint->lossFunction(),
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
+
+  // Check
+  EXPECT_NEAR(0.0, orientation_variable->getYaw(), 1.0e-3);
+
+  // Compute the covariance
+  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
+  ceres::Covariance::Options cov_options;
+  ceres::Covariance covariance(cov_options);
+  covariance.Compute(covariance_blocks, &problem);
+  fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
+  covariance.GetCovarianceBlockInTangentSpace(
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+
+  // Define the expected covariance
+  fuse_core::Matrix1d expected_covariance;
+  expected_covariance << 1.0;
+  EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
+{
+  // Optimize a single orientation at +PI and single constraint, verify the expected value and covariance are
+  // generated.
+
+  // Create the variables
+  auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(M_PI);
+
+  // Create an absolute orientation constraint
+  fuse_core::Vector1d mean;
+  mean << M_PI;
+
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
+    "test",
+    *orientation_variable,
+    mean,
+    cov);
+
+  // Build the problem
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+  ceres::Problem problem(problem_options);
+  problem.AddParameterBlock(
+    orientation_variable->data(),
+    orientation_variable->size(),
+    orientation_variable->localParameterization());
+
+  std::vector<double*> parameter_blocks;
+  parameter_blocks.push_back(orientation_variable->data());
+  problem.AddResidualBlock(
+    constraint->costFunction(),
+    constraint->lossFunction(),
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
+
+  // Check
+  // We expect +PI to roll over to -PI because our range is [-PI, PI)
+  EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
+
+  // Compute the covariance
+  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
+  ceres::Covariance::Options cov_options;
+  ceres::Covariance covariance(cov_options);
+  covariance.Compute(covariance_blocks, &problem);
+  fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
+  covariance.GetCovarianceBlockInTangentSpace(
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+
+  // Define the expected covariance
+  fuse_core::Matrix1d expected_covariance;
+  expected_covariance << 1.0;
+  EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
+{
+  // Optimize a single orientation at -PI and single constraint, verify the expected value and covariance are
+  // generated.
+
+  // Create the variables
+  auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(-M_PI);
+
+  // Create an absolute orientation constraint
+  fuse_core::Vector1d mean;
+  mean << -M_PI;
+
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
+    "test",
+    *orientation_variable,
+    mean,
+    cov);
+
+  // Build the problem
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+  ceres::Problem problem(problem_options);
+  problem.AddParameterBlock(
+    orientation_variable->data(),
+    orientation_variable->size(),
+    orientation_variable->localParameterization());
+
+  std::vector<double*> parameter_blocks;
+  parameter_blocks.push_back(orientation_variable->data());
+  problem.AddResidualBlock(
+    constraint->costFunction(),
+    constraint->lossFunction(),
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
+
+  // Check
+  EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
+
+  // Compute the covariance
+  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
+  ceres::Covariance::Options cov_options;
+  ceres::Covariance covariance(cov_options);
+  covariance.Compute(covariance_blocks, &problem);
+  fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
+  covariance.GetCovarianceBlockInTangentSpace(
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+
+  // Define the expected covariance
+  fuse_core::Matrix1d expected_covariance;
+  expected_covariance << 1.0;
+  EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, Serialization)
+{
+  // Construct a constraint
+  Orientation2DStamped orientation_variable(ros::Time(1234, 5678), fuse_core::uuid::generate("walle"));
+  fuse_core::Vector1d mean;
+  mean << 1.0;
+  fuse_core::Matrix1d cov;
+  cov << 1.0;
+  AbsoluteOrientation2DStampedConstraint expected("test", orientation_variable, mean, cov);
+
+  // Serialize the constraint into an archive
+  std::stringstream stream;
+  {
+    fuse_core::TextOutputArchive archive(stream);
+    expected.serialize(archive);
+  }
+
+  // Deserialize a new constraint from that same stream
+  AbsoluteOrientation2DStampedConstraint actual;
+  {
+    fuse_core::TextInputArchive archive(stream);
+    actual.deserialize(archive);
+  }
+
+  // Compare
+  EXPECT_EQ(expected.uuid(), actual.uuid());
+  EXPECT_EQ(expected.variables(), actual.variables());
+  EXPECT_MATRIX_EQ(expected.mean(), actual.mean());
+  EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -91,7 +91,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
   // Optimize a single pose and single constraint, verify the expected value and covariance are generated.
   // Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 0.8;
+  orientation_variable->setYaw(0.8);
   auto position_variable = Position2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
   position_variable->x() = 1.5;
   position_variable->y() = -3.0;
@@ -132,7 +132,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
   // Check
   EXPECT_NEAR(1.0, position_variable->x(), 1.0e-5);
   EXPECT_NEAR(2.0, position_variable->y(), 1.0e-5);
-  EXPECT_NEAR(3.0, orientation_variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation_variable->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double*, const double*> > covariance_blocks;
   covariance_blocks.emplace_back(position_variable->data(), position_variable->data());
@@ -167,7 +167,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   // Optimize a single pose and single constraint, verify the expected value and covariance are generated.
   // Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 0.8;
+  orientation_variable->setYaw(0.8);
   auto position_variable = Position2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("spra"));
   position_variable->x() = 1.5;
   position_variable->y() = -3.0;
@@ -237,7 +237,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   // Check
   EXPECT_NEAR(1.0, position_variable->x(), 1.0e-5);
   EXPECT_NEAR(2.0, position_variable->y(), 1.0e-5);
-  EXPECT_NEAR(3.0, orientation_variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation_variable->getYaw(), 1.0e-5);
 
   // Compute the covariance
   std::vector<std::pair<const double*, const double*> > covariance_blocks;

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -410,11 +410,11 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   auto x1 = fuse_variables::Orientation2DStamped::make_shared(
     ros::Time(1234, 5678),
     fuse_core::uuid::generate("t800"));
-  x1->yaw() = 0.7;
+  x1->setYaw(0.7);
   auto x2 = fuse_variables::Orientation2DStamped::make_shared(
     ros::Time(1235, 5678),
     fuse_core::uuid::generate("t800"));
-  x2->yaw() = -2.2;
+  x2->setYaw(-2.2);
   // Create an absolute constraint
   fuse_core::Vector1d mean;
   mean << 1.0;
@@ -466,8 +466,8 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
   // Check
-  EXPECT_NEAR(1.0, x1->yaw(), 1.0e-5);
-  EXPECT_NEAR(1.1, x2->yaw(), 1.0e-5);
+  EXPECT_NEAR(1.0, x1->getYaw(), 1.0e-5);
+  EXPECT_NEAR(1.1, x2->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double*, const double*> > covariance_blocks;
   covariance_blocks.emplace_back(x1->data(), x1->data());

--- a/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
@@ -105,12 +105,12 @@ TEST(RelativePose2DStampedConstraint, OptimizationFull)
   // Verify the expected poses and covariances are generated.
   // Create two poses
   auto orientation1 = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation1->yaw() = 0.8;
+  orientation1->setYaw(0.8);
   auto position1 = Position2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
   position1->x() = 1.5;
   position1->y() = -3.0;
   auto orientation2 = Orientation2DStamped::make_shared(ros::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation2->yaw() = -2.7;
+  orientation2->setYaw(-2.7);
   auto position2 = Position2DStamped::make_shared(ros::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
   position2->x() = 3.7;
   position2->y() = 1.2;
@@ -181,10 +181,10 @@ TEST(RelativePose2DStampedConstraint, OptimizationFull)
   // Check
   EXPECT_NEAR(0.0, position1->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position1->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation1->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation1->getYaw(), 1.0e-5);
   EXPECT_NEAR(1.0, position2->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position2->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation2->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation2->getYaw(), 1.0e-5);
   // Compute the marginal covariance for pose1
   {
     std::vector<std::pair<const double*, const double*> > covariance_blocks;
@@ -252,13 +252,13 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
   // Verify the expected poses and covariances are generated.
   // Create two poses
   auto orientation1 = Orientation2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation1->yaw() = 0.8;
+  orientation1->setYaw(0.8);
   auto position1 = Position2DStamped::make_shared(ros::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
   position1->x() = 1.5;
   position1->y() = -3.0;
 
   auto orientation2 = Orientation2DStamped::make_shared(ros::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation2->yaw() = -2.7;
+  orientation2->setYaw(-2.7);
   auto position2 = Position2DStamped::make_shared(ros::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
   position2->x() = 3.7;
   position2->y() = 1.2;
@@ -362,10 +362,10 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
   // Check
   EXPECT_NEAR(0.0, position1->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position1->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation1->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation1->getYaw(), 1.0e-5);
   EXPECT_NEAR(1.0, position2->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position2->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation2->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation2->getYaw(), 1.0e-5);
 
   // Compute the marginal covariance for pose1
   {

--- a/fuse_core/include/fuse_core/util.h
+++ b/fuse_core/include/fuse_core/util.h
@@ -92,10 +92,12 @@ static inline T getRoll(const T w, const T x, const T y, const T z)
 /**
  * @brief Returns the Euler yaw angle from a quaternion
  *
+ * Returned angle is in the range [-Pi, +Pi]
+ *
  * @param[in] w The quaternion real-valued component
  * @param[in] x The quaternion x-axis component
- * @param[in] y The quaternion x-axis component
- * @param[in] z The quaternion x-axis component
+ * @param[in] y The quaternion y-axis component
+ * @param[in] z The quaternion z-axis component
  * @return      The quaternion's Euler yaw angle component
  */
 template <typename T>

--- a/fuse_models/include/fuse_models/common/sensor_proc.h
+++ b/fuse_models/include/fuse_models/common/sensor_proc.h
@@ -313,7 +313,7 @@ inline bool processAbsolutePoseWithCovariance(
   auto orientation = fuse_variables::Orientation2DStamped::make_shared(pose.header.stamp, device_id);
   position->x() = absolute_pose_2d.x();
   position->y() = absolute_pose_2d.y();
-  orientation->yaw() = absolute_pose_2d.yaw();
+  orientation->setYaw(absolute_pose_2d.yaw());
 
   // Create the pose for the constraint
   fuse_core::Vector3d pose_mean;
@@ -432,13 +432,13 @@ inline bool processDifferentialPoseWithCovariance(
     fuse_variables::Orientation2DStamped::make_shared(pose1.header.stamp, device_id);
   position1->x() = pose1_2d.x();
   position1->y() = pose1_2d.y();
-  orientation1->yaw() = pose1_2d.yaw();
+  orientation1->setYaw(pose1_2d.yaw());
 
   auto position2 = fuse_variables::Position2DStamped::make_shared(pose2.header.stamp, device_id);
   auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(pose2.header.stamp, device_id);
   position2->x() = pose2_2d.x();
   position2->y() = pose2_2d.y();
-  orientation2->yaw() = pose2_2d.yaw();
+  orientation2->setYaw(pose2_2d.yaw());
 
   // Create the delta for the constraint
   const double sy = ::sin(-pose1_2d.yaw());
@@ -780,13 +780,13 @@ inline bool processDifferentialPoseWithTwistCovariance(
     fuse_variables::Orientation2DStamped::make_shared(pose1.header.stamp, device_id);
   position1->x() = pose1_2d.x();
   position1->y() = pose1_2d.y();
-  orientation1->yaw() = pose1_2d.yaw();
+  orientation1->setYaw(pose1_2d.yaw());
 
   auto position2 = fuse_variables::Position2DStamped::make_shared(pose2.header.stamp, device_id);
   auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(pose2.header.stamp, device_id);
   position2->x() = pose2_2d.x();
   position2->y() = pose2_2d.y();
-  orientation2->yaw() = pose2_2d.yaw();
+  orientation2->setYaw(pose2_2d.yaw());
 
   // Create the delta for the constraint
   const auto delta = pose1_2d.inverseTimes(pose2_2d);

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -288,7 +288,7 @@ bool Odometry2DPublisher::getState(
     odometry.pose.pose.position.x = position_variable.x();
     odometry.pose.pose.position.y = position_variable.y();
     odometry.pose.pose.position.z = 0.0;
-    odometry.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.yaw()));
+    odometry.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.getYaw()));
     odometry.twist.twist.linear.x = velocity_linear_variable.x();
     odometry.twist.twist.linear.y = velocity_linear_variable.y();
     odometry.twist.twist.linear.z = 0.0;

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -256,10 +256,10 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::PoseWithCovarianceStampe
   position->x() = pose.pose.pose.position.x;
   position->y() = pose.pose.pose.position.y;
   auto orientation = fuse_variables::Orientation2DStamped::make_shared(stamp, device_id_);
-  orientation->yaw() = fuse_core::getYaw(pose.pose.pose.orientation.w,
-                                         pose.pose.pose.orientation.x,
-                                         pose.pose.pose.orientation.y,
-                                         pose.pose.pose.orientation.z);
+  orientation->setYaw(fuse_core::getYaw(pose.pose.pose.orientation.w,
+                                        pose.pose.pose.orientation.x,
+                                        pose.pose.pose.orientation.y,
+                                        pose.pose.pose.orientation.z));
   auto linear_velocity = fuse_variables::VelocityLinear2DStamped::make_shared(stamp, device_id_);
   linear_velocity->x() = params_.initial_state[3];
   linear_velocity->y() = params_.initial_state[4];
@@ -295,7 +295,7 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::PoseWithCovarianceStampe
   auto orientation_constraint = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared(
     name(),
     *orientation,
-    fuse_core::Vector1d(orientation->yaw()),
+    fuse_core::Vector1d(orientation->getYaw()),
     orientation_cov);
   auto linear_velocity_constraint = fuse_constraints::AbsoluteVelocityLinear2DStampedConstraint::make_shared(
     name(),
@@ -332,7 +332,7 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::PoseWithCovarianceStampe
   sendTransaction(transaction);
 
   ROS_INFO_STREAM("Received a set_pose request (stamp: " << stamp << ", x: " << position->x() << ", y: " <<
-                  position->y() << ", yaw: " << orientation->yaw() << ")");
+                  position->y() << ", yaw: " << orientation->getYaw() << ")");
 }
 
 }  // namespace fuse_models

--- a/fuse_models/test/test_unicycle_2d.cpp
+++ b/fuse_models/test/test_unicycle_2d.cpp
@@ -38,7 +38,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
   auto linear_acceleration1 = fuse_variables::AccelerationLinear2DStamped::make_shared(ros::Time(1, 0));
   position1->x() = 1.1;
   position1->y() = 2.1;
-  yaw1->yaw() = 3.1;
+  yaw1->setYaw(3.1);
   linear_velocity1->x() = 1.0;
   linear_velocity1->y() = 0.0;
   yaw_velocity1->yaw() = 0.0;
@@ -51,7 +51,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
   auto linear_acceleration2 = fuse_variables::AccelerationLinear2DStamped::make_shared(ros::Time(2, 0));
   position2->x() = 1.2;
   position2->y() = 2.2;
-  yaw2->yaw() = M_PI / 2.0;
+  yaw2->setYaw(M_PI / 2.0);
   linear_velocity2->x() = 0.0;
   linear_velocity2->y() = 1.0;
   yaw_velocity2->yaw() = 0.0;
@@ -64,7 +64,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
   auto linear_acceleration3 = fuse_variables::AccelerationLinear2DStamped::make_shared(ros::Time(3, 0));
   position3->x() = 1.3;
   position3->y() = 2.3;
-  yaw3->yaw() = 3.3;
+  yaw3->setYaw(3.3);
   linear_velocity3->x() = 4.3;
   linear_velocity3->y() = 5.3;
   yaw_velocity3->yaw() = 6.3;
@@ -77,7 +77,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
   auto linear_acceleration4 = fuse_variables::AccelerationLinear2DStamped::make_shared(ros::Time(4, 0));
   position4->x() = 1.4;
   position4->y() = 2.4;
-  yaw4->yaw() = 3.4;
+  yaw4->setYaw(3.4);
   linear_velocity4->x() = 4.4;
   linear_velocity4->y() = 5.4;
   yaw_velocity4->yaw() = 6.4;
@@ -90,7 +90,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
   auto linear_acceleration5 = fuse_variables::AccelerationLinear2DStamped::make_shared(ros::Time(5, 0));
   position5->x() = 1.5;
   position5->y() = 2.5;
-  yaw5->yaw() = 3.5;
+  yaw5->setYaw(3.5);
   linear_velocity5->x() = 4.5;
   linear_velocity5->y() = 5.5;
   yaw_velocity5->yaw() = 6.5;

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -114,7 +114,7 @@ void Path2DPublisher::notifyCallback(
       pose.pose.position.x = position->x();
       pose.pose.position.y = position->y();
       pose.pose.position.z = 0.0;
-      pose.pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation->yaw()));
+      pose.pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation->getYaw()));
       poses.push_back(std::move(pose));
     }
   }

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -80,7 +80,7 @@ bool findPose(
     pose.position.x = position_variable.x();
     pose.position.y = position_variable.y();
     pose.position.z = 0.0;
-    pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation_variable.yaw()));
+    pose.orientation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation_variable.getYaw()));
   }
   catch (const std::exception& e)
   {

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -71,24 +71,24 @@ public:
     position1->x() = 1.01;
     position1->y() = 2.01;
     auto orientation1 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1234, 10));
-    orientation1->yaw() = 3.01;
+    orientation1->setYaw(3.01);
     auto position2 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 10));
     position2->x() = 1.02;
     position2->y() = 2.02;
     auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 10));
-    orientation2->yaw() = 3.02;
+    orientation2->setYaw(3.02);
     auto position3 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 9));
     position3->x() = 1.03;
     position3->y() = 2.03;
     auto orientation3 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 9));
-    orientation3->yaw() = 3.03;
+    orientation3->setYaw(3.03);
     auto position4 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 11),
                                                                     fuse_core::uuid::generate("kitt"));
     position4->x() = 1.04;
     position4->y() = 2.04;
     auto orientation4 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 11),
                                                                           fuse_core::uuid::generate("kitt"));
-    orientation4->yaw() = 3.04;
+    orientation4->setYaw(3.04);
 
     transaction_->addInvolvedStamp(position1->stamp());
     transaction_->addInvolvedStamp(orientation1->stamp());

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -73,24 +73,24 @@ public:
     position1->x() = 1.01;
     position1->y() = 2.01;
     auto orientation1 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1234, 10));
-    orientation1->yaw() = 3.01;
+    orientation1->setYaw(3.01);
     auto position2 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 10));
     position2->x() = 1.02;
     position2->y() = 2.02;
     auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 10));
-    orientation2->yaw() = 3.02;
+    orientation2->setYaw(3.02);
     auto position3 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 9));
     position3->x() = 1.03;
     position3->y() = 2.03;
     auto orientation3 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 9));
-    orientation3->yaw() = 3.03;
+    orientation3->setYaw(3.03);
     auto position4 = fuse_variables::Position2DStamped::make_shared(ros::Time(1235, 11),
                                                                     fuse_core::uuid::generate("kitt"));
     position4->x() = 1.04;
     position4->y() = 2.04;
     auto orientation4 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 11),
                                                                           fuse_core::uuid::generate("kitt"));
-    orientation4->yaw() = 3.04;
+    orientation4->setYaw(3.04);
 
     transaction_->addInvolvedStamp(position1->stamp());
     transaction_->addInvolvedStamp(orientation1->stamp());

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -178,7 +178,7 @@ public:
   /**
    * @brief Write access to the heading angle.
    */
-  void setYaw(const double yaw) { data_[YAW] = yaw; }
+  void setYaw(const double yaw) { data_[YAW] = fuse_core::wrapAngle2D(yaw); }
 
   /**
    * @brief Print a human-readable description of the variable to the provided stream.

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -161,12 +161,24 @@ public:
   /**
    * @brief Read-write access to the heading angle.
    */
+  [[deprecated("The yaw value must be in the range [-pi, pi). Use the setYaw(value) method to ensure minimum phase.")]]
   double& yaw() { return data_[YAW]; }
 
   /**
    * @brief Read-only access to the heading angle.
    */
+  [[deprecated("Use the getYaw()/setYaw(value) methods to ensure const-correctness.")]]
   const double& yaw() const { return data_[YAW]; }
+
+  /**
+   * @brief Read-only access to the heading angle.
+   */
+  const double& getYaw() const { return data_[YAW]; }
+
+  /**
+   * @brief Write access to the heading angle.
+   */
+  void setYaw(const double yaw) { data_[YAW] = yaw; }
 
   /**
    * @brief Print a human-readable description of the variable to the provided stream.

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -62,7 +62,7 @@ void Orientation2DStamped::print(std::ostream& stream) const
          << "  device_id: " << deviceId() << "\n"
          << "  size: " << size() << "\n"
          << "  data:\n"
-         << "  - yaw: " << yaw() << "\n";
+         << "  - yaw: " << getYaw() << "\n";
 }
 
 fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() const

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -240,7 +240,7 @@ TEST(Orientation2DStamped, Optimization)
 {
   // Create a Orientation2DStamped
   Orientation2DStamped orientation(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
-  orientation.yaw() = 1.5;
+  orientation.setYaw(1.5);
 
   // Create a simple a constraint
   ceres::CostFunction* cost_function = new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(new CostFunctor());
@@ -264,14 +264,14 @@ TEST(Orientation2DStamped, Optimization)
   ceres::Solve(options, &problem, &summary);
 
   // Check
-  EXPECT_NEAR(3.0, orientation.yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation.getYaw(), 1.0e-5);
 }
 
 TEST(Orientation2DStamped, Serialization)
 {
   // Create a Orientation2DStamped
   Orientation2DStamped expected(ros::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
-  expected.yaw() = 1.5;
+  expected.setYaw(1.5);
 
   // Serialize the variable into an archive
   std::stringstream stream;
@@ -290,7 +290,7 @@ TEST(Orientation2DStamped, Serialization)
   // Compare
   EXPECT_EQ(expected.deviceId(), actual.deviceId());
   EXPECT_EQ(expected.stamp(), actual.stamp());
-  EXPECT_EQ(expected.yaw(), actual.yaw());
+  EXPECT_EQ(expected.getYaw(), actual.getYaw());
 }
 
 int main(int argc, char **argv)

--- a/fuse_viz/include/fuse_viz/conversions.h
+++ b/fuse_viz/include/fuse_viz/conversions.h
@@ -90,7 +90,7 @@ inline tf2::Vector3 toTF(const fuse_variables::Position2DStamped& position)
 
 inline tf2::Quaternion toTF(const fuse_variables::Orientation2DStamped& orientation)
 {
-  return { tf2::Vector3{ 0, 0, 1 }, orientation.yaw() };
+  return { tf2::Vector3{ 0, 0, 1 }, orientation.getYaw() };
 }
 
 inline tf2::Transform toTF(const fuse_variables::Position2DStamped& position,


### PR DESCRIPTION
If you initialize a robot with an orientation of exactly +PI, the Ceres optimizer will fail. This results in an unusable output, and the entire optimizer node shuts down.

The reason for this is a rather complex series of things. I'll do my best to summarize:
* Orientation variables are not technically linear because of the 2PI roll-over effect. Orientation variables use special local parameterizations when applying updates to force the updates to wrap when needed.
* Fuse uses a valid angle range of [-PI, +PI). So +PI is not technically a valid value. It should be wrapped to -PI. The choice of -PI versus +PI is arbitrary, but one of them is not valid.
* When optimizing a variable with non-minimum phase (-2PI, +PI, +2PI, +3PI, etc.), the cost functions properly treat the difference between +PI and -PI as a zero error. This is correct.
* However, the local parameterization we report a delta to be applied of 2PI. This is also correct....but it is strange to have a correction when the error is zero.
* When optimizing, the Ceres optimizer has a set of criteria it uses to decide when to stop iterating. There is no absolute error condition. Instead we have several ratios (things like `(new_cost - old_cost) < function_tolerance * old_cost`). Because the original error is zero, none of these ratio or proportional stopping criteria are triggered after the first iteration. 0 is not less than 0.
* There is an absolute check on the gradient value which terminates the iterations in normal cases of zero error. However, in the orientation case, the gradient is large because of the 2PI rollover correction. So that stopping criteria does not trigger either.
* The second and all subsequent iterations fail because it is impossible to find a step that reduces the error below zero.

In order to fix this issue without modifying how the Ceres stopping criteria work, the orientation variables must always be minimum phase. However, I have not found any bullet-proof ways of enforcing that requirement.

This PR:
* Marks the original `Orientation2D::yaw()` methods as deprecated. The way these accessors were written prevents me from inserting additional checks or enforcing requirements.
* Adds a new getter() and setter() for the yaw value of the Orientation2D class. These new methods do allow me to wrap the user input to the proper range before setting the variable value.
* Update all uses to the new getter()/setter() methods.

Why is this not an ideal solution?
* Even though they are marked as deprecated, the old methods still exist and can be used. So it is still possible to set the orientation variable to a non-minimum phase.
* The Ceres Solver interface requires read-write access to the variable values. This is a requirement of the NLS solver and cannot be avoided. So there will always be a method to set the variable values to anything the user desires. The API is just less friendly.
* I should really update _all_ of the variables to have getters() and setters() for consistency. I will do that at some point, but I didn't want to clutter up this PR any more than required.

If anyone has an alternate solution, I am happy to test it out.