### PR TITLE
Fix openmp compile error

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -12,6 +12,8 @@ set(build_depends
   std_srvs
 )
 
+find_package(OpenMP)
+
 find_package(catkin REQUIRED COMPONENTS
   ${build_depends}
 )
@@ -47,11 +49,15 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  ${OpenMP_CXX_LIBRARIES}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED YES
+)
+target_compile_options(${PROJECT_NAME}
+  PRIVATE ${OpenMP_CXX_FLAGS}
 )
 
 ## batch_optimizer node


### PR DESCRIPTION
Fixes the following error when compiling:

```
/usr/bin/ld: /usr/local/lib/libceres.a(local_parameterization.cc.o): undefined reference to symbol 'omp_get_max_threads@@OMP_1.0'
/usr/bin/ld: /lib/x86_64-linux-gnu/libgomp.so.1: error adding symbols: DSO missing from command line
```
