### PR TITLE
[RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2

### DIFF
--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -414,7 +414,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   auto variable = fuse_variables::Orientation2DStamped::make_shared(
     rclcpp::Time(1234, 5678),
     fuse_core::uuid::generate("tiktok"));
-  variable->yaw() = 0.7;
+  variable->setYaw(0.7);
   // Create an absolute constraint
   fuse_core::VectorXd mean(1);
   mean << 7.0;
@@ -445,7 +445,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
   // Check
-  EXPECT_NEAR(7.0 - 2 * M_PI, variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(7.0 - 2 * M_PI, variable->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
   covariance_blocks.emplace_back(variable->data(), variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
@@ -96,7 +96,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
   // Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 1.0;
+  orientation_variable->setYaw(1.0);
 
   // Create an absolute orientation constraint
   fuse_core::VectorXd mean(1);
@@ -136,7 +136,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
   EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
 
   // Check
-  EXPECT_NEAR(1.0, orientation_variable->yaw(), 1.0e-3);
+  EXPECT_NEAR(1.0, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
@@ -164,7 +164,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
   auto orientation_variable = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0),
     fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 0.0;
+  orientation_variable->setYaw(0.0);
 
   // Create an absolute orientation constraint
   fuse_core::VectorXd mean(1);
@@ -204,7 +204,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
   EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
 
   // Check
-  EXPECT_NEAR(0.0, orientation_variable->yaw(), 1.0e-3);
+  EXPECT_NEAR(0.0, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
@@ -223,91 +223,20 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
 }
 
-// Temporarily disable this unit test. This should be fixed by PR #335.
-// TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
-// {
-//   // Optimize a single orientation at +PI and single constraint, verify the expected value and
-//   // covariance are generated.
-//
-//   // Create the variables
-//   auto orientation_variable = Orientation2DStamped::make_shared(
-//     rclcpp::Time(1, 0),
-//     fuse_core::uuid::generate("spra"));
-//   orientation_variable->yaw() = M_PI;
-//
-//   // Create an absolute orientation constraint
-//   fuse_core::Vector1d mean;
-//   mean << M_PI;
-//
-//   fuse_core::Matrix1d cov;
-//   cov << 1.0;
-//   auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
-//     "test",
-//     *orientation_variable,
-//     mean,
-//     cov);
-//
-//   // Build the problem
-//   ceres::Problem::Options problem_options;
-//   problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
-//   ceres::Problem problem(problem_options);
-//   problem.AddParameterBlock(
-//     orientation_variable->data(),
-//     orientation_variable->size(),
-// #if !CERES_SUPPORTS_MANIFOLDS
-//     orientation_variable->localParameterization());
-// #else
-//     orientation_variable->manifold());
-// #endif
-//
-//   std::vector<double *> parameter_blocks;
-//   parameter_blocks.push_back(orientation_variable->data());
-//   problem.AddResidualBlock(
-//     constraint->costFunction(),
-//     constraint->lossFunction(),
-//     parameter_blocks);
-//
-//   // Run the solver
-//   ceres::Solver::Options options;
-//   ceres::Solver::Summary summary;
-//   ceres::Solve(options, &problem, &summary);
-//   EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
-//
-//   // Check
-//   // We expect +PI to roll over to -PI because our range is [-PI, PI)
-//   EXPECT_NEAR(-M_PI, orientation_variable->yaw(), 1.0e-3);
-//
-//   // Compute the covariance
-//   std::vector<std::pair<const double *, const double *>> covariance_blocks;
-//   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
-//   ceres::Covariance::Options cov_options;
-//   ceres::Covariance covariance(cov_options);
-//   covariance.Compute(covariance_blocks, &problem);
-//   fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(),
-//     orientation_variable->localSize());
-//   covariance.GetCovarianceBlockInTangentSpace(
-//     orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
-//
-//   // Define the expected covariance
-//   fuse_core::Matrix1d expected_covariance;
-//   expected_covariance << 1.0;
-//   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
-// }
-
-TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
+TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
 {
-  // Optimize a single orientation at -PI and single constraint, verify the expected value and
+  // Optimize a single orientation at +PI and single constraint, verify the expected value and
   // covariance are generated.
 
   // Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(
-    rclcpp::Time(1, 0),
-    fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = -M_PI;
+    rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(M_PI);
 
   // Create an absolute orientation constraint
   fuse_core::VectorXd mean(1);
-  mean << -M_PI;
+  mean << M_PI;
+
   fuse_core::MatrixXd cov(1, 1);
   cov << 1.0;
   auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
@@ -343,7 +272,8 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
   EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
 
   // Check
-  EXPECT_NEAR(-M_PI, orientation_variable->yaw(), 1.0e-3);
+  // We expect +PI to roll over to -PI because our range is [-PI, PI)
+  EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
@@ -351,13 +281,81 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
-  fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(),
+  fuse_core::MatrixXd actual_covariance(orientation_variable->localSize(),
     orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
     orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
 
   // Define the expected covariance
-  fuse_core::Matrix1d expected_covariance;
+  fuse_core::MatrixXd expected_covariance(1, 1);
+  expected_covariance << 1.0;
+  EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
+}
+
+TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
+{
+  // Optimize a single orientation at -PI and single constraint, verify the expected value and
+  // covariance are generated.
+
+  // Create the variables
+  auto orientation_variable = Orientation2DStamped::make_shared(
+    rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
+  orientation_variable->setYaw(-M_PI);
+
+  // Create an absolute orientation constraint
+  fuse_core::VectorXd mean(1);
+  mean << -M_PI;
+
+  fuse_core::MatrixXd cov(1, 1);
+  cov << 1.0;
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
+    "test",
+    *orientation_variable,
+    mean,
+    cov);
+
+  // Build the problem
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
+  ceres::Problem problem(problem_options);
+  problem.AddParameterBlock(
+    orientation_variable->data(),
+    orientation_variable->size(),
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization());
+#else
+    orientation_variable->manifold());
+#endif
+
+  std::vector<double *> parameter_blocks;
+  parameter_blocks.push_back(orientation_variable->data());
+  problem.AddResidualBlock(
+    constraint->costFunction(),
+    constraint->lossFunction(),
+    parameter_blocks);
+
+  // Run the solver
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  EXPECT_TRUE(summary.IsSolutionUsable()) << summary.FullReport();
+
+  // Check
+  EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
+
+  // Compute the covariance
+  std::vector<std::pair<const double *, const double *>> covariance_blocks;
+  covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
+  ceres::Covariance::Options cov_options;
+  ceres::Covariance covariance(cov_options);
+  covariance.Compute(covariance_blocks, &problem);
+  fuse_core::MatrixXd actual_covariance(orientation_variable->localSize(),
+    orientation_variable->localSize());
+  covariance.GetCovarianceBlockInTangentSpace(
+    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+
+  // Define the expected covariance
+  fuse_core::MatrixXd expected_covariance(1, 1);
   expected_covariance << 1.0;
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-3);
 }

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -100,7 +100,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
   // generated. Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 0.8;
+  orientation_variable->setYaw(0.8);
   auto position_variable = Position2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
   position_variable->x() = 1.5;
@@ -150,7 +150,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
   // Check
   EXPECT_NEAR(1.0, position_variable->x(), 1.0e-5);
   EXPECT_NEAR(2.0, position_variable->y(), 1.0e-5);
-  EXPECT_NEAR(3.0, orientation_variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation_variable->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
   covariance_blocks.emplace_back(position_variable->data(), position_variable->data());
@@ -193,7 +193,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   // generated. Create the variables
   auto orientation_variable = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
-  orientation_variable->yaw() = 0.8;
+  orientation_variable->setYaw(0.8);
   auto position_variable = Position2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("spra"));
   position_variable->x() = 1.5;
@@ -271,7 +271,7 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   // Check
   EXPECT_NEAR(1.0, position_variable->x(), 1.0e-5);
   EXPECT_NEAR(2.0, position_variable->y(), 1.0e-5);
-  EXPECT_NEAR(3.0, orientation_variable->yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation_variable->getYaw(), 1.0e-5);
 
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -460,11 +460,11 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   auto x1 = fuse_variables::Orientation2DStamped::make_shared(
     rclcpp::Time(1234, 5678),
     fuse_core::uuid::generate("t800"));
-  x1->yaw() = 0.7;
+  x1->setYaw(0.7);
   auto x2 = fuse_variables::Orientation2DStamped::make_shared(
     rclcpp::Time(1235, 5678),
     fuse_core::uuid::generate("t800"));
-  x2->yaw() = -2.2;
+  x2->setYaw(-2.2);
   // Create an absolute constraint
   fuse_core::VectorXd mean(1);
   mean << 1.0;
@@ -524,8 +524,8 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
   // Check
-  EXPECT_NEAR(1.0, x1->yaw(), 1.0e-5);
-  EXPECT_NEAR(1.1, x2->yaw(), 1.0e-5);
+  EXPECT_NEAR(1.0, x1->getYaw(), 1.0e-5);
+  EXPECT_NEAR(1.1, x2->getYaw(), 1.0e-5);
   // Compute the covariance
   std::vector<std::pair<const double *, const double *>> covariance_blocks;
   covariance_blocks.emplace_back(x1->data(), x1->data());

--- a/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
@@ -111,14 +111,14 @@ TEST(RelativePose2DStampedConstraint, OptimizationFull)
   // Create two poses
   auto orientation1 = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation1->yaw() = 0.8;
+  orientation1->setYaw(0.8);
   auto position1 =
     Position2DStamped::make_shared(rclcpp::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
   position1->x() = 1.5;
   position1->y() = -3.0;
   auto orientation2 = Orientation2DStamped::make_shared(
     rclcpp::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation2->yaw() = -2.7;
+  orientation2->setYaw(-2.7);
   auto position2 =
     Position2DStamped::make_shared(rclcpp::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
   position2->x() = 3.7;
@@ -206,10 +206,10 @@ TEST(RelativePose2DStampedConstraint, OptimizationFull)
   // Check
   EXPECT_NEAR(0.0, position1->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position1->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation1->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation1->getYaw(), 1.0e-5);
   EXPECT_NEAR(1.0, position2->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position2->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation2->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation2->getYaw(), 1.0e-5);
   // Compute the marginal covariance for pose1
   {
     std::vector<std::pair<const double *, const double *>> covariance_blocks;
@@ -286,7 +286,7 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
   // Create two poses
   auto orientation1 = Orientation2DStamped::make_shared(
     rclcpp::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation1->yaw() = 0.8;
+  orientation1->setYaw(0.8);
   auto position1 =
     Position2DStamped::make_shared(rclcpp::Time(1, 0), fuse_core::uuid::generate("3b6ra7"));
   position1->x() = 1.5;
@@ -294,7 +294,7 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
 
   auto orientation2 = Orientation2DStamped::make_shared(
     rclcpp::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
-  orientation2->yaw() = -2.7;
+  orientation2->setYaw(-2.7);
   auto position2 =
     Position2DStamped::make_shared(rclcpp::Time(2, 0), fuse_core::uuid::generate("3b6ra7"));
   position2->x() = 3.7;
@@ -415,10 +415,10 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
   // Check
   EXPECT_NEAR(0.0, position1->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position1->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation1->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation1->getYaw(), 1.0e-5);
   EXPECT_NEAR(1.0, position2->x(), 1.0e-5);
   EXPECT_NEAR(0.0, position2->y(), 1.0e-5);
-  EXPECT_NEAR(0.0, orientation2->yaw(), 1.0e-5);
+  EXPECT_NEAR(0.0, orientation2->getYaw(), 1.0e-5);
 
   // Compute the marginal covariance for pose1
   {

--- a/fuse_models/include/fuse_models/common/sensor_proc.hpp
+++ b/fuse_models/include/fuse_models/common/sensor_proc.hpp
@@ -326,7 +326,7 @@ inline bool processAbsolutePoseWithCovariance(
     fuse_variables::Orientation2DStamped::make_shared(pose.header.stamp, device_id);
   position->x() = absolute_pose_2d.x();
   position->y() = absolute_pose_2d.y();
-  orientation->yaw() = absolute_pose_2d.yaw();
+  orientation->setYaw(absolute_pose_2d.yaw());
 
   // Create the pose for the constraint
   fuse_core::VectorXd pose_mean(3);
@@ -448,7 +448,7 @@ inline bool processDifferentialPoseWithCovariance(
     fuse_variables::Orientation2DStamped::make_shared(pose1.header.stamp, device_id);
   position1->x() = pose1_2d.x();
   position1->y() = pose1_2d.y();
-  orientation1->yaw() = pose1_2d.yaw();
+  orientation1->setYaw(pose1_2d.yaw());
 
   auto position2 = fuse_variables::Position2DStamped::make_shared(pose2.header.stamp, device_id);
   auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(
@@ -456,7 +456,7 @@ inline bool processDifferentialPoseWithCovariance(
     device_id);
   position2->x() = pose2_2d.x();
   position2->y() = pose2_2d.y();
-  orientation2->yaw() = pose2_2d.yaw();
+  orientation2->setYaw(pose2_2d.yaw());
 
   // Create the delta for the constraint
   const double sy = ::sin(-pose1_2d.yaw());
@@ -813,7 +813,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
     fuse_variables::Orientation2DStamped::make_shared(pose1.header.stamp, device_id);
   position1->x() = pose1_2d.x();
   position1->y() = pose1_2d.y();
-  orientation1->yaw() = pose1_2d.yaw();
+  orientation1->setYaw(pose1_2d.yaw());
 
   auto position2 = fuse_variables::Position2DStamped::make_shared(pose2.header.stamp, device_id);
   auto orientation2 = fuse_variables::Orientation2DStamped::make_shared(
@@ -821,7 +821,7 @@ inline bool processDifferentialPoseWithTwistCovariance(
     device_id);
   position2->x() = pose2_2d.x();
   position2->y() = pose2_2d.y();
-  orientation2->yaw() = pose2_2d.yaw();
+  orientation2->setYaw(pose2_2d.yaw());
 
   // Create the delta for the constraint
   const auto delta = pose1_2d.inverseTimes(pose2_2d);

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -322,7 +322,7 @@ bool Odometry2DPublisher::getState(
     odometry.pose.pose.position.x = position_variable.x();
     odometry.pose.pose.position.y = position_variable.y();
     odometry.pose.pose.position.z = 0.0;
-    odometry.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.yaw()));
+    odometry.pose.pose.orientation = tf2::toMsg(tf2_2d::Rotation(orientation_variable.getYaw()));
     odometry.twist.twist.linear.x = velocity_linear_variable.x();
     odometry.twist.twist.linear.y = velocity_linear_variable.y();
     odometry.twist.twist.linear.z = 0.0;

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -315,11 +315,12 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::msg::PoseWithCovarianceS
   position->x() = pose.pose.pose.position.x;
   position->y() = pose.pose.pose.position.y;
   auto orientation = fuse_variables::Orientation2DStamped::make_shared(stamp, device_id_);
-  orientation->yaw() = fuse_core::getYaw(
-    pose.pose.pose.orientation.w,
-    pose.pose.pose.orientation.x,
-    pose.pose.pose.orientation.y,
-    pose.pose.pose.orientation.z);
+  orientation->setYaw(
+    fuse_core::getYaw(
+      pose.pose.pose.orientation.w,
+      pose.pose.pose.orientation.x,
+      pose.pose.pose.orientation.y,
+      pose.pose.pose.orientation.z));
   auto linear_velocity = fuse_variables::VelocityLinear2DStamped::make_shared(stamp, device_id_);
   linear_velocity->x() = params_.initial_state[3];
   linear_velocity->y() = params_.initial_state[4];
@@ -340,7 +341,7 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::msg::PoseWithCovarianceS
   position_cov << pose.pose.covariance[0], pose.pose.covariance[1],
     pose.pose.covariance[6], pose.pose.covariance[7];
   auto orientation_mean = fuse_core::VectorXd(1);
-  orientation_mean << orientation->yaw();
+  orientation_mean << orientation->getYaw();
   auto orientation_cov = fuse_core::MatrixXd(1, 1);
   orientation_cov << pose.pose.covariance[35];
   auto linear_velocity_mean = fuse_core::VectorXd(2);
@@ -411,7 +412,7 @@ void Unicycle2DIgnition::sendPrior(const geometry_msgs::msg::PoseWithCovarianceS
     logger_,
     "Received a set_pose request (stamp: " << rclcpp::Time(stamp).nanoseconds()
                                            << ", x: " << position->x() << ", y: "
-                                           << position->y() << ", yaw: " << orientation->yaw() <<
+                                           << position->y() << ", yaw: " << orientation->getYaw() <<
       ")");
 }
 

--- a/fuse_models/test/test_unicycle_2d.cpp
+++ b/fuse_models/test/test_unicycle_2d.cpp
@@ -37,7 +37,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
     fuse_variables::AccelerationLinear2DStamped::make_shared(rclcpp::Time(1, 0));
   position1->x() = 1.1;
   position1->y() = 2.1;
-  yaw1->yaw() = 3.1;
+  yaw1->setYaw(3.1);
   linear_velocity1->x() = 1.0;
   linear_velocity1->y() = 0.0;
   yaw_velocity1->yaw() = 0.0;
@@ -51,7 +51,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
     fuse_variables::AccelerationLinear2DStamped::make_shared(rclcpp::Time(2, 0));
   position2->x() = 1.2;
   position2->y() = 2.2;
-  yaw2->yaw() = M_PI / 2.0;
+  yaw2->setYaw(M_PI / 2.0);
   linear_velocity2->x() = 0.0;
   linear_velocity2->y() = 1.0;
   yaw_velocity2->yaw() = 0.0;
@@ -65,7 +65,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
     fuse_variables::AccelerationLinear2DStamped::make_shared(rclcpp::Time(3, 0));
   position3->x() = 1.3;
   position3->y() = 2.3;
-  yaw3->yaw() = 3.3;
+  yaw3->setYaw(3.3);
   linear_velocity3->x() = 4.3;
   linear_velocity3->y() = 5.3;
   yaw_velocity3->yaw() = 6.3;
@@ -79,7 +79,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
     fuse_variables::AccelerationLinear2DStamped::make_shared(rclcpp::Time(4, 0));
   position4->x() = 1.4;
   position4->y() = 2.4;
-  yaw4->yaw() = 3.4;
+  yaw4->setYaw(3.4);
   linear_velocity4->x() = 4.4;
   linear_velocity4->y() = 5.4;
   yaw_velocity4->yaw() = 6.4;
@@ -93,7 +93,7 @@ TEST(Unicycle2D, UpdateStateHistoryEstimates)
     fuse_variables::AccelerationLinear2DStamped::make_shared(rclcpp::Time(5, 0));
   position5->x() = 1.5;
   position5->y() = 2.5;
-  yaw5->yaw() = 3.5;
+  yaw5->setYaw(3.5);
   linear_velocity5->x() = 4.5;
   linear_velocity5->y() = 5.5;
   yaw_velocity5->yaw() = 6.5;

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -132,7 +132,7 @@ void Path2DPublisher::notifyCallback(
       pose.pose.position.y = position->y();
       pose.pose.position.z = 0.0;
       pose.pose.orientation =
-        tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation->yaw()));
+        tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation->getYaw()));
       poses.push_back(std::move(pose));
     }
   }

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -83,7 +83,7 @@ bool findPose(
     pose.position.y = position_variable.y();
     pose.position.z = 0.0;
     pose.orientation =
-      tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation_variable.yaw()));
+      tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), orientation_variable.getYaw()));
   } catch (const std::exception & e) {
     RCLCPP_WARN_STREAM_THROTTLE(
       logger, clock, 10.0 * 1000,

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -76,28 +76,28 @@ public:
     position1->y() = 2.01;
     auto orientation1 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1234, 10, RCL_ROS_TIME));
-    orientation1->yaw() = 3.01;
+    orientation1->setYaw(3.01);
     auto position2 =
       fuse_variables::Position2DStamped::make_shared(rclcpp::Time(1235, 10, RCL_ROS_TIME));
     position2->x() = 1.02;
     position2->y() = 2.02;
     auto orientation2 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1235, 10, RCL_ROS_TIME));
-    orientation2->yaw() = 3.02;
+    orientation2->setYaw(3.02);
     auto position3 =
       fuse_variables::Position2DStamped::make_shared(rclcpp::Time(1235, 9, RCL_ROS_TIME));
     position3->x() = 1.03;
     position3->y() = 2.03;
     auto orientation3 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1235, 9, RCL_ROS_TIME));
-    orientation3->yaw() = 3.03;
+    orientation3->setYaw(3.03);
     auto position4 = fuse_variables::Position2DStamped::make_shared(
       rclcpp::Time(1235, 11, RCL_ROS_TIME), fuse_core::uuid::generate("kitt"));
     position4->x() = 1.04;
     position4->y() = 2.04;
     auto orientation4 = fuse_variables::Orientation2DStamped::make_shared(
       rclcpp::Time(1235, 11, RCL_ROS_TIME), fuse_core::uuid::generate("kitt"));
-    orientation4->yaw() = 3.04;
+    orientation4->setYaw(3.04);
 
     transaction_->addInvolvedStamp(position1->stamp());
     transaction_->addInvolvedStamp(orientation1->stamp());

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -79,21 +79,21 @@ public:
     position1->y() = 2.01;
     auto orientation1 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1234, 10, RCL_ROS_TIME));
-    orientation1->yaw() = 3.01;
+    orientation1->setYaw(3.01);
     auto position2 =
       fuse_variables::Position2DStamped::make_shared(rclcpp::Time(1235, 10, RCL_ROS_TIME));
     position2->x() = 1.02;
     position2->y() = 2.02;
     auto orientation2 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1235, 10, RCL_ROS_TIME));
-    orientation2->yaw() = 3.02;
+    orientation2->setYaw(3.02);
     auto position3 =
       fuse_variables::Position2DStamped::make_shared(rclcpp::Time(1235, 9, RCL_ROS_TIME));
     position3->x() = 1.03;
     position3->y() = 2.03;
     auto orientation3 =
       fuse_variables::Orientation2DStamped::make_shared(rclcpp::Time(1235, 9, RCL_ROS_TIME));
-    orientation3->yaw() = 3.03;
+    orientation3->setYaw(3.03);
     auto position4 = fuse_variables::Position2DStamped::make_shared(
       rclcpp::Time(1235, 11, RCL_ROS_TIME),
       fuse_core::uuid::generate("kitt"));
@@ -102,7 +102,7 @@ public:
     auto orientation4 = fuse_variables::Orientation2DStamped::make_shared(
       rclcpp::Time(1235, 11, RCL_ROS_TIME),
       fuse_core::uuid::generate("kitt"));
-    orientation4->yaw() = 3.04;
+    orientation4->setYaw(3.04);
 
     transaction_->addInvolvedStamp(position1->stamp());
     transaction_->addInvolvedStamp(orientation1->stamp());

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.hpp
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.hpp
@@ -233,12 +233,28 @@ public:
   /**
    * @brief Read-write access to the heading angle.
    */
+  [[deprecated(
+      "Yaw must be in the range [-pi, pi). Use the setYaw(value) method to ensure minimum phase.")
+    ]]
   double & yaw() {return data_[YAW];}
 
   /**
    * @brief Read-only access to the heading angle.
    */
+  [[deprecated(
+    "Use the getYaw()/setYaw(value) methods to ensure const-correctness.")
+  ]]
   const double & yaw() const {return data_[YAW];}
+
+  /**
+   * @brief Read-only access to the heading angle.
+   */
+  const double & getYaw() const {return data_[YAW];}
+
+  /**
+   * @brief Write access to the heading angle.
+   */
+  void setYaw(const double yaw) {data_[YAW] = yaw;}
 
   /**
    * @brief Print a human-readable description of the variable to the provided stream.

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.hpp
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.hpp
@@ -254,7 +254,7 @@ public:
   /**
    * @brief Write access to the heading angle.
    */
-  void setYaw(const double yaw) {data_[YAW] = yaw;}
+  void setYaw(const double yaw) {data_[YAW] = fuse_core::wrapAngle2D(yaw);}
 
   /**
    * @brief Print a human-readable description of the variable to the provided stream.

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -62,7 +62,7 @@ void Orientation2DStamped::print(std::ostream & stream) const
          << "  device_id: " << deviceId() << "\n"
          << "  size: " << size() << "\n"
          << "  data:\n"
-         << "  - yaw: " << yaw() << "\n";
+         << "  - yaw: " << getYaw() << "\n";
 }
 
 fuse_core::LocalParameterization * Orientation2DStamped::localParameterization() const

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -243,7 +243,7 @@ TEST(Orientation2DStamped, Optimization)
   // Create a Orientation2DStamped
   Orientation2DStamped orientation(
     rclcpp::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
-  orientation.yaw() = 1.5;
+  orientation.setYaw(1.5);
 
   // Create a simple a constraint
   ceres::CostFunction * cost_function = new ceres::AutoDiffCostFunction<CostFunctor, 1, 1>(
@@ -272,7 +272,7 @@ TEST(Orientation2DStamped, Optimization)
   ceres::Solve(options, &problem, &summary);
 
   // Check
-  EXPECT_NEAR(3.0, orientation.yaw(), 1.0e-5);
+  EXPECT_NEAR(3.0, orientation.getYaw(), 1.0e-5);
 }
 
 TEST(Orientation2DStamped, Serialization)
@@ -280,7 +280,7 @@ TEST(Orientation2DStamped, Serialization)
   // Create a Orientation2DStamped
   Orientation2DStamped expected(
     rclcpp::Time(12345678, 910111213), fuse_core::uuid::generate("hal9000"));
-  expected.yaw() = 1.5;
+  expected.setYaw(1.5);
 
   // Serialize the variable into an archive
   std::stringstream stream;
@@ -299,7 +299,7 @@ TEST(Orientation2DStamped, Serialization)
   // Compare
   EXPECT_EQ(expected.deviceId(), actual.deviceId());
   EXPECT_EQ(expected.stamp(), actual.stamp());
-  EXPECT_EQ(expected.yaw(), actual.yaw());
+  EXPECT_EQ(expected.getYaw(), actual.getYaw());
 }
 
 #if CERES_SUPPORTS_MANIFOLDS

--- a/fuse_viz/include/fuse_viz/conversions.hpp
+++ b/fuse_viz/include/fuse_viz/conversions.hpp
@@ -90,7 +90,7 @@ inline tf2::Vector3 toTF(const fuse_variables::Position2DStamped & position)
 
 inline tf2::Quaternion toTF(const fuse_variables::Orientation2DStamped & orientation)
 {
-  return {tf2::Vector3{0, 0, 1}, orientation.yaw()};
+  return {tf2::Vector3{0, 0, 1}, orientation.getYaw()};
 }
 
 inline tf2::Transform toTF(


### PR DESCRIPTION
Ported fix for optimization errors when the orientation is initialized at +PI (https://github.com/locusrobotics/fuse/pull/334) from ROS1 to ROS2