### PR TITLE
Support gcc12 and ceres 2.1.0

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -105,6 +105,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -35,7 +35,47 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror)
+
+# Disable warnings about array bounds with -Wno-array-bounds until gcc 12 fixes this bug:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247
+#
+# Also reported in Eigen, and confirmed to be due to gcc 12:
+# https://gitlab.com/libeigen/eigen/-/issues/2506
+#
+# In file included from include/immintrin.h:43,
+#                  from include/eigen3/Eigen/src/Core/util/ConfigureVectorization.h:361,
+#                  from include/eigen3/Eigen/Core:22,
+#                  from include/fuse_core/fuse_macros.h:63,
+#                  from include/fuse_core/loss.h:37,
+#                  from include/fuse_core/constraint.h:37,
+#                  from src/fuse/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h:37,
+#                  from src/fuse/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp:34:
+# In function ‘__m256d _mm256_loadu_pd(const double*)’,
+#     inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double]’ at include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:582:129,
+#     inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double; int Alignment = 0]’ at include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
+#     inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index) const [with int LoadMode = 0; PacketType = __vector(4) double; Derived = Eigen::Matrix<double, 3, 1>]’ at include/eigen3/Eigen/src/Core/CoreEvaluators.h:245:40,
+#     inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacket(Eigen::Index) [with int StoreMode = 32; int LoadMode = 0; PacketType = __vector(4) double; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Map<Eigen::Matrix<double, -1, 1> > >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:681:114,
+#     inlined from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 3, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Map<Eigen::Matrix<double, -1, 1> > >, Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >, Eigen::internal::assign_op<double, double>, 0>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:437:75,
+#     inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Map<Eigen::Matrix<double, -1, 1> >; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
+#     inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Map<Eigen::Matrix<double, -1, 1> >; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = Eigen::internal::assign_op<double, double>; Weak = void]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
+#     inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Matrix<double, 3, 1>; Func = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
+#     inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename enable_if<evaluator_assume_aliasing<Src>::value, void*>::type) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>; Func = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:851:27,
+#     inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:836:18,
+#     inlined from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>; Derived = Eigen::Map<Eigen::Matrix<double, -1, 1> >]’ at include/eigen3/Eigen/src/Core/Assign.h:66:28,
+#     inlined from ‘void Eigen::EigenBase<Derived>::applyThisOnTheLeft(Dest&) const [with Dest = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Derived = Eigen::Matrix<double, 3, 3, 1>]’ at include/eigen3/Eigen/src/Core/EigenBase.h:114:9:
+# include/avxintrin.h:893:24: error: array subscript ‘__m256d_u[0]’ is partly outside array bounds of ‘Eigen::internal::plain_matrix_type<Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>, Eigen::Dense>::type [1]’ {aka ‘Eigen::Matrix<double, 3, 1> [1]’} [-Werror=array-bounds]
+#   893 |   return *(__m256d_u *)__P;
+#       |                        ^~~
+# In file included from include/eigen3/Eigen/Core:278:
+# include/eigen3/Eigen/src/Core/AssignEvaluator.h: In member function ‘void Eigen::EigenBase<Derived>::applyThisOnTheLeft(Dest&) const [with Dest = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Derived = Eigen::Matrix<double, 3, 3, 1>]’:
+# include/eigen3/Eigen/src/Core/AssignEvaluator.h:850:41: note: at offset [0, 16] into object ‘tmp’ of size 24
+#   850 |   typename plain_matrix_type<Src>::type tmp(src);
+#       |                                         ^~~
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+  add_compile_options(-Wall -Werror -Wno-array-bounds)
+else()
+  add_compile_options(-Wall -Werror)
+endif()
 
 # fuse_constraints library
 add_library(${PROJECT_NAME}

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -121,7 +121,7 @@ public:
    */
   const std::vector<fuse_core::VectorXd>& x_bar() const { return x_bar_; }
 
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   /**
    * @brief Read-only access to the variable local parameterizations
    */
@@ -157,7 +157,7 @@ public:
 protected:
   std::vector<fuse_core::MatrixXd> A_;  //!< The A matrices of the marginal constraint
   fuse_core::VectorXd b_;  //!< The b vector of the marginal constraint
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   std::vector<fuse_core::LocalParameterization::SharedPtr> local_parameterizations_;  //!< Parameterizations
 #else
   std::vector<fuse_core::Manifold::SharedPtr> manifolds_;  //!< Manifolds
@@ -180,7 +180,7 @@ private:
     archive& boost::serialization::base_object<fuse_core::Constraint>(*this);
     archive& A_;
     archive& b_;
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     archive& local_parameterizations_;
 #else
     archive& manifolds_;
@@ -207,7 +207,7 @@ inline const fuse_core::VectorXd getCurrentValue(const fuse_core::Variable& vari
   return Eigen::Map<const fuse_core::VectorXd>(variable.data(), variable.size());
 }
 
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
 /**
  * @brief Return the local parameterization of the provided variable
  */
@@ -215,6 +215,7 @@ inline fuse_core::LocalParameterization::SharedPtr const getLocalParameterizatio
 {
   return fuse_core::LocalParameterization::SharedPtr(variable.localParameterization());
 }
+
 #else
 /**
  * @brief Return the manifold of the provided variable
@@ -241,7 +242,7 @@ MarginalConstraint::MarginalConstraint(
     boost::make_transform_iterator(last_variable, &fuse_constraints::detail::getUuid)),
   A_(first_A, last_A),
   b_(b),
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   local_parameterizations_(
     boost::make_transform_iterator(first_variable, &fuse_constraints::detail::getLocalParameterization),
     boost::make_transform_iterator(last_variable, &fuse_constraints::detail::getLocalParameterization)),
@@ -256,7 +257,7 @@ MarginalConstraint::MarginalConstraint(
 {
   assert(!A_.empty());
   assert(A_.size() == x_bar_.size());
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   assert(A_.size() == local_parameterizations_.size());
 #else
   assert(A_.size() == manifolds_.size());

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -123,7 +123,7 @@ public:
    */
   const std::vector<fuse_core::VectorXd>& x_bar() const { return x_bar_; }
 
-  #if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Read-only access to the variable local parameterizations
    */
@@ -131,7 +131,7 @@ public:
   {
     return local_parameterizations_;
   }
-  #else 
+#else 
   /**
    * @brief Read-only access to the variable local parameterizations
    */
@@ -139,7 +139,7 @@ public:
   {
     return manifolds_;
   }
-  #endif
+#endif
 
   /**
    * @brief Print a human-readable description of the constraint to the provided stream.
@@ -163,9 +163,9 @@ protected:
   std::vector<fuse_core::MatrixXd> A_;  //!< The A matrices of the marginal constraint
   fuse_core::VectorXd b_;  //!< The b vector of the marginal constraint
 #if !CERES_VERSION_AT_LEAST(2, 1, 0)
-  const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
+  std::vector<fuse_core::LocalParameterization::SharedPtr> local_parameterizations_;  //!< Parameterizations
 #else
-  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Manifolds
+  std::vector<fuse_core::Manifold::SharedPtr> manifolds_;  //!< Manifolds
 #endif
   std::vector<fuse_core::VectorXd> x_bar_;  //!< The linearization point of each involved variable
 

--- a/fuse_constraints/include/fuse_constraints/marginal_constraint.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_constraint.h
@@ -262,12 +262,13 @@ MarginalConstraint::MarginalConstraint(
   assert(A_.size() == manifolds_.size());
 #endif
   assert(b_.rows() > 0);
-  assert(std::all_of(A_.begin(), A_.end(), [this](const auto& A) { return A.rows() == this->b_.rows(); }));  // NOLINT
-  assert(std::all_of(
-    boost::make_zip_iterator(boost::make_tuple(A_.begin(), first_variable)),
-    boost::make_zip_iterator(boost::make_tuple(A_.end(), last_variable)),
-    [](const boost::tuple<const fuse_core::MatrixXd&, const fuse_core::Variable&>& tuple)  // NOLINT
-    { return static_cast<size_t>(tuple.get<0>().cols()) == tuple.get<1>().localSize(); }));  // NOLINT
+  assert(std::all_of(A_.begin(), A_.end(), [this](const auto& A){ return A.rows() == this->b_.rows(); }));  // NOLINT
+  assert(std::all_of(boost::make_zip_iterator(boost::make_tuple(A_.begin(), first_variable)),
+                     boost::make_zip_iterator(boost::make_tuple(A_.end(), last_variable)),
+                     [](const boost::tuple<const fuse_core::MatrixXd&, const fuse_core::Variable&>& tuple)  // NOLINT
+                     {
+                       return static_cast<size_t>(tuple.get<0>().cols()) == tuple.get<1>().localSize();
+                     }));  // NOLINT
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -42,10 +42,8 @@
 
 #include <vector>
 
-
 namespace fuse_constraints
 {
-
 /**
  * @brief Implements a cost function designed for precomputed marginal distributions
  *
@@ -57,7 +55,7 @@ namespace fuse_constraints
  *
  * where, the A matrices and the b vector are fixed, x_bar is the linearization point used when calculating the A
  * matrices and b vector, and the minus operator in (x - x_bar) is provided by the variable's local parameterization.
- * 
+ *
  * The A matrices can have any number of rows, but they must all be the same. The number of columns of each A matrix
  * must match the associated variable's local parameterization size, and the number of rows of each x_bar must match
  * the associated variable's global size. The cost function will have the same number of residuals as the rows of A.
@@ -104,10 +102,7 @@ public:
    * @brief Compute the cost values/residuals, and optionally the Jacobians, using the provided variable/parameter
    *        values
    */
-  bool Evaluate(
-    double const* const* parameters,
-    double* residuals,
-    double** jacobians) const override;
+  bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override;
 
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -115,7 +115,7 @@ private:
 #if !CERES_VERSION_AT_LEAST(2, 1, 0)
   const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
 #else
-  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Parameterizations
+  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Manifolds
 #endif
   const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
 };

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -63,7 +63,7 @@ namespace fuse_constraints
 class MarginalCostFunction : public ceres::CostFunction
 {
 public:
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   /**
    * @brief Construct a cost function instance
    *
@@ -107,7 +107,7 @@ public:
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
   const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
 #else
   const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Manifolds

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -36,6 +36,7 @@
 
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/manifold.h>
 
 #include <ceres/cost_function.h>
 
@@ -64,6 +65,7 @@ namespace fuse_constraints
 class MarginalCostFunction : public ceres::CostFunction
 {
 public:
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Construct a cost function instance
    *
@@ -77,6 +79,21 @@ public:
     const fuse_core::VectorXd& b,
     const std::vector<fuse_core::VectorXd>& x_bar,
     const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations);
+#else
+  /**
+   * @brief Construct a cost function instance
+   *
+   * @param[in] A                       The A matrix of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] b                       The b vector of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] x_bar                   The linearization point of the involved variables
+   * @param[in] manifolds               The manifold associated with the variable
+   */
+  MarginalCostFunction(
+    const std::vector<fuse_core::MatrixXd>& A,
+    const fuse_core::VectorXd& b,
+    const std::vector<fuse_core::VectorXd>& x_bar,
+    const std::vector<fuse_core::Manifold::SharedPtr>& manifolds);
+#endif
 
   /**
    * @brief Destructor
@@ -95,7 +112,11 @@ public:
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
   const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
+#else
+  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Parameterizations
+#endif
   const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
 };
 

--- a/fuse_constraints/include/fuse_constraints/marginalize_variables.h
+++ b/fuse_constraints/include/fuse_constraints/marginalize_variables.h
@@ -39,7 +39,6 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/local_parameterization.h>
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>

--- a/fuse_constraints/include/fuse_constraints/marginalize_variables.h
+++ b/fuse_constraints/include/fuse_constraints/marginalize_variables.h
@@ -38,8 +38,8 @@
 #include <fuse_constraints/uuid_ordering.h>
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/graph.h>
 #include <fuse_core/fuse_macros.h>
+#include <fuse_core/graph.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>
 
@@ -53,10 +53,8 @@
 #include <string>
 #include <vector>
 
-
 namespace fuse_constraints
 {
-
 /**
  * @brief Compute an efficient elimination order for the marginalized variables
  *
@@ -128,7 +126,6 @@ fuse_core::Transaction marginalizeVariables(
 
 namespace detail
 {
-
 /**
  * @brief Structure holding linearized Jacobian blocks
  *

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -37,15 +37,13 @@
 #include <fuse_core/constraint.h>
 #include <pluginlib/class_list_macros.hpp>
 
-#include <boost/serialization/export.hpp>
 #include <Eigen/Core>
+#include <boost/serialization/export.hpp>
 
 #include <ostream>
 
-
 namespace fuse_constraints
 {
-
 void MarginalConstraint::print(std::ostream& stream) const
 {
   stream << type() << "\n"
@@ -59,8 +57,10 @@ void MarginalConstraint::print(std::ostream& stream) const
   Eigen::IOFormat indent(4, 0, ", ", "\n", "   [", "]");
   for (size_t i = 0; i < A().size(); ++i)
   {
-    stream << "  A[" << i << "]:\n" << A()[i].format(indent) << "\n"
-           << "  x_bar[" << i << "]:\n" << x_bar()[i].format(indent) << "\n";
+    stream << "  A[" << i << "]:\n"
+           << A()[i].format(indent) << "\n"
+           << "  x_bar[" << i << "]:\n"
+           << x_bar()[i].format(indent) << "\n";
   }
   stream << "  b:\n" << b().format(indent) << "\n";
 

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -73,7 +73,11 @@ void MarginalConstraint::print(std::ostream& stream) const
 
 ceres::CostFunction* MarginalConstraint::costFunction() const
 {
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   return new MarginalCostFunction(A_, b_, x_bar_, local_parameterizations_);
+#else
+  return new MarginalCostFunction(A_, b_, x_bar_, manifolds_);
+#endif
 }
 
 }  // namespace fuse_constraints

--- a/fuse_constraints/src/marginal_constraint.cpp
+++ b/fuse_constraints/src/marginal_constraint.cpp
@@ -73,7 +73,7 @@ void MarginalConstraint::print(std::ostream& stream) const
 
 ceres::CostFunction* MarginalConstraint::costFunction() const
 {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   return new MarginalCostFunction(A_, b_, x_bar_, local_parameterizations_);
 #else
   return new MarginalCostFunction(A_, b_, x_bar_, manifolds_);

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -38,19 +38,17 @@
 
 #include <Eigen/Core>
 
-#include <vector>
 #include <iostream>
-
+#include <vector>
 
 namespace fuse_constraints
 {
-
 #if !CERES_VERSION_AT_LEAST(2, 1, 0)
 MarginalCostFunction::MarginalCostFunction(
-    const std::vector<fuse_core::MatrixXd>& A,
-    const fuse_core::VectorXd& b,
-    const std::vector<fuse_core::VectorXd>& x_bar,
-    const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations) :
+  const std::vector<fuse_core::MatrixXd>& A,
+  const fuse_core::VectorXd& b,
+  const std::vector<fuse_core::VectorXd>& x_bar,
+  const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations) :
   A_(A),
   b_(b),
   local_parameterizations_(local_parameterizations),
@@ -64,10 +62,10 @@ MarginalCostFunction::MarginalCostFunction(
 }
 #else
 MarginalCostFunction::MarginalCostFunction(
-    const std::vector<fuse_core::MatrixXd>& A,
-    const fuse_core::VectorXd& b,
-    const std::vector<fuse_core::VectorXd>& x_bar,
-    const std::vector<fuse_core::Manifold::SharedPtr>& manifolds) :
+  const std::vector<fuse_core::MatrixXd>& A,
+  const fuse_core::VectorXd& b,
+  const std::vector<fuse_core::VectorXd>& x_bar,
+  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds) :
   A_(A),
   b_(b),
   manifolds_(manifolds),
@@ -81,10 +79,7 @@ MarginalCostFunction::MarginalCostFunction(
 }
 #endif
 
-bool MarginalCostFunction::Evaluate(
-  double const* const* parameters,
-  double* residuals,
-  double** jacobians) const
+bool MarginalCostFunction::Evaluate(double const* const* parameters, double* residuals, double** jacobians) const
 {
   // Compute cost
   Eigen::Map<fuse_core::VectorXd> residuals_map(residuals, num_residuals());
@@ -97,7 +92,7 @@ bool MarginalCostFunction::Evaluate(
     {
       local_parameterizations_[i]->Minus(x_bar_[i].data(), parameters[i], delta.data());
     }
-#else 
+#else
     if (manifolds_[i])
     {
       manifolds_[i]->Minus(parameters[i], x_bar_[i].data(), delta.data());

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -100,7 +100,7 @@ bool MarginalCostFunction::Evaluate(
 #else 
     if (manifolds_[i])
     {
-      manifolds_[i]->Minus(parameters[i], x_bar_[i].data() delta.data());
+      manifolds_[i]->Minus(parameters[i], x_bar_[i].data(), delta.data());
     }
 #endif
     else
@@ -133,7 +133,7 @@ bool MarginalCostFunction::Evaluate(
         {
           const auto& manifold = manifolds_[i];
           fuse_core::MatrixXd J_local(manifold->TangentSize(), manifold->AmbientSize());
-          local_parameterization->MinusJacobian(parameters[i], J_local.data());
+          manifold->MinusJacobian(parameters[i], J_local.data());
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
 #endif

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -98,13 +98,8 @@ bool MarginalCostFunction::Evaluate(
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-          fuse_core::MatrixXd J_local(local_parameterization->TangentSize(), local_parameterization->AmbientSize());
-          local_parameterization->MinusJacobian(parameters[i], J_local.data());
-#else
           fuse_core::MatrixXd J_local(local_parameterization->LocalSize(), local_parameterization->GlobalSize());
           local_parameterization->ComputeMinusJacobian(parameters[i], J_local.data());
-#endif
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
         else

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -33,6 +33,7 @@
  */
 #include <fuse_constraints/marginal_cost_function.h>
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
 
@@ -97,8 +98,13 @@ bool MarginalCostFunction::Evaluate(
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+          fuse_core::MatrixXd J_local(local_parameterization->TangentSize(), local_parameterization->AmbientSize());
+          local_parameterization->MinusJacobian(parameters[i], J_local.data());
+#else
           fuse_core::MatrixXd J_local(local_parameterization->LocalSize(), local_parameterization->GlobalSize());
           local_parameterization->ComputeMinusJacobian(parameters[i], J_local.data());
+#endif
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
         else

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -43,7 +43,7 @@
 
 namespace fuse_constraints
 {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
 MarginalCostFunction::MarginalCostFunction(
   const std::vector<fuse_core::MatrixXd>& A,
   const fuse_core::VectorXd& b,
@@ -87,7 +87,7 @@ bool MarginalCostFunction::Evaluate(double const* const* parameters, double* res
   for (size_t i = 0; i < A_.size(); ++i)
   {
     fuse_core::VectorXd delta(A_[i].cols());
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     if (local_parameterizations_[i])
     {
       local_parameterizations_[i]->Minus(x_bar_[i].data(), parameters[i], delta.data());
@@ -115,7 +115,7 @@ bool MarginalCostFunction::Evaluate(double const* const* parameters, double* res
     {
       if (jacobians[i])
       {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -335,7 +335,7 @@ LinearTerm linearize(
   {
     const auto& variable_uuid = variable_uuids[index];
     const auto& variable = graph.getVariable(variable_uuid);
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     auto local_parameterization = variable.localParameterization();
     auto& jacobian = result.A[index];
     if (variable.holdConstant())

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -35,6 +35,7 @@
 #include <fuse_constraints/marginalize_variables.h>
 #include <fuse_constraints/uuid_ordering.h>
 #include <fuse_constraints/variable_constraints.h>
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/uuid.h>
 
 #include <boost/iterator/transform_iterator.hpp>
@@ -342,14 +343,23 @@ LinearTerm linearize(
     {
       if (local_parameterization)
       {
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+        jacobian.resize(Eigen::NoChange, local_parameterization->TangentSize());
+#else
         jacobian.resize(Eigen::NoChange, local_parameterization->LocalSize());
+#endif
       }
       jacobian.setZero();
     }
     else if (local_parameterization)
     {
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+      fuse_core::MatrixXd J(local_parameterization->AmbientSize(), local_parameterization->TangentSize());
+      local_parameterization->PlusJacobian(variable_values[index], J.data());
+#else
       fuse_core::MatrixXd J(local_parameterization->GlobalSize(), local_parameterization->LocalSize());
       local_parameterization->ComputeJacobian(variable_values[index], J.data());
+#endif
       jacobian *= J;
     }
     if (local_parameterization)

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -185,13 +185,13 @@ fuse_core::Transaction marginalizeVariables(
   //                 the problem before the linearization and solve steps. A similar approach should be implemented
   //                 here, but that will require a major refactor.
 
-  assert(std::all_of(
-    marginalized_variables.begin(),
-    marginalized_variables.end(),
-    [&elimination_order, &marginalized_variables](const fuse_core::UUID& variable_uuid) {
-      return elimination_order.exists(variable_uuid) &&
-             elimination_order.at(variable_uuid) < marginalized_variables.size();
-    }));  // NOLINT
+  assert(std::all_of(marginalized_variables.begin(),
+                     marginalized_variables.end(),
+                     [&elimination_order, &marginalized_variables](const fuse_core::UUID& variable_uuid)
+                     {
+                       return elimination_order.exists(variable_uuid) &&
+                              elimination_order.at(variable_uuid) < marginalized_variables.size();
+                     }));  // NOLINT
 
   fuse_core::Transaction transaction;
 

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -343,23 +343,14 @@ LinearTerm linearize(
     {
       if (local_parameterization)
       {
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-        jacobian.resize(Eigen::NoChange, local_parameterization->TangentSize());
-#else
         jacobian.resize(Eigen::NoChange, local_parameterization->LocalSize());
-#endif
       }
       jacobian.setZero();
     }
     else if (local_parameterization)
     {
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-      fuse_core::MatrixXd J(local_parameterization->AmbientSize(), local_parameterization->TangentSize());
-      local_parameterization->PlusJacobian(variable_values[index], J.data());
-#else
       fuse_core::MatrixXd J(local_parameterization->GlobalSize(), local_parameterization->LocalSize());
       local_parameterization->ComputeJacobian(variable_values[index], J.data());
-#endif
       jacobian *= J;
     }
     if (local_parameterization)

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -379,7 +379,7 @@ LinearTerm linearize(
     }
     if (manifold)
     {
-      delete manifoldn;
+      delete manifold;
     } 
 #endif
   }

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -563,7 +563,8 @@ MarginalConstraint::SharedPtr createMarginalConstraint(
   const fuse_core::Graph& graph,
   const UuidOrdering& elimination_order)
 {
-  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable& {
+  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable& 
+  {
     return graph.getVariable(elimination_order.at(index));
   };
 

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -563,7 +563,7 @@ MarginalConstraint::SharedPtr createMarginalConstraint(
   const fuse_core::Graph& graph,
   const UuidOrdering& elimination_order)
 {
-  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable& 
+  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable&
   {
     return graph.getVariable(elimination_order.at(index));
   };

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -35,15 +35,15 @@
 #include <fuse_constraints/marginalize_variables.h>
 #include <fuse_constraints/uuid_ordering.h>
 #include <fuse_constraints/variable_constraints.h>
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/manifold.h>
-#include <fuse_core/ceres_macros.h>
 #include <fuse_core/uuid.h>
 
-#include <boost/iterator/transform_iterator.hpp>
-#include <boost/range/empty.hpp>
 #include <Eigen/Core>
 #include <Eigen/Dense>
+#include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/empty.hpp>
 #include <suitesparse/ccolamd.h>
 
 #include <algorithm>
@@ -55,10 +55,8 @@
 #include <utility>
 #include <vector>
 
-
 namespace fuse_constraints
 {
-
 UuidOrdering computeEliminationOrder(
   const std::vector<fuse_core::UUID>& marginalized_variables,
   const fuse_core::Graph& graph)
@@ -105,10 +103,8 @@ UuidOrdering computeEliminationOrder(
   }
 
   // Construct the CCOLAMD input structures
-  auto recommended_size = ccolamd_recommended(
-    variable_constraints.size(),
-    constraint_order.size(),
-    variable_order.size());
+  auto recommended_size =
+    ccolamd_recommended(variable_constraints.size(), constraint_order.size(), variable_order.size());
   auto A = std::vector<int>(recommended_size);
   auto p = std::vector<int>(variable_order.size() + 1);
 
@@ -189,13 +185,13 @@ fuse_core::Transaction marginalizeVariables(
   //                 the problem before the linearization and solve steps. A similar approach should be implemented
   //                 here, but that will require a major refactor.
 
-  assert(std::all_of(marginalized_variables.begin(),
-                     marginalized_variables.end(),
-                     [&elimination_order, &marginalized_variables](const fuse_core::UUID& variable_uuid)
-                     {
-                       return elimination_order.exists(variable_uuid) &&
-                              elimination_order.at(variable_uuid) < marginalized_variables.size();
-                     }));  // NOLINT
+  assert(std::all_of(
+    marginalized_variables.begin(),
+    marginalized_variables.end(),
+    [&elimination_order, &marginalized_variables](const fuse_core::UUID& variable_uuid) {
+      return elimination_order.exists(variable_uuid) &&
+             elimination_order.at(variable_uuid) < marginalized_variables.size();
+    }));  // NOLINT
 
   fuse_core::Transaction transaction;
 
@@ -380,7 +376,7 @@ LinearTerm linearize(
     if (manifold)
     {
       delete manifold;
-    } 
+    }
 #endif
   }
 
@@ -567,8 +563,7 @@ MarginalConstraint::SharedPtr createMarginalConstraint(
   const fuse_core::Graph& graph,
   const UuidOrdering& elimination_order)
 {
-  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable&
-  {
+  auto index_to_variable = [&graph, &elimination_order](const unsigned int index) -> const fuse_core::Variable& {
     return graph.getVariable(elimination_order.at(index));
   };
 

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -52,7 +52,6 @@
 #include <utility>
 #include <vector>
 
-
 TEST(AbsoluteConstraint, Constructor)
 {
   // Construct a constraint for every type, just to make sure they compile.
@@ -80,8 +79,7 @@ TEST(AbsoluteConstraint, Constructor)
     mean << 3.0;
     fuse_core::Matrix1d cov;
     cov << 1.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::AbsoluteOrientation2DStampedConstraint constraint("test", variable, mean, cov));
+    EXPECT_NO_THROW(fuse_constraints::AbsoluteOrientation2DStampedConstraint constraint("test", variable, mean, cov));
   }
   {
     fuse_variables::Position2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("rosie"));
@@ -89,8 +87,7 @@ TEST(AbsoluteConstraint, Constructor)
     mean << 1.0, 2.0;
     fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::AbsolutePosition2DStampedConstraint constraint("test", variable, mean, cov));
+    EXPECT_NO_THROW(fuse_constraints::AbsolutePosition2DStampedConstraint constraint("test", variable, mean, cov));
   }
   {
     fuse_variables::Position3DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("clank"));
@@ -98,8 +95,7 @@ TEST(AbsoluteConstraint, Constructor)
     mean << 1.0, 2.0, 3.0;
     fuse_core::Matrix3d cov;
     cov << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::AbsolutePosition3DStampedConstraint constraint("test", variable, mean, cov));
+    EXPECT_NO_THROW(fuse_constraints::AbsolutePosition3DStampedConstraint constraint("test", variable, mean, cov));
   }
   {
     fuse_variables::VelocityAngular2DStamped variable(ros::Time(1234, 5678), fuse_core::uuid::generate("gort"));
@@ -128,7 +124,7 @@ TEST(AbsoluteConstraint, PartialMeasurement)
   mean << 3.0, 1.0;
   fuse_core::Matrix2d cov;
   cov << 3.0, 0.2, 0.2, 1.0;
-  auto indices = std::vector<size_t>{2, 0};
+  auto indices = std::vector<size_t> { 2, 0 };
   EXPECT_NO_THROW(
     fuse_constraints::AbsolutePosition3DStampedConstraint constraint("test", variable, mean, cov, indices));
 }
@@ -146,8 +142,7 @@ TEST(AbsoluteConstraint, Covariance)
     fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint constraint("test", variable, mean, cov);
     // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
     fuse_core::Matrix2d expected_sqrt_info;
-    expected_sqrt_info <<  1.002509414234171, -0.050125470711709,
-                           0.000000000000000,  0.707106781186547;
+    expected_sqrt_info << 1.002509414234171, -0.050125470711709, 0.000000000000000, 0.707106781186547;
     fuse_core::Matrix2d expected_cov = cov;
     // Compare
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -160,7 +155,7 @@ TEST(AbsoluteConstraint, Covariance)
     mean << 3.0, 1.0;
     fuse_core::Matrix2d cov;
     cov << 3.0, 0.2, 0.2, 1.0;
-    auto indices = std::vector<size_t>{2, 0};
+    auto indices = std::vector<size_t> { 2, 0 };
     fuse_constraints::AbsolutePosition3DStampedConstraint constraint("test", variable, mean, cov, indices);
     // Define the expected matrices
     fuse_core::Vector3d expected_mean;
@@ -168,8 +163,8 @@ TEST(AbsoluteConstraint, Covariance)
     fuse_core::Matrix3d expected_cov;
     expected_cov << 1.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.2, 0.0, 3.0;
     fuse_core::MatrixXd expected_sqrt_info(2, 3);
-    expected_sqrt_info << -0.116247638743819,  0.000000000000000,  0.581238193719096,
-                           1.000000000000000,  0.000000000000000,  0.000000000000000;
+    expected_sqrt_info << -0.116247638743819, 0.000000000000000, 0.581238193719096, 1.000000000000000,
+      0.000000000000000, 0.000000000000000;
     // Compare
     EXPECT_TRUE(expected_mean.isApprox(constraint.mean(), 1.0e-9));
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -193,11 +188,8 @@ TEST(AbsoluteConstraint, Optimization)
     mean << 1.0, 2.0;
     fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
-    auto constraint = fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared(
-      "test",
-      *variable,
-      mean,
-      cov);
+    auto constraint =
+      fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared("test", *variable, mean, cov);
     // Build the problem
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -206,18 +198,14 @@ TEST(AbsoluteConstraint, Optimization)
       variable->data(),
       variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      variable->localParameterization()
+      variable->localParameterization());
 #else
-      variable->manifold()
+      variable->manifold());
 #endif
-    );
 
     std::vector<double*> parameter_blocks;
     parameter_blocks.push_back(variable->data());
-    problem.AddResidualBlock(
-      constraint->costFunction(),
-      constraint->lossFunction(),
-      parameter_blocks);
+    problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
     // Run the solver
     ceres::Solver::Options options;
     ceres::Solver::Summary summary;
@@ -226,7 +214,7 @@ TEST(AbsoluteConstraint, Optimization)
     EXPECT_NEAR(1.0, variable->x(), 1.0e-5);
     EXPECT_NEAR(2.0, variable->y(), 1.0e-5);
     // Compute the covariance
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(variable->data(), variable->data());
     ceres::Covariance::Options cov_options;
     ceres::Covariance covariance(cov_options);
@@ -251,26 +239,15 @@ TEST(AbsoluteConstraint, Optimization)
     fuse_core::Vector3d mean1;
     mean1 << 1.0, 2.0, 3.0;
     fuse_core::Matrix3d cov1;
-    cov1 << 1.0, 0.0, 0.0,
-            0.0, 1.0, 0.0,
-            0.0, 0.0, 1.0;
-    auto constraint1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(
-      "test",
-      *var,
-      mean1,
-      cov1);
+    cov1 << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0;
+    auto constraint1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared("test", *var, mean1, cov1);
     fuse_core::Vector2d mean2;
     mean2 << 4.0, 2.0;
     fuse_core::Matrix2d cov2;
-    cov2 << 1.0, 0.0,
-            0.0, 1.0;
-    auto indices2 = std::vector<size_t>{2, 0};
-    auto constraint2 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(
-      "test",
-      *var,
-      mean2,
-      cov2,
-      indices2);
+    cov2 << 1.0, 0.0, 0.0, 1.0;
+    auto indices2 = std::vector<size_t> { 2, 0 };
+    auto constraint2 =
+      fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared("test", *var, mean2, cov2, indices2);
     // Build the problem
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -279,21 +256,14 @@ TEST(AbsoluteConstraint, Optimization)
       var->data(),
       var->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      var->localParameterization()
+      var->localParameterization());
 #else
-      var->manifold()
+      var->manifold());
 #endif
-    );
     std::vector<double*> parameter_blocks;
     parameter_blocks.push_back(var->data());
-    problem.AddResidualBlock(
-      constraint1->costFunction(),
-      constraint1->lossFunction(),
-      parameter_blocks);
-    problem.AddResidualBlock(
-      constraint2->costFunction(),
-      constraint2->lossFunction(),
-      parameter_blocks);
+    problem.AddResidualBlock(constraint1->costFunction(), constraint1->lossFunction(), parameter_blocks);
+    problem.AddResidualBlock(constraint2->costFunction(), constraint2->lossFunction(), parameter_blocks);
     // Run the solver
     ceres::Solver::Options options;
     ceres::Solver::Summary summary;
@@ -303,7 +273,7 @@ TEST(AbsoluteConstraint, Optimization)
     EXPECT_NEAR(2.0, var->y(), 1.0e-5);
     EXPECT_NEAR(3.5, var->z(), 1.0e-5);
     // Compute the covariance
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(var->data(), var->data());
     ceres::Covariance::Options cov_options;
     ceres::Covariance covariance(cov_options);
@@ -312,9 +282,7 @@ TEST(AbsoluteConstraint, Optimization)
     covariance.GetCovarianceBlock(var->data(), var->data(), covariance_vector.data());
     fuse_core::Matrix3d actual_cov(covariance_vector.data());
     fuse_core::Matrix3d expected_cov;
-    expected_cov << 0.5, 0.0, 0.0,
-                    0.0, 1.0, 0.0,
-                    0.0, 0.0, 0.5;
+    expected_cov << 0.5, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.5;
     EXPECT_TRUE(expected_cov.isApprox(actual_cov, 1.0e-9));
   }
 }
@@ -331,28 +299,19 @@ TEST(AbsoluteConstraint, PartialOptimization)
   fuse_core::Vector2d mean1;
   mean1 << 1.0, 3.0;
   fuse_core::Matrix2d cov1;
-  cov1 << 1.0, 0.0,
-          0.0, 1.0;
-  std::vector<size_t> indices1 = {fuse_variables::Position3DStamped::Z, fuse_variables::Position3DStamped::X};
-  auto constraint1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(
-    "test",
-    *var,
-    mean1,
-    cov1,
-    indices1);
+  cov1 << 1.0, 0.0, 0.0, 1.0;
+  std::vector<size_t> indices1 = { fuse_variables::Position3DStamped::Z, fuse_variables::Position3DStamped::X };
+  auto constraint1 =
+    fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared("test", *var, mean1, cov1, indices1);
 
   // Create another constraint for the second index
   fuse_core::Vector1d mean2;
   mean2 << 2.0;
   fuse_core::Matrix1d cov2;
   cov2 << 1.0;
-  std::vector<size_t> indices2 = {fuse_variables::Position3DStamped::Y};
-  auto constraint2 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(
-    "test",
-    *var,
-    mean2,
-    cov2,
-    indices2);
+  std::vector<size_t> indices2 = { fuse_variables::Position3DStamped::Y };
+  auto constraint2 =
+    fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared("test", *var, mean2, cov2, indices2);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -362,21 +321,14 @@ TEST(AbsoluteConstraint, PartialOptimization)
     var->data(),
     var->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    var->localParameterization()
+    var->localParameterization());
 #else
-    var->manifold()
+    var->manifold());
 #endif
-  );
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(var->data());
-  problem.AddResidualBlock(
-    constraint1->costFunction(),
-    constraint1->lossFunction(),
-    parameter_blocks);
-  problem.AddResidualBlock(
-    constraint2->costFunction(),
-    constraint2->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint1->costFunction(), constraint1->lossFunction(), parameter_blocks);
+  problem.AddResidualBlock(constraint2->costFunction(), constraint2->lossFunction(), parameter_blocks);
   // Run the solver
   ceres::Solver::Options options;
   ceres::Solver::Summary summary;
@@ -391,20 +343,15 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
 {
   // Optimize a single variable and single constraint, verify the expected value and covariance are generated.
   // Create a variable
-  auto variable = fuse_variables::Orientation2DStamped::make_shared(
-    ros::Time(1234, 5678),
-    fuse_core::uuid::generate("tiktok"));
+  auto variable =
+    fuse_variables::Orientation2DStamped::make_shared(ros::Time(1234, 5678), fuse_core::uuid::generate("tiktok"));
   variable->setYaw(0.7);
   // Create an absolute constraint
   fuse_core::Vector1d mean;
   mean << 7.0;
   fuse_core::Matrix1d cov;
   cov << 0.10;
-  auto constraint = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *variable,
-    mean,
-    cov);
+  auto constraint = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared("test", *variable, mean, cov);
   // Build the problem
   ceres::Problem::Options problem_options;
   problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -413,17 +360,13 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
     variable->data(),
     variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    variable->localParameterization()
+    variable->localParameterization());
 #else
-    variable->manifold()
+    variable->manifold());
 #endif
-  );
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(variable->data());
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
   // Run the solver
   ceres::Solver::Options options;
   ceres::Solver::Summary summary;
@@ -431,7 +374,7 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   // Check
   EXPECT_NEAR(7.0 - 2 * M_PI, variable->getYaw(), 1.0e-5);
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(variable->data(), variable->data());
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
@@ -473,7 +416,7 @@ TEST(AbsoluteConstraint, Serialization)
   EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_constraints/test/test_absolute_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_constraint.cpp
@@ -205,7 +205,13 @@ TEST(AbsoluteConstraint, Optimization)
     problem.AddParameterBlock(
       variable->data(),
       variable->size(),
-      variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      variable->localParameterization()
+#else
+      variable->manifold()
+#endif
+    );
+
     std::vector<double*> parameter_blocks;
     parameter_blocks.push_back(variable->data());
     problem.AddResidualBlock(
@@ -272,7 +278,12 @@ TEST(AbsoluteConstraint, Optimization)
     problem.AddParameterBlock(
       var->data(),
       var->size(),
-      var->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      var->localParameterization()
+#else
+      var->manifold()
+#endif
+    );
     std::vector<double*> parameter_blocks;
     parameter_blocks.push_back(var->data());
     problem.AddResidualBlock(
@@ -350,7 +361,12 @@ TEST(AbsoluteConstraint, PartialOptimization)
   problem.AddParameterBlock(
     var->data(),
     var->size(),
-    var->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    var->localParameterization()
+#else
+    var->manifold()
+#endif
+  );
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(var->data());
   problem.AddResidualBlock(
@@ -396,7 +412,12 @@ TEST(AbsoluteConstraint, AbsoluteOrientation2DOptimization)
   problem.AddParameterBlock(
     variable->data(),
     variable->size(),
-    variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    variable->localParameterization()
+#else
+    variable->manifold()
+#endif
+  );
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(variable->data());
   problem.AddResidualBlock(

--- a/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
@@ -105,11 +105,10 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
@@ -167,11 +166,10 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
@@ -229,11 +227,10 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
@@ -292,11 +289,10 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_2d_stamped_constraint.cpp
@@ -39,10 +39,10 @@
 #include <fuse_variables/orientation_2d_stamped.h>
 #include <geometry_msgs/Quaternion.h>
 
+#include <Eigen/Geometry>
 #include <ceres/covariance.h>
 #include <ceres/problem.h>
 #include <ceres/solver.h>
-#include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
 #include <utility>
@@ -50,7 +50,6 @@
 
 using fuse_constraints::AbsoluteOrientation2DStampedConstraint;
 using fuse_variables::Orientation2DStamped;
-
 
 TEST(AbsoluteOrientation2DStampedConstraint, Constructor)
 {
@@ -75,7 +74,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, Covariance)
 
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
   fuse_core::Matrix1d expected_sqrt_info;
-  expected_sqrt_info <<  1.0;
+  expected_sqrt_info << 1.0;
   fuse_core::Matrix1d expected_cov = cov;
 
   // Compare
@@ -96,11 +95,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
 
   fuse_core::Matrix1d cov;
   cov << 1.0;
-  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *orientation_variable,
-    mean,
-    cov);
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared("test", *orientation_variable, mean, cov);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -109,14 +104,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -128,14 +125,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, Optimization)
   EXPECT_NEAR(1.0, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
   fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+    orientation_variable->data(),
+    orientation_variable->data(),
+    actual_covariance.data());
 
   // Define the expected covariance
   fuse_core::Matrix1d expected_covariance;
@@ -158,11 +157,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
 
   fuse_core::Matrix1d cov;
   cov << 1.0;
-  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *orientation_variable,
-    mean,
-    cov);
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared("test", *orientation_variable, mean, cov);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -171,14 +166,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -190,14 +187,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationZero)
   EXPECT_NEAR(0.0, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
   fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+    orientation_variable->data(),
+    orientation_variable->data(),
+    actual_covariance.data());
 
   // Define the expected covariance
   fuse_core::Matrix1d expected_covariance;
@@ -220,11 +219,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
 
   fuse_core::Matrix1d cov;
   cov << 1.0;
-  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *orientation_variable,
-    mean,
-    cov);
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared("test", *orientation_variable, mean, cov);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -233,14 +228,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -253,14 +250,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationPositivePi)
   EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
   fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+    orientation_variable->data(),
+    orientation_variable->data(),
+    actual_covariance.data());
 
   // Define the expected covariance
   fuse_core::Matrix1d expected_covariance;
@@ -283,11 +282,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
 
   fuse_core::Matrix1d cov;
   cov << 1.0;
-  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *orientation_variable,
-    mean,
-    cov);
+  auto constraint = AbsoluteOrientation2DStampedConstraint::make_shared("test", *orientation_variable, mean, cov);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -296,14 +291,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -315,14 +312,16 @@ TEST(AbsoluteOrientation2DStampedConstraint, OptimizationNegativePi)
   EXPECT_NEAR(-M_PI, orientation_variable->getYaw(), 1.0e-3);
 
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
   ceres::Covariance::Options cov_options;
   ceres::Covariance covariance(cov_options);
   covariance.Compute(covariance_blocks, &problem);
   fuse_core::Matrix1d actual_covariance(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), actual_covariance.data());
+    orientation_variable->data(),
+    orientation_variable->data(),
+    actual_covariance.data());
 
   // Define the expected covariance
   fuse_core::Matrix1d expected_covariance;
@@ -361,7 +360,7 @@ TEST(AbsoluteOrientation2DStampedConstraint, Serialization)
   EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
@@ -125,7 +125,12 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_constraint.cpp
@@ -126,11 +126,10 @@ TEST(AbsoluteOrientation3DStampedConstraint, Optimization)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -120,7 +120,12 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationFull)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());
@@ -190,7 +195,12 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationPartial)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -196,11 +196,10 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationPartial)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_orientation_3d_stamped_euler_constraint.cpp
@@ -121,11 +121,10 @@ TEST(AbsoluteOrientation3DStampedEulerConstraint, OptimizationFull)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(orientation_variable->data());

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -113,11 +113,22 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
   problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position_variable->data(),
     position_variable->size(),
-    position_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position_variable->localParameterization()
+#else
+    position_variable->manifold()
+#endif
+  );
+
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());
   parameter_blocks.push_back(orientation_variable->data());
@@ -209,13 +220,23 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
   problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
   ceres::Problem problem(problem_options);
   problem.AddParameterBlock(
-    position_variable->data(),
-    position_variable->size(),
-    position_variable->localParameterization());
-  problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
+  problem.AddParameterBlock(
+    position_variable->data(),
+    position_variable->size(),
+#if !CERES_SUPPORTS_MANIFOLDS
+    position_variable->localParameterization()
+#else
+    position_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());

--- a/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_2d_stamped_constraint.cpp
@@ -114,20 +114,18 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationFull)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     position_variable->data(),
     position_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    position_variable->localParameterization()
+    position_variable->localParameterization());
 #else
-    position_variable->manifold()
+    position_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());
@@ -223,20 +221,18 @@ TEST(AbsolutePose2DStampedConstraint, OptimizationPartial)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     position_variable->data(),
     position_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    position_variable->localParameterization()
+    position_variable->localParameterization());
 #else
-    position_variable->manifold()
+    position_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());

--- a/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
@@ -148,13 +148,23 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
   problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
   ceres::Problem problem(problem_options);
   problem.AddParameterBlock(
-    position_variable->data(),
-    position_variable->size(),
-    position_variable->localParameterization());
-  problem.AddParameterBlock(
     orientation_variable->data(),
     orientation_variable->size(),
-    orientation_variable->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation_variable->localParameterization()
+#else
+    orientation_variable->manifold()
+#endif
+  );
+  problem.AddParameterBlock(
+    position_variable->data(),
+    position_variable->size(),
+#if !CERES_SUPPORTS_MANIFOLDS
+    position_variable->localParameterization()
+#else
+    position_variable->manifold()
+#endif
+  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());

--- a/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_absolute_pose_3d_stamped_constraint.cpp
@@ -47,10 +47,9 @@
 #include <utility>
 #include <vector>
 
+using fuse_constraints::AbsolutePose3DStampedConstraint;
 using fuse_variables::Orientation3DStamped;
 using fuse_variables::Position3DStamped;
-using fuse_constraints::AbsolutePose3DStampedConstraint;
-
 
 TEST(AbsolutePose3DStampedConstraint, Constructor)
 {
@@ -63,12 +62,12 @@ TEST(AbsolutePose3DStampedConstraint, Constructor)
 
   // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
   EXPECT_NO_THROW(
     AbsolutePose3DStampedConstraint constraint("test", position_variable, orientation_variable, mean, cov));
@@ -85,23 +84,24 @@ TEST(AbsolutePose3DStampedConstraint, Covariance)
 
   // Generated PD matrix using Octiave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
   AbsolutePose3DStampedConstraint constraint("test", position_variable, orientation_variable, mean, cov);
 
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
   fuse_core::Matrix6d expected_sqrt_info;
-  expected_sqrt_info << 2.12658752275893, 1.20265444927878, 4.71225672571804, 1.43587520991272, -4.12764062992821, -3.19509486240291,    // NOLINT
-                        0.0,              2.41958656956248, 5.93151964116945, 3.72535320852517, -4.23326858606213, -5.27776664777548,    // NOLINT
-                        0.0,              0.0,              3.82674686590005, 2.80341171946161, -2.68168478581452, -2.8894384435255,     // NOLINT
-                        0.0,              0.0,              0.0,              1.83006791372784, -0.696917410192509, -1.17412835464633,   // NOLINT
-                        0.0,              0.0,              0.0,              0.0,               0.953302832761324, -0.769654414882847,  // NOLINT
-                        0.0,              0.0,              0.0,              0.0,               0.0,                0.681477739760948;  // NOLINT
+  expected_sqrt_info << 2.12658752275893, 1.20265444927878, 4.71225672571804, 1.43587520991272, -4.12764062992821,
+    -3.19509486240291,  // NOLINT
+    0.0, 2.41958656956248, 5.93151964116945, 3.72535320852517, -4.23326858606213, -5.27776664777548,  // NOLINT
+    0.0, 0.0, 3.82674686590005, 2.80341171946161, -2.68168478581452, -2.8894384435255,  // NOLINT
+    0.0, 0.0, 0.0, 1.83006791372784, -0.696917410192509, -1.17412835464633,  // NOLINT
+    0.0, 0.0, 0.0, 0.0, 0.953302832761324, -0.769654414882847,  // NOLINT
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.681477739760948;  // NOLINT
   fuse_core::Matrix6d expected_cov = cov;
 
   // Compare
@@ -129,19 +129,11 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
   mean << 1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0;
 
   fuse_core::Matrix6d cov;
-  cov << 1.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-         0.1, 2.0, 0.6, 0.5, 0.4, 0.3,
-         0.2, 0.6, 3.0, 0.2, 0.1, 0.2,
-         0.3, 0.5, 0.2, 4.0, 0.3, 0.4,
-         0.4, 0.4, 0.1, 0.3, 5.0, 0.5,
-         0.5, 0.3, 0.2, 0.4, 0.5, 6.0;
+  cov << 1.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.1, 2.0, 0.6, 0.5, 0.4, 0.3, 0.2, 0.6, 3.0, 0.2, 0.1, 0.2, 0.3, 0.5, 0.2, 4.0,
+    0.3, 0.4, 0.4, 0.4, 0.1, 0.3, 5.0, 0.5, 0.5, 0.3, 0.2, 0.4, 0.5, 6.0;
 
-  auto constraint = AbsolutePose3DStampedConstraint::make_shared(
-    "test",
-    *position_variable,
-    *orientation_variable,
-    mean,
-    cov);
+  auto constraint =
+    AbsolutePose3DStampedConstraint::make_shared("test", *position_variable, *orientation_variable, mean, cov);
 
   // Build the problem
   ceres::Problem::Options problem_options;
@@ -151,29 +143,24 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
     orientation_variable->data(),
     orientation_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation_variable->localParameterization()
+    orientation_variable->localParameterization());
 #else
-    orientation_variable->manifold()
+    orientation_variable->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     position_variable->data(),
     position_variable->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    position_variable->localParameterization()
+    position_variable->localParameterization());
 #else
-    position_variable->manifold()
+    position_variable->manifold());
 #endif
-  );
 
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position_variable->data());
   parameter_blocks.push_back(orientation_variable->data());
 
-  problem.AddResidualBlock(
-    constraint->costFunction(),
-    constraint->lossFunction(),
-    parameter_blocks);
+  problem.AddResidualBlock(constraint->costFunction(), constraint->lossFunction(), parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -190,7 +177,7 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
   EXPECT_NEAR(0.0, orientation_variable->z(), 1.0e-3);
 
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(position_variable->data(), position_variable->data());
   covariance_blocks.emplace_back(orientation_variable->data(), orientation_variable->data());
   covariance_blocks.emplace_back(position_variable->data(), orientation_variable->data());
@@ -203,11 +190,15 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
 
   fuse_core::MatrixXd cov_or_or(orientation_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    orientation_variable->data(), orientation_variable->data(), cov_or_or.data());
+    orientation_variable->data(),
+    orientation_variable->data(),
+    cov_or_or.data());
 
   fuse_core::MatrixXd cov_pos_or(position_variable->localSize(), orientation_variable->localSize());
   covariance.GetCovarianceBlockInTangentSpace(
-    position_variable->data(), orientation_variable->data(), cov_pos_or.data());
+    position_variable->data(),
+    orientation_variable->data(),
+    cov_pos_or.data());
 
   // Assemble the full covariance from the covariance blocks
   fuse_core::Matrix6d actual_covariance;
@@ -215,13 +206,8 @@ TEST(AbsolutePose3DStampedConstraint, Optimization)
 
   // Define the expected covariance
   fuse_core::Matrix6d expected_covariance;
-  expected_covariance <<
-    1.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-    0.1, 2.0, 0.6, 0.5, 0.4, 0.3,
-    0.2, 0.6, 3.0, 0.2, 0.1, 0.2,
-    0.3, 0.5, 0.2, 4.0, 0.3, 0.4,
-    0.4, 0.4, 0.1, 0.3, 5.0, 0.5,
-    0.5, 0.3, 0.2, 0.4, 0.5, 6.0;
+  expected_covariance << 1.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.1, 2.0, 0.6, 0.5, 0.4, 0.3, 0.2, 0.6, 3.0, 0.2, 0.1, 0.2, 0.3,
+    0.5, 0.2, 4.0, 0.3, 0.4, 0.4, 0.4, 0.1, 0.3, 5.0, 0.5, 0.5, 0.3, 0.2, 0.4, 0.5, 6.0;
 
   EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-5);
 }
@@ -237,12 +223,12 @@ TEST(AbsolutePose3DStampedConstraint, Serialization)
 
   // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
   AbsolutePose3DStampedConstraint expected("test", position_variable, orientation_variable, mean, cov);
 
@@ -267,7 +253,7 @@ TEST(AbsolutePose3DStampedConstraint, Serialization)
   EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -207,11 +207,11 @@ TEST(MarginalConstraint, LocalParameterization)
   fuse_core::Vector1d expected_residuals;
   expected_residuals << 10.581088914;  // 5.0 * 0.15  +  6.0 * -0.2  +  7.0 * 0.433012702   +   8.0
   fuse_core::MatrixXd expected_jacobian1(1, 4);
-  expected_jacobian1 << -13.29593, 3.86083, 9.164586, 12.818822;
+  expected_jacobian1 << 13.29593, -3.86083, -9.164586, -12.818822;
   // A1 * J_local
-  // [5.0, 6.0, 7.0] * [-0.720368,  1.491122,  1.052086,  -0.388248]
-  //                   [-0.388248, -1.052086,  1.491122,   0.720368]
-  //                   [-1.052086,  0.388248, -0.720368,   1.491122]
+  // [5.0, 6.0, 7.0] * [0.720368, -1.491122, -1.052086,  0.388248]
+  //                   [0.388248,  1.052086, -1.491122, -0.720368]
+  //                   [1.052086, -0.388248,  0.720368, -1.491122]
 
   EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
   EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -115,13 +115,8 @@ TEST(MarginalConstraint, TwoVariables)
   fuse_core::Vector1d b;
   b << 9.0;
 
-  auto constraint = fuse_constraints::MarginalConstraint(
-    "test",
-    variables.begin(),
-    variables.end(),
-    A.begin(),
-    A.end(),
-    b);
+  auto constraint =
+    fuse_constraints::MarginalConstraint("test", variables.begin(), variables.end(), A.begin(), A.end(), b);
 
   auto cost_function = constraint.costFunction();
 
@@ -174,13 +169,8 @@ TEST(MarginalConstraint, LocalParameterization)
   fuse_core::Vector1d b;
   b << 8.0;
 
-  auto constraint = fuse_constraints::MarginalConstraint(
-    "test",
-    variables.begin(),
-    variables.end(),
-    A.begin(),
-    A.end(),
-    b);
+  auto constraint =
+    fuse_constraints::MarginalConstraint("test", variables.begin(), variables.end(), A.begin(), A.end(), b);
   auto cost_function = constraint.costFunction();
 
   // Update the variable value
@@ -236,13 +226,8 @@ TEST(MarginalConstraint, Serialization)
   fuse_core::Vector1d b;
   b << 8.0;
 
-  auto expected = fuse_constraints::MarginalConstraint(
-    "test",
-    variables.begin(),
-    variables.end(),
-    A.begin(),
-    A.end(),
-    b);
+  auto expected =
+    fuse_constraints::MarginalConstraint("test", variables.begin(), variables.end(), A.begin(), A.end(), b);
 
   // Serialize the constraint into an archive
   std::stringstream stream;

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -191,15 +191,11 @@ TEST(MarginalConstraint, LocalParameterization)
   fuse_core::Vector1d expected_residuals;
   expected_residuals << 10.581088914;  // 5.0 * 0.15  +  6.0 * -0.2  +  7.0 * 0.433012702   +   8.0
   fuse_core::MatrixXd expected_jacobian1(1, 4);
-#if CERES_SUPPORTS_MANIFOLDS
-  expected_jacobian1 << 13.29593, -3.86083, -9.164586, -12.818822;
-#else
   expected_jacobian1 << -13.29593, 3.86083, 9.164586, 12.818822;
-#endif
   // A1 * J_local
-  // [5.0, 6.0, 7.0] * [0.720368, -1.491122, -1.052086,  0.388248]
-  //                   [0.388248,  1.052086, -1.491122, -0.720368]
-  //                   [1.052086, -0.388248,  0.720368, -1.491122]
+  // [5.0, 6.0, 7.0] * [-0.720368,  1.491122,  1.052086,  -0.388248]
+  //                   [-0.388248, -1.052086,  1.491122,   0.720368]
+  //                   [-1.052086,  0.388248, -0.720368,   1.491122]
 
   EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
   EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -53,7 +53,6 @@
 #include <utility>
 #include <vector>
 
-
 TEST(RelativeConstraint, Constructor)
 {
   // Construct a constraint for every type, just to make sure they compile.
@@ -84,8 +83,7 @@ TEST(RelativeConstraint, Constructor)
     delta << 3.0;
     fuse_core::Matrix1d cov;
     cov << 1.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::RelativeOrientation2DStampedConstraint constraint("test", x1, x2, delta, cov));
+    EXPECT_NO_THROW(fuse_constraints::RelativeOrientation2DStampedConstraint constraint("test", x1, x2, delta, cov));
   }
   {
     fuse_variables::Position2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("rosie"));
@@ -94,8 +92,7 @@ TEST(RelativeConstraint, Constructor)
     delta << 1.0, 2.0;
     fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::RelativePosition2DStampedConstraint constraint("test", x1, x2, delta, cov));
+    EXPECT_NO_THROW(fuse_constraints::RelativePosition2DStampedConstraint constraint("test", x1, x2, delta, cov));
   }
   {
     fuse_variables::Position3DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("clank"));
@@ -104,8 +101,7 @@ TEST(RelativeConstraint, Constructor)
     delta << 1.0, 2.0, 3.0;
     fuse_core::Matrix3d cov;
     cov << 1.0, 0.1, 0.2, 0.3, 2.0, 0.3, 0.2, 0.3, 3.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::RelativePosition3DStampedConstraint constraint("test", x1, x2, delta, cov));
+    EXPECT_NO_THROW(fuse_constraints::RelativePosition3DStampedConstraint constraint("test", x1, x2, delta, cov));
   }
   {
     fuse_variables::VelocityAngular2DStamped x1(ros::Time(1234, 5678), fuse_core::uuid::generate("gort"));
@@ -124,8 +120,7 @@ TEST(RelativeConstraint, Constructor)
     delta << 1.0, 2.0;
     fuse_core::Matrix2d cov;
     cov << 1.0, 0.1, 0.1, 2.0;
-    EXPECT_NO_THROW(
-      fuse_constraints::RelativeVelocityLinear2DStampedConstraint constraint("test", x1, x2, delta, cov));
+    EXPECT_NO_THROW(fuse_constraints::RelativeVelocityLinear2DStampedConstraint constraint("test", x1, x2, delta, cov));
   }
 }
 
@@ -137,7 +132,7 @@ TEST(RelativeConstraint, PartialMeasurement)
   delta << 3.0, 1.0;
   fuse_core::Matrix2d cov;
   cov << 3.0, 0.2, 0.2, 1.0;
-  auto indices = std::vector<size_t>{2, 0};
+  auto indices = std::vector<size_t> { 2, 0 };
   EXPECT_NO_THROW(
     fuse_constraints::RelativePosition3DStampedConstraint constraint("test", x1, x2, delta, cov, indices));
 }
@@ -156,8 +151,7 @@ TEST(RelativeConstraint, Covariance)
     fuse_constraints::RelativeAccelerationLinear2DStampedConstraint constraint("test", x1, x2, delta, cov);
     // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
     fuse_core::Matrix2d expected_sqrt_info;
-    expected_sqrt_info <<  1.002509414234171, -0.050125470711709,
-                           0.000000000000000,  0.707106781186547;
+    expected_sqrt_info << 1.002509414234171, -0.050125470711709, 0.000000000000000, 0.707106781186547;
     fuse_core::Matrix2d expected_cov = cov;
     // Compare
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -171,7 +165,7 @@ TEST(RelativeConstraint, Covariance)
     delta << 3.0, 1.0;
     fuse_core::Matrix2d cov;
     cov << 3.0, 0.2, 0.2, 1.0;
-    auto indices = std::vector<size_t>{2, 0};
+    auto indices = std::vector<size_t> { 2, 0 };
     fuse_constraints::RelativePosition3DStampedConstraint constraint("test", x1, x2, delta, cov, indices);
     // Define the expected matrices
     fuse_core::Vector3d expected_delta;
@@ -179,8 +173,8 @@ TEST(RelativeConstraint, Covariance)
     fuse_core::Matrix3d expected_cov;
     expected_cov << 1.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.2, 0.0, 3.0;
     fuse_core::MatrixXd expected_sqrt_info(2, 3);
-    expected_sqrt_info << -0.116247638743819,  0.000000000000000,  0.581238193719096,
-                           1.000000000000000,  0.000000000000000,  0.000000000000000;
+    expected_sqrt_info << -0.116247638743819, 0.000000000000000, 0.581238193719096, 1.000000000000000,
+      0.000000000000000, 0.000000000000000;
     // Compare
     EXPECT_TRUE(expected_delta.isApprox(constraint.delta(), 1.0e-9));
     EXPECT_TRUE(expected_cov.isApprox(constraint.covariance(), 1.0e-9));
@@ -210,22 +204,14 @@ TEST(RelativeConstraint, Optimization)
     mean << 1.0, 2.0;
     fuse_core::Matrix2d cov1;
     cov1 << 1.0, 0.1, 0.1, 2.0;
-    auto prior = fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared(
-      "test",
-      *x1,
-      mean,
-      cov1);
+    auto prior = fuse_constraints::AbsoluteAccelerationLinear2DStampedConstraint::make_shared("test", *x1, mean, cov1);
     // Create an relative constraint
     fuse_core::Vector2d delta;
     delta << 0.1, 0.2;
     fuse_core::Matrix2d cov2;
     cov2 << 1.0, 0.0, 0.0, 2.0;
-    auto relative = fuse_constraints::RelativeAccelerationLinear2DStampedConstraint::make_shared(
-      "test",
-      *x1,
-      *x2,
-      delta,
-      cov2);
+    auto relative =
+      fuse_constraints::RelativeAccelerationLinear2DStampedConstraint::make_shared("test", *x1, *x2, delta, cov2);
     // Build the problem
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -234,33 +220,25 @@ TEST(RelativeConstraint, Optimization)
       x1->data(),
       x1->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      x1->localParameterization()
+      x1->localParameterization());
 #else
-      x1->manifold()
+      x1->manifold());
 #endif
-    );
     problem.AddParameterBlock(
       x2->data(),
       x2->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      x2->localParameterization()
+      x2->localParameterization());
 #else
-      x2->manifold()
+      x2->manifold());
 #endif
-    );
     std::vector<double*> prior_parameter_blocks;
     prior_parameter_blocks.push_back(x1->data());
-    problem.AddResidualBlock(
-      prior->costFunction(),
-      prior->lossFunction(),
-      prior_parameter_blocks);
+    problem.AddResidualBlock(prior->costFunction(), prior->lossFunction(), prior_parameter_blocks);
     std::vector<double*> relative_parameter_blocks;
     relative_parameter_blocks.push_back(x1->data());
     relative_parameter_blocks.push_back(x2->data());
-    problem.AddResidualBlock(
-      relative->costFunction(),
-      relative->lossFunction(),
-      relative_parameter_blocks);
+    problem.AddResidualBlock(relative->costFunction(), relative->lossFunction(), relative_parameter_blocks);
     // Run the solver
     ceres::Solver::Options options;
     ceres::Solver::Summary summary;
@@ -271,7 +249,7 @@ TEST(RelativeConstraint, Optimization)
     EXPECT_NEAR(1.1, x2->x(), 1.0e-5);
     EXPECT_NEAR(2.2, x2->y(), 1.0e-5);
     // Compute the covariance
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(x1->data(), x1->data());
     covariance_blocks.emplace_back(x2->data(), x2->data());
     ceres::Covariance::Options cov_options;
@@ -299,15 +277,11 @@ TEST(RelativeConstraint, Optimization)
     // Optimize a two-variable system with a prior on the first variable and a relative constraint connecting the two.
     // Verify the expected value and covariance are generated.
     // Create the variables
-    auto x1 = fuse_variables::Position3DStamped::make_shared(
-      ros::Time(1234, 5678),
-      fuse_core::uuid::generate("t1000"));
+    auto x1 = fuse_variables::Position3DStamped::make_shared(ros::Time(1234, 5678), fuse_core::uuid::generate("t1000"));
     x1->x() = 10.7;
     x1->y() = -3.2;
     x1->z() = 0.4;
-    auto x2 = fuse_variables::Position3DStamped::make_shared(
-      ros::Time(1235, 5678),
-      fuse_core::uuid::generate("t1000"));
+    auto x2 = fuse_variables::Position3DStamped::make_shared(ros::Time(1235, 5678), fuse_core::uuid::generate("t1000"));
     x2->x() = -4.2;
     x2->y() = 1.9;
     x2->z() = 19.2;
@@ -316,35 +290,21 @@ TEST(RelativeConstraint, Optimization)
     mean1 << 1.0, 2.0, 3.0;
     fuse_core::Matrix3d cov1;
     cov1 << 1.0, 0.1, 0.2, 0.1, 2.0, 0.3, 0.2, 0.3, 3.0;
-    auto c1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared(
-      "test",
-      *x1,
-      mean1,
-      cov1);
+    auto c1 = fuse_constraints::AbsolutePosition3DStampedConstraint::make_shared("test", *x1, mean1, cov1);
     // Create an relative constraint
     fuse_core::Vector3d delta2;
     delta2 << 0.1, 0.2, 0.3;
     fuse_core::Matrix3d cov2;
     cov2 << 1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0;
-    auto c2 = fuse_constraints::RelativePosition3DStampedConstraint::make_shared(
-      "test",
-      *x1,
-      *x2,
-      delta2,
-      cov2);
+    auto c2 = fuse_constraints::RelativePosition3DStampedConstraint::make_shared("test", *x1, *x2, delta2, cov2);
     // Create an partial relative constraint
     fuse_core::Vector2d delta3;
     delta3 << 0.1, 0.2;
     fuse_core::Matrix2d cov3;
     cov3 << 1.0, 0.0, 0.0, 3.0;
-    auto indices3 = std::vector<size_t>{2, 0};
-    auto c3 = fuse_constraints::RelativePosition3DStampedConstraint::make_shared(
-      "test",
-      *x1,
-      *x2,
-      delta3,
-      cov3,
-      indices3);
+    auto indices3 = std::vector<size_t> { 2, 0 };
+    auto c3 =
+      fuse_constraints::RelativePosition3DStampedConstraint::make_shared("test", *x1, *x2, delta3, cov3, indices3);
     // Build the problem
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -353,40 +313,29 @@ TEST(RelativeConstraint, Optimization)
       x1->data(),
       x1->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      x1->localParameterization()
+      x1->localParameterization());
 #else
-      x1->manifold()
+      x1->manifold());
 #endif
-    );
     problem.AddParameterBlock(
       x2->data(),
       x2->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-      x2->localParameterization()
+      x2->localParameterization());
 #else
-      x2->manifold()
+      x2->manifold());
 #endif
-    );
     std::vector<double*> c1_parameter_blocks;
     c1_parameter_blocks.push_back(x1->data());
-    problem.AddResidualBlock(
-      c1->costFunction(),
-      c1->lossFunction(),
-      c1_parameter_blocks);
+    problem.AddResidualBlock(c1->costFunction(), c1->lossFunction(), c1_parameter_blocks);
     std::vector<double*> c2_parameter_blocks;
     c2_parameter_blocks.push_back(x1->data());
     c2_parameter_blocks.push_back(x2->data());
-    problem.AddResidualBlock(
-      c2->costFunction(),
-      c2->lossFunction(),
-      c2_parameter_blocks);
+    problem.AddResidualBlock(c2->costFunction(), c2->lossFunction(), c2_parameter_blocks);
     std::vector<double*> c3_parameter_blocks;
     c3_parameter_blocks.push_back(x1->data());
     c3_parameter_blocks.push_back(x2->data());
-    problem.AddResidualBlock(
-      c3->costFunction(),
-      c3->lossFunction(),
-      c3_parameter_blocks);
+    problem.AddResidualBlock(c3->costFunction(), c3->lossFunction(), c3_parameter_blocks);
     // Run the solver
     ceres::Solver::Options options;
     ceres::Solver::Summary summary;
@@ -399,7 +348,7 @@ TEST(RelativeConstraint, Optimization)
     EXPECT_NEAR(2.2, x2->y(), 1.0e-5);
     EXPECT_NEAR(3.15, x2->z(), 1.0e-5);
     // Compute the marginal covariances
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(x1->data(), x1->data());
     covariance_blocks.emplace_back(x2->data(), x2->data());
     ceres::Covariance::Options cov_options;
@@ -427,35 +376,22 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   // Optimize a two-variable system with a prior on the first variable and a relative constraint connecting the two.
   // Verify the expected value and covariance are generated.
   // Create the variables
-  auto x1 = fuse_variables::Orientation2DStamped::make_shared(
-    ros::Time(1234, 5678),
-    fuse_core::uuid::generate("t800"));
+  auto x1 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1234, 5678), fuse_core::uuid::generate("t800"));
   x1->setYaw(0.7);
-  auto x2 = fuse_variables::Orientation2DStamped::make_shared(
-    ros::Time(1235, 5678),
-    fuse_core::uuid::generate("t800"));
+  auto x2 = fuse_variables::Orientation2DStamped::make_shared(ros::Time(1235, 5678), fuse_core::uuid::generate("t800"));
   x2->setYaw(-2.2);
   // Create an absolute constraint
   fuse_core::Vector1d mean;
   mean << 1.0;
   fuse_core::Matrix1d cov1;
   cov1 << 2.0;
-  auto prior = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared(
-    "test",
-    *x1,
-    mean,
-    cov1);
+  auto prior = fuse_constraints::AbsoluteOrientation2DStampedConstraint::make_shared("test", *x1, mean, cov1);
   // Create an relative constraint
   fuse_core::Vector1d delta;
   delta << 0.1;
   fuse_core::Matrix1d cov2;
   cov2 << 1.0;
-  auto relative = fuse_constraints::RelativeOrientation2DStampedConstraint::make_shared(
-    "test",
-    *x1,
-    *x2,
-    delta,
-    cov2);
+  auto relative = fuse_constraints::RelativeOrientation2DStampedConstraint::make_shared("test", *x1, *x2, delta, cov2);
   // Build the problem
   ceres::Problem::Options problem_options;
   problem_options.loss_function_ownership = fuse_core::Loss::Ownership;
@@ -464,33 +400,25 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
     x1->data(),
     x1->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    x1->localParameterization()
+    x1->localParameterization());
 #else
-    x1->manifold()
+    x1->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     x2->data(),
     x2->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    x2->localParameterization()
+    x2->localParameterization());
 #else
-    x2->manifold()
+    x2->manifold());
 #endif
-  );
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(x1->data());
-  problem.AddResidualBlock(
-    prior->costFunction(),
-    prior->lossFunction(),
-    prior_parameter_blocks);
+  problem.AddResidualBlock(prior->costFunction(), prior->lossFunction(), prior_parameter_blocks);
   std::vector<double*> relative_parameter_blocks;
   relative_parameter_blocks.push_back(x1->data());
   relative_parameter_blocks.push_back(x2->data());
-  problem.AddResidualBlock(
-    relative->costFunction(),
-    relative->lossFunction(),
-    relative_parameter_blocks);
+  problem.AddResidualBlock(relative->costFunction(), relative->lossFunction(), relative_parameter_blocks);
   // Run the solver
   ceres::Solver::Options options;
   ceres::Solver::Summary summary;
@@ -499,7 +427,7 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   EXPECT_NEAR(1.0, x1->getYaw(), 1.0e-5);
   EXPECT_NEAR(1.1, x2->getYaw(), 1.0e-5);
   // Compute the covariance
-  std::vector<std::pair<const double*, const double*> > covariance_blocks;
+  std::vector<std::pair<const double*, const double*>> covariance_blocks;
   covariance_blocks.emplace_back(x1->data(), x1->data());
   covariance_blocks.emplace_back(x2->data(), x2->data());
   ceres::Covariance::Options cov_options;
@@ -553,7 +481,7 @@ TEST(RelativeConstraint, Serialization)
   EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_constraints/test/test_relative_constraint.cpp
+++ b/fuse_constraints/test/test_relative_constraint.cpp
@@ -233,11 +233,21 @@ TEST(RelativeConstraint, Optimization)
     problem.AddParameterBlock(
       x1->data(),
       x1->size(),
-      x1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      x1->localParameterization()
+#else
+      x1->manifold()
+#endif
+    );
     problem.AddParameterBlock(
       x2->data(),
       x2->size(),
-      x2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      x2->localParameterization()
+#else
+      x2->manifold()
+#endif
+    );
     std::vector<double*> prior_parameter_blocks;
     prior_parameter_blocks.push_back(x1->data());
     problem.AddResidualBlock(
@@ -342,11 +352,21 @@ TEST(RelativeConstraint, Optimization)
     problem.AddParameterBlock(
       x1->data(),
       x1->size(),
-      x1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      x1->localParameterization()
+#else
+      x1->manifold()
+#endif
+    );
     problem.AddParameterBlock(
       x2->data(),
       x2->size(),
-      x2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+      x2->localParameterization()
+#else
+      x2->manifold()
+#endif
+    );
     std::vector<double*> c1_parameter_blocks;
     c1_parameter_blocks.push_back(x1->data());
     problem.AddResidualBlock(
@@ -443,11 +463,21 @@ TEST(RelativeConstraint, RelativeOrientation2DOptimization)
   problem.AddParameterBlock(
     x1->data(),
     x1->size(),
-    x1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    x1->localParameterization()
+#else
+    x1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     x2->data(),
     x2->size(),
-    x2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    x2->localParameterization()
+#else
+    x2->manifold()
+#endif
+  );
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(x1->data());
   problem.AddResidualBlock(

--- a/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_2d_stamped_constraint.cpp
@@ -145,19 +145,39 @@ TEST(RelativePose2DStampedConstraint, OptimizationFull)
   problem.AddParameterBlock(
     orientation1->data(),
     orientation1->size(),
-    orientation1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation1->localParameterization()
+#else
+    orientation1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position1->data(),
     position1->size(),
-    position1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position1->localParameterization()
+#else
+    position1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     orientation2->data(),
     orientation2->size(),
-    orientation2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation2->localParameterization()
+#else
+    orientation2->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position2->data(),
     position2->size(),
-    position2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position2->localParameterization()
+#else
+    position2->manifold()
+#endif
+  );
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(position1->data());
   prior_parameter_blocks.push_back(orientation1->data());
@@ -318,19 +338,39 @@ TEST(RelativePose2DStampedConstraint, OptimizationPartial)
   problem.AddParameterBlock(
     orientation1->data(),
     orientation1->size(),
-    orientation1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation1->localParameterization()
+#else
+    orientation1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position1->data(),
     position1->size(),
-    position1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position1->localParameterization()
+#else
+    position1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     orientation2->data(),
     orientation2->size(),
-    orientation2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation2->localParameterization()
+#else
+    orientation2->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position2->data(),
     position2->size(),
-    position2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position2->localParameterization()
+#else
+    position2->manifold()
+#endif
+  );
 
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(position1->data());

--- a/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
@@ -179,19 +179,39 @@ TEST(RelativePose3DStampedConstraint, Optimization)
   problem.AddParameterBlock(
     orientation1->data(),
     orientation1->size(),
-    orientation1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation1->localParameterization()
+#else
+    orientation1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position1->data(),
     position1->size(),
-    position1->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position1->localParameterization()
+#else
+    position1->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     orientation2->data(),
     orientation2->size(),
-    orientation2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    orientation2->localParameterization()
+#else
+    orientation2->manifold()
+#endif
+  );
   problem.AddParameterBlock(
     position2->data(),
     position2->size(),
-    position2->localParameterization());
+#if !CERES_SUPPORTS_MANIFOLDS
+    position2->localParameterization()
+#else
+    position2->manifold()
+#endif
+  );
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(position1->data());
   prior_parameter_blocks.push_back(orientation1->data());

--- a/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
+++ b/fuse_constraints/test/test_relative_pose_3d_stamped_constraint.cpp
@@ -48,11 +48,10 @@
 #include <utility>
 #include <vector>
 
-using fuse_variables::Orientation3DStamped;
-using fuse_variables::Position3DStamped;
 using fuse_constraints::AbsolutePose3DStampedConstraint;
 using fuse_constraints::RelativePose3DStampedConstraint;
-
+using fuse_variables::Orientation3DStamped;
+using fuse_variables::Position3DStamped;
 
 TEST(RelativePose3DStampedConstraint, Constructor)
 {
@@ -67,12 +66,12 @@ TEST(RelativePose3DStampedConstraint, Constructor)
 
   // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
   EXPECT_NO_THROW(
     RelativePose3DStampedConstraint constraint("test", position1, orientation1, position2, orientation2, delta, cov));
@@ -90,30 +89,24 @@ TEST(RelativePose3DStampedConstraint, Covariance)
 
   // Generated PD matrix using Octiave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
-  RelativePose3DStampedConstraint constraint(
-    "test",
-    position1,
-    orientation1,
-    position2,
-    orientation2,
-    delta,
-    cov);
+  RelativePose3DStampedConstraint constraint("test", position1, orientation1, position2, orientation2, delta, cov);
 
   // Define the expected matrices (used Octave to compute sqrt_info: 'chol(inv(A))')
   fuse_core::Matrix6d expected_sqrt_info;
-  expected_sqrt_info << 2.12658752275893, 1.20265444927878, 4.71225672571804, 1.43587520991272, -4.12764062992821, -3.19509486240291,    // NOLINT
-                        0.0,              2.41958656956248, 5.93151964116945, 3.72535320852517, -4.23326858606213, -5.27776664777548,    // NOLINT
-                        0.0,              0.0,              3.82674686590005, 2.80341171946161, -2.68168478581452, -2.8894384435255,     // NOLINT
-                        0.0,              0.0,              0.0,              1.83006791372784, -0.696917410192509, -1.17412835464633,   // NOLINT
-                        0.0,              0.0,              0.0,              0.0,               0.953302832761324, -0.769654414882847,  // NOLINT
-                        0.0,              0.0,              0.0,              0.0,               0.0,                0.681477739760948;  // NOLINT
+  expected_sqrt_info << 2.12658752275893, 1.20265444927878, 4.71225672571804, 1.43587520991272, -4.12764062992821,
+    -3.19509486240291,  // NOLINT
+    0.0, 2.41958656956248, 5.93151964116945, 3.72535320852517, -4.23326858606213, -5.27776664777548,  // NOLINT
+    0.0, 0.0, 3.82674686590005, 2.80341171946161, -2.68168478581452, -2.8894384435255,  // NOLINT
+    0.0, 0.0, 0.0, 1.83006791372784, -0.696917410192509, -1.17412835464633,  // NOLINT
+    0.0, 0.0, 0.0, 0.0, 0.953302832761324, -0.769654414882847,  // NOLINT
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.681477739760948;  // NOLINT
   fuse_core::Matrix6d expected_cov = cov;
 
   // Compare
@@ -152,12 +145,7 @@ TEST(RelativePose3DStampedConstraint, Optimization)
   fuse_core::Vector7d mean_origin;
   mean_origin << 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
   fuse_core::Matrix6d cov_origin = fuse_core::Matrix6d::Identity();
-  auto prior = AbsolutePose3DStampedConstraint::make_shared(
-    "test",
-    *position1,
-    *orientation1,
-    mean_origin,
-    cov_origin);
+  auto prior = AbsolutePose3DStampedConstraint::make_shared("test", *position1, *orientation1, mean_origin, cov_origin);
 
   // Create a relative pose constraint for 1m in the x direction
   fuse_core::Vector7d mean_delta;
@@ -180,54 +168,44 @@ TEST(RelativePose3DStampedConstraint, Optimization)
     orientation1->data(),
     orientation1->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation1->localParameterization()
+    orientation1->localParameterization());
 #else
-    orientation1->manifold()
+    orientation1->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     position1->data(),
     position1->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    position1->localParameterization()
+    position1->localParameterization());
 #else
-    position1->manifold()
+    position1->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     orientation2->data(),
     orientation2->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    orientation2->localParameterization()
+    orientation2->localParameterization());
 #else
-    orientation2->manifold()
+    orientation2->manifold());
 #endif
-  );
   problem.AddParameterBlock(
     position2->data(),
     position2->size(),
 #if !CERES_SUPPORTS_MANIFOLDS
-    position2->localParameterization()
+    position2->localParameterization());
 #else
-    position2->manifold()
+    position2->manifold());
 #endif
-  );
   std::vector<double*> prior_parameter_blocks;
   prior_parameter_blocks.push_back(position1->data());
   prior_parameter_blocks.push_back(orientation1->data());
-  problem.AddResidualBlock(
-    prior->costFunction(),
-    prior->lossFunction(),
-    prior_parameter_blocks);
+  problem.AddResidualBlock(prior->costFunction(), prior->lossFunction(), prior_parameter_blocks);
   std::vector<double*> relative_parameter_blocks;
   relative_parameter_blocks.push_back(position1->data());
   relative_parameter_blocks.push_back(orientation1->data());
   relative_parameter_blocks.push_back(position2->data());
   relative_parameter_blocks.push_back(orientation2->data());
-  problem.AddResidualBlock(
-    relative->costFunction(),
-    relative->lossFunction(),
-    relative_parameter_blocks);
+  problem.AddResidualBlock(relative->costFunction(), relative->lossFunction(), relative_parameter_blocks);
 
   // Run the solver
   ceres::Solver::Options options;
@@ -252,7 +230,7 @@ TEST(RelativePose3DStampedConstraint, Optimization)
 
   // Compute the marginal covariance for pose1
   {
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(position1->data(), position1->data());
     covariance_blocks.emplace_back(orientation1->data(), orientation1->data());
     covariance_blocks.emplace_back(position1->data(), orientation1->data());
@@ -276,20 +254,15 @@ TEST(RelativePose3DStampedConstraint, Optimization)
 
     // Define the expected covariance
     fuse_core::Matrix6d expected_covariance;
-    expected_covariance <<
-      1.0,  0.0,  0.0,  0.0,  0.0,  0.0,
-      0.0,  1.0,  0.0,  0.0,  0.0,  0.0,
-      0.0,  0.0,  1.0,  0.0,  0.0,  0.0,
-      0.0,  0.0,  0.0,  1.0,  0.0,  0.0,
-      0.0,  0.0,  0.0,  0.0,  1.0,  0.0,
-      0.0,  0.0,  0.0,  0.0,  0.0,  1.0;
+    expected_covariance << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0;
 
     EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-9);
   }
 
   // Compute the marginal covariance for pose2
   {
-    std::vector<std::pair<const double*, const double*> > covariance_blocks;
+    std::vector<std::pair<const double*, const double*>> covariance_blocks;
     covariance_blocks.emplace_back(position2->data(), position2->data());
     covariance_blocks.emplace_back(position2->data(), orientation2->data());
     covariance_blocks.emplace_back(orientation2->data(), orientation2->data());
@@ -313,13 +286,8 @@ TEST(RelativePose3DStampedConstraint, Optimization)
 
     // Define the expected covariance
     fuse_core::Matrix6d expected_covariance;
-    expected_covariance <<
-      2.0,  0.0,  0.0,  0.0,  0.0,  0.0,
-      0.0,  3.0,  0.0,  0.0,  0.0,  1.0,
-      0.0,  0.0,  3.0,  0.0, -1.0,  0.0,
-      0.0,  0.0,  0.0,  2.0,  0.0,  0.0,
-      0.0,  0.0, -1.0,  0.0,  2.0,  0.0,
-      0.0,  1.0,  0.0,  0.0,  0.0,  2.0;
+    expected_covariance << 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 3.0, 0.0, -1.0, 0.0,
+      0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0;
 
     EXPECT_MATRIX_NEAR(expected_covariance, actual_covariance, 1.0e-9);
   }
@@ -338,12 +306,12 @@ TEST(RelativePose3DStampedConstraint, Serialization)
 
   // Generated PD matrix using Octave: R = rand(6, 6); A = R * R' (use format long g to get the required precision)
   fuse_core::Matrix6d cov;
-  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891,  1.5153042667951,
-         1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
-         1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
-         1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
-         1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147,   2.503913946461, 1.73844731158092,
-         1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
+  cov << 2.0847236144069, 1.10752598122138, 1.02943174290333, 1.96120532313878, 1.96735470687891, 1.5153042667951,
+    1.10752598122138, 1.39176289439125, 0.643422499737987, 1.35471905449013, 1.18353784377297, 1.28979625492894,
+    1.02943174290333, 0.643422499737987, 1.26701658550187, 1.23641771365403, 1.55169301761377, 1.34706781598061,
+    1.96120532313878, 1.35471905449013, 1.23641771365403, 2.39750866789926, 2.06887486311147, 2.04350823837035,
+    1.96735470687891, 1.18353784377297, 1.55169301761377, 2.06887486311147, 2.503913946461, 1.73844731158092,
+    1.5153042667951, 1.28979625492894, 1.34706781598061, 2.04350823837035, 1.73844731158092, 2.15326088526198;
 
   RelativePose3DStampedConstraint expected("test", position1, orientation1, position2, orientation2, delta, cov);
 
@@ -368,7 +336,7 @@ TEST(RelativePose3DStampedConstraint, Serialization)
   EXPECT_MATRIX_EQ(expected.sqrtInformation(), actual.sqrtInformation());
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -58,6 +58,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
@@ -86,6 +89,9 @@ add_dependencies(fuse_echo
 target_include_directories(fuse_echo
   PUBLIC
     include
+)
+target_include_directories(fuse_echo
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
 )
 target_link_libraries(fuse_echo

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -212,9 +212,7 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   double delta[kLocalSize] = {};  // zero-initialize
 
   const double* parameter_ptrs[2] = {x, x};
-  // We only need to compute the Jacobian w.r.t. the first argument, see:
-  // https://github.com/ceres-solver/ceres-solver/blob/77497373193a6304a67d0/include/ceres/autodiff_manifold.h#L244-L246
-  double* jacobian_ptrs[2] = {jacobian, NULL};
+  double* jacobian_ptrs[2] = {NULL, jacobian};
 #if !CERES_VERSION_AT_LEAST(2, 0, 0)
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -212,7 +212,9 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   double delta[kLocalSize] = {};  // zero-initialize
 
   const double* parameter_ptrs[2] = {x, x};
-  double* jacobian_ptrs[2] = {NULL, jacobian};
+  // We only need to compute the Jacobian w.r.t. the first argument, see:
+  // https://github.com/ceres-solver/ceres-solver/blob/77497373193a6304a67d0/include/ceres/autodiff_manifold.h#L244-L246
+  double* jacobian_ptrs[2] = {jacobian, NULL};
 #if !CERES_VERSION_AT_LEAST(2, 0, 0)
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);

--- a/fuse_core/include/fuse_core/ceres_macros.h
+++ b/fuse_core/include/fuse_core/ceres_macros.h
@@ -43,4 +43,6 @@
                                         (CERES_VERSION_MINOR > y || (CERES_VERSION_MINOR    >= y && \
                                                                      CERES_VERSION_REVISION >= z))))
 
+#define CERES_SUPPORTS_MANIFOLDS CERES_VERSION_AT_LEAST(2, 1, 0)
+
 #endif  // FUSE_CORE_CERES_MACROS_H

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -71,21 +71,25 @@ public:
   /**
    * @brief Generalization of the subtraction operation
    *
-   * Minus(x1, x2) -> delta
+   * Minus(y, x) -> x_minus_y
    *
    * with the conditions that:
    *  - Minus(x, x) -> 0
-   *  - if Plus(x1, delta) -> x2, then Minus(x1, x2) -> delta
+   *  - if Plus(y, delta) -> x, then Minus(y, x) -> delta
+   * 
+   * i.e. x + delta = y
    *
-   * @param[in]  x1    The value of the first variable, of size \p GlobalSize()
-   * @param[in]  x2    The value of the second variable, of size \p GlobalSize()
-   * @param[out] delta The difference between the second variable and the first, of size \p LocalSize()
+   * @param[in]  x    The value of the first variable, of size \p GlobalSize()
+   * @param[in]  y    The value of the second variable, of size \p GlobalSize()
+   * @param[out] y_minus_x The difference between the second variable and the first, of size \p LocalSize()
    * @return True if successful, false otherwise
    */
-  virtual bool Minus(const double* x1, const double* x2, double* delta) const = 0;
+  virtual bool Minus(const double* x, const double* y, double* y_minus_x) const = 0;
 
   /**
-   * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
+   * @brief The jacobian of Minus(y, x) w.r.t x at x = y, i.e
+   * 
+   *      (D_1 Minus) (x, x)
    *
    * @param[in]  x        The value used to evaluate the Jacobian, of size \p GlobalSize()
    * @param[out] jacobian The first-order derivative in row-major order, of size \p LocalSize() x \p GlobalSize()

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -85,9 +85,9 @@ public:
   virtual bool Minus(const double* x, const double* y, double* y_minus_x) const = 0;
 
   /**
-   * @brief The jacobian of Minus(y, x) w.r.t x at x = y, i.e
+   * @brief The jacobian of Minus(x, y) w.r.t y at y = x, i.e
    * 
-   *      (D_1 Minus) (x, x)
+   *      (D_1 Minus) (y, y)
    *
    * @param[in]  x        The value used to evaluate the Jacobian, of size \p GlobalSize()
    * @param[out] jacobian The first-order derivative in row-major order, of size \p LocalSize() x \p GlobalSize()

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -71,7 +71,7 @@ public:
   /**
    * @brief Generalization of the subtraction operation
    *
-   * Minus(y, x) -> x_minus_y
+   * Minus(x, y) -> y_minus_x
    *
    * with the conditions that:
    *  - Minus(x, x) -> 0

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -40,16 +40,11 @@
 
 #include <boost/serialization/access.hpp>
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-// Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
+// Local parameterizations is removed in favour of Manifold in
+// version 2.2.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
-// and they got removed in 2.2.0, see
-// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
-#include <fuse_core/manifold.h>
-#else
 #include <ceres/local_parameterization.h>
-#endif
-
 
 namespace fuse_core
 {
@@ -64,17 +59,11 @@ namespace fuse_core
  *
  * See the Ceres documentation for more details. http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class LocalParameterization : public
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-                              fuse_core::Manifold
-#else
-                              ceres::LocalParameterization
-#endif
+class LocalParameterization : public ceres::LocalParameterization
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
 
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Generalization of the subtraction operation
    *
@@ -104,7 +93,6 @@ public:
   virtual bool ComputeMinusJacobian(
     const double* x,
     double* jacobian) const = 0;
-#endif
 
 private:
   // Allow Boost Serialization access to private methods
@@ -123,5 +111,7 @@ private:
 };
 
 }  // namespace fuse_core
+
+#endif 
 
 #endif  // FUSE_CORE_LOCAL_PARAMETERIZATION_H

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -75,9 +75,7 @@ public:
    *
    * with the conditions that:
    *  - Minus(x, x) -> 0
-   *  - if Plus(y, delta) -> x, then Minus(y, x) -> delta
-   * 
-   * i.e. x + delta = y
+   *  - if Plus(y, delta) -> x, then Minus(x, y) -> delta
    *
    * @param[in]  x    The value of the first variable, of size \p GlobalSize()
    * @param[in]  y    The value of the second variable, of size \p GlobalSize()

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -45,7 +45,7 @@
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
 // and they got removed in 2.2.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
-#include <ceres/manifold.h>
+#include <fuse_core/manifold.h>
 #else
 #include <ceres/local_parameterization.h>
 #endif
@@ -66,7 +66,7 @@ namespace fuse_core
  */
 class LocalParameterization : public
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-                              ceres::Manifold
+                              fuse_core::Manifold
 #else
                               ceres::LocalParameterization
 #endif

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -34,11 +34,21 @@
 #ifndef FUSE_CORE_LOCAL_PARAMETERIZATION_H
 #define FUSE_CORE_LOCAL_PARAMETERIZATION_H
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+// Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+// and they got removed in 2.2.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+#include <ceres/manifold.h>
+#else
 #include <ceres/local_parameterization.h>
+#endif
 
 
 namespace fuse_core
@@ -54,11 +64,17 @@ namespace fuse_core
  *
  * See the Ceres documentation for more details. http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class LocalParameterization : public ceres::LocalParameterization
+class LocalParameterization : public
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+                              ceres::Manifold
+#else
+                              ceres::LocalParameterization
+#endif
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
 
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Generalization of the subtraction operation
    *
@@ -88,6 +104,7 @@ public:
   virtual bool ComputeMinusJacobian(
     const double* x,
     double* jacobian) const = 0;
+#endif
 
 private:
   // Allow Boost Serialization access to private methods

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -100,19 +100,27 @@ public:
 #if CERES_SUPPORTS_MANIFOLDS
   virtual ~LocalParameterization() = default;
 
-  // Generalization of the addition operation,
-  //
-  //   x_plus_delta = Plus(x, delta)
-  //
-  // with the condition that Plus(x, 0) = x.
-  //
+  /**
+   * @brief Generalization of the addition operation,
+   * 
+   *    x_plus_delta = Plus(x, delta)
+   * 
+   * with the condition that Plus(x, 0) = x.
+   * @param[in] x variable of size \p GlobalSize()
+   * @param[in] delta variable of size \p LocalSize()
+   * @param[out] x_plus_delta of size \p GlobalSize()
+  */
   virtual bool Plus(const double* x,
                     const double* delta,
                     double* x_plus_delta) const = 0;
 
-  // The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
-  //
-  // jacobian is a row-major GlobalSize() x LocalSize() matrix.
+  /**
+   * @brief The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
+   * 
+   * @param[in] x variable of size \p GlobalSize()
+   * @param[out] jacobian a row-major GlobalSize() x LocalSize() matrix.
+   * @return 
+   */
   virtual bool ComputeJacobian(const double* x, double* jacobian) const = 0;
 
   /**

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -40,11 +40,12 @@
 
 #include <boost/serialization/access.hpp>
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
 // Local parameterizations is removed in favour of Manifold in
 // version 2.2.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
 #include <ceres/local_parameterization.h>
+#endif
 
 namespace fuse_core
 {
@@ -58,7 +59,11 @@ namespace fuse_core
  *
  * See the Ceres documentation for more details. http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class LocalParameterization : public ceres::LocalParameterization
+class LocalParameterization
+// extend ceres LocalParameterization if we are <= 2.1
+#if !CERES_SUPPORTS_MANIFOLDS
+  : public ceres::LocalParameterization
+#endif
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
@@ -88,6 +93,65 @@ public:
    */
   virtual bool ComputeMinusJacobian(const double* x, double* jacobian) const = 0;
 
+#if CERES_SUPPORTS_MANIFOLDS
+  virtual ~LocalParameterization() = default;
+
+  // Generalization of the addition operation,
+  //
+  //   x_plus_delta = Plus(x, delta)
+  //
+  // with the condition that Plus(x, 0) = x.
+  //
+  virtual bool Plus(const double* x,
+                    const double* delta,
+                    double* x_plus_delta) const = 0;
+
+  // The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
+  //
+  // jacobian is a row-major GlobalSize() x LocalSize() matrix.
+  virtual bool ComputeJacobian(const double* x, double* jacobian) const = 0;
+
+  /**
+   * @brief Computes local_matrix = global_matrix * jacobian
+   *
+   * This is only used by GradientProblem. For most normal uses, it is
+   * okay to use the default implementation.
+   *
+   * jacobian(x) is the matrix returned by ComputeJacobian at x.
+   *
+   * @param[in] x
+   * @param[in] num_rows
+   * @param[in] global_matrix is a num_rows x GlobalSize  row major matrix.
+   * @param[out] local_matrix is a num_rows x LocalSize row major matrix.
+   */
+  virtual bool MultiplyByJacobian(
+    const double* x,
+    const int num_rows,
+    const double* global_matrix,
+    double* local_matrix) const
+  {
+    if (LocalSize() == 0)
+    {
+      return true;
+    }
+
+    Eigen::MatrixXd jacobian(GlobalSize(), LocalSize());
+    if (!ComputeJacobian(x, jacobian.data()))
+    {
+      return false;
+    }
+
+    Eigen::Map<Eigen::MatrixXd>(local_matrix, num_rows, LocalSize()) =
+      Eigen::Map<const Eigen::MatrixXd>(global_matrix, num_rows, GlobalSize()) * jacobian;
+    return true;
+  }
+
+  // Size of x.
+  virtual int GlobalSize() const = 0;
+  // Size of delta.
+  virtual int LocalSize() const = 0;
+
+#endif
 private:
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;
@@ -105,7 +169,5 @@ private:
 };
 
 }  // namespace fuse_core
-
-#endif
 
 #endif  // FUSE_CORE_LOCAL_PARAMETERIZATION_H

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -48,7 +48,6 @@
 
 namespace fuse_core
 {
-
 /**
  * @brief The LocalParameterization interface definition.
  *
@@ -78,10 +77,7 @@ public:
    * @param[out] delta The difference between the second variable and the first, of size \p LocalSize()
    * @return True if successful, false otherwise
    */
-  virtual bool Minus(
-    const double* x1,
-    const double* x2,
-    double* delta) const = 0;
+  virtual bool Minus(const double* x1, const double* x2, double* delta) const = 0;
 
   /**
    * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
@@ -90,9 +86,7 @@ public:
    * @param[out] jacobian The first-order derivative in row-major order, of size \p LocalSize() x \p GlobalSize()
    * @return True if successful, false otherwise
    */
-  virtual bool ComputeMinusJacobian(
-    const double* x,
-    double* jacobian) const = 0;
+  virtual bool ComputeMinusJacobian(const double* x, double* jacobian) const = 0;
 
 private:
   // Allow Boost Serialization access to private methods
@@ -104,7 +98,7 @@ private:
    * @param[in/out] archive - The archive object that holds the serialized class members
    * @param[in] version - The version of the archive being read/written. Generally unused.
    */
-  template<class Archive>
+  template <class Archive>
   void serialize(Archive& /* archive */, const unsigned int /* version */)
   {
   }
@@ -112,6 +106,6 @@ private:
 
 }  // namespace fuse_core
 
-#endif 
+#endif
 
 #endif  // FUSE_CORE_LOCAL_PARAMETERIZATION_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -1,0 +1,161 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_MANIFOLD_H
+#define FUSE_CORE_MANIFOLD_H
+
+#include <fuse_core/ceres_macros.h>
+#include <fuse_core/fuse_macros.h>
+#include <fuse_core/serialization.h>
+
+#include <boost/serialization/access.hpp>
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+// Local parameterizations got marked as deprecated in favour of Manifold in
+// version 2.1.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+// and they got removed in 2.2.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+#include <ceres/manifold.h>
+
+namespace fuse_core {
+
+/**
+ * @brief The Manifold interface definition.
+ *
+ * This class extends the Ceres Manifold class but adds methods to match the
+ * fuse::LocalParameterization API
+ *
+ * See the Ceres documentation for more details.
+ * http://ceres-solver.org/nnls_modeling.html#manifold
+ */
+class Manifold : public ceres::Manifold {
+public:
+  FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
+
+  /**
+   * @brief Generalization of the addition operation, with the condition that
+   * Plus(x, 0) = x
+   *
+   * @param[in] x    The value of the first variable, of size \p GlobalSize()
+   * @param[in] delta The value of the perturbation, of size \p LocalSize()
+   * @param[out] x_plus_delta Perturbed x, of size \p GlobalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool Plus(const double *x, const double *delta,
+                    double *x_plus_delta) const = 0;
+
+  /**
+   * @brief The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
+   *
+   * @param[in] x    The value of the first variable, of size \p GlobalSize()
+   * @param[out] jacobian Jacobian is a row-major GlobalSize() x LocalSize()
+   * matrix.
+   * @return True if successful, false otherwise
+   */
+  virtual bool ComputeJacobian(const double *x,
+                               double *jacobian) const = 0;
+
+  /**
+   * @brief Generalization of the subtraction operation
+   *
+   * Minus(x2, x1) -> x2_minus_x1
+   *
+   * with the conditions that:
+   *  - Minus(x, x) -> 0
+   *  - if Plus(x1, delta) -> x2, then Minus(x2, x1) -> delta
+   *
+   * @param[in]  x2    The value of the first variable, of size \p GlobalSize()
+   * @param[in]  x1    The value of the second variable, of size \p GlobalSize()
+   * @param[out] x2_minus_x1 The difference between x2 and x1, of size \p
+   * LocalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool Minus(const double *x2, const double *x1,
+                     double *x2_minus_x1) const = 0;
+
+  /**
+   * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
+   *
+   * @param[in]  x        The value used to evaluate the Jacobian, of size \p
+   * GlobalSize()
+   * @param[out] jacobian The first-order derivative in row-major order, of size
+   * \p LocalSize() x \p GlobalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool ComputeMinusJacobian(const double *x,
+                                    double *jacobian) const = 0;
+
+  // Size of x.
+  virtual int GlobalSize() const = 0;
+  // Size of delta.
+  virtual int LocalSize() const = 0;
+
+  /// Equivalent to \p GlobalSize()
+  int AmbientSize() const override { return GlobalSize(); }
+
+  /// Equivalent to \p LocalSize()
+  int TangentSize() const override { return LocalSize(); }
+
+  /// Equivalent to \p ComputeJacobian()
+  bool PlusJacobian(const double *x, double *jacobian) const override {
+    return ComputeJacobian(x, jacobian);
+  }
+
+  /// Equivalent to \p ComputeMinusJacobian()
+  bool MinusJacobian(const double *x, double *jacobian) const override {
+    return ComputeMinusJacobian(x, jacobian);
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive & /* archive */, const unsigned int /* version */) {}
+};
+
+} // namespace fuse_core
+
+#endif
+
+#endif // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -48,8 +48,7 @@
 // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
 #include <ceres/manifold.h>
 
-namespace fuse_core 
-{
+namespace fuse_core {
 
 /**
  * @brief The Manifold interface definition.
@@ -60,92 +59,69 @@ namespace fuse_core
  * See the Ceres documentation for more details.
  * http://ceres-solver.org/nnls_modeling.html#manifold
  */
-class Manifold : public ceres::Manifold 
-{
+class Manifold : public ceres::Manifold {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
 
+  // Dimension of the ambient space in which the manifold is embedded.
+  virtual int AmbientSize() const = 0;
+
+  // Dimension of the manifold/tangent space.
+  virtual int TangentSize() const = 0;
+
   /**
-   * @brief Generalization of the addition operation, with the condition that
-   * Plus(x, 0) = x
+   * @brief  x_plus_delta = Plus(x, delta),
    *
-   * @param[in] x    The value of the first variable, of size \p GlobalSize()
-   * @param[in] delta The value of the perturbation, of size \p LocalSize()
-   * @param[out] x_plus_delta Perturbed x, of size \p GlobalSize()
-   * @return True if successful, false otherwise
+   * A generalization of vector addition in Euclidean space, Plus computes the
+   * result of moving along delta in the tangent space at x, and then projecting
+   * back onto the manifold that x belongs to.
+   *
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[in] delta delta is a \p TangentSize() vector.
+   * @param[out] x_plus_delta  is a \p AmbientSize() vector.
+   * @return Return value indicates if the operation was successful or not.
    */
   virtual bool Plus(const double *x, const double *delta,
                     double *x_plus_delta) const = 0;
 
   /**
-   * @brief The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
+   * @brief Compute the derivative of Plus(x, delta) w.r.t delta at delta = 0,
+   * i.e.
    *
-   * @param[in] x    The value of the first variable, of size \p GlobalSize()
-   * @param[out] jacobian Jacobian is a row-major GlobalSize() x LocalSize()
+   * (D_2 Plus)(x, 0)
+   *
+   * @param[in] x is a \p AmbientSize() vector
+   * @param[out] jacobian is a row-major \p AmbientSize() x \p TangentSize()
    * matrix.
-   * @return True if successful, false otherwise
+   * @return
    */
-  virtual bool ComputeJacobian(const double *x,
-                               double *jacobian) const = 0;
+  virtual bool PlusJacobian(const double *x, double *jacobian) const = 0;
 
   /**
-   * @brief Generalization of the subtraction operation
-   *
-   * Minus(x2, x1) -> x2_minus_x1
-   *
-   * with the conditions that:
-   *  - Minus(x, x) -> 0
-   *  - if Plus(x1, delta) -> x2, then Minus(x2, x1) -> delta
-   *
-   * @param[in]  x2    The value of the first variable, of size \p GlobalSize()
-   * @param[in]  x1    The value of the second variable, of size \p GlobalSize()
-   * @param[out] x2_minus_x1 The difference between x2 and x1, of size \p
-   * LocalSize()
-   * @return True if successful, false otherwise
+   * @brief y_minus_x = Minus(y, x)
+   * 
+   * Given two points on the manifold, Minus computes the change to x in the
+   * tangent space at x, that will take it to y.
+   * 
+   * @param[in] y is a \p AmbientSize() vector.
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] y_minus_x is a \p TangentSize() vector.
+   * @return Return value indicates if the operation was successful or not.
    */
-  virtual bool Minus(const double *x2, const double *x1,
-                     double *x2_minus_x1) const = 0;
+  virtual bool Minus(const double *y, const double *x,
+                     double *y_minus_x) const = 0;
+
 
   /**
-   * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
-   *
-   * @param[in]  x        The value used to evaluate the Jacobian, of size \p
-   * GlobalSize()
-   * @param[out] jacobian The first-order derivative in row-major order, of size
-   * \p LocalSize() x \p GlobalSize()
-   * @return True if successful, false otherwise
+   * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
+   * 
+   *      (D_1 Minus) (x, x)
+   * 
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.
+   * @return Return value indicates whether the operation was successful or not.
    */
-  virtual bool ComputeMinusJacobian(const double *x,
-                                    double *jacobian) const = 0;
-
-  // Size of x.
-  virtual int GlobalSize() const = 0;
-  // Size of delta.
-  virtual int LocalSize() const = 0;
-
-  /// Equivalent to \p GlobalSize()
-  int AmbientSize() const override 
-  { 
-    return GlobalSize(); 
-  }
-
-  /// Equivalent to \p LocalSize()
-  int TangentSize() const override 
-  { 
-    return LocalSize(); 
-  }
-
-  /// Equivalent to \p ComputeJacobian()
-  bool PlusJacobian(const double *x, double *jacobian) const override 
-  {
-    return ComputeJacobian(x, jacobian);
-  }
-
-  /// Equivalent to \p ComputeMinusJacobian()
-  bool MinusJacobian(const double *x, double *jacobian) const override 
-  {
-    return ComputeMinusJacobian(x, jacobian);
-  }
+  virtual bool MinusJacobian(const double *x, double *jacobian) const = 0;
 
 private:
   // Allow Boost Serialization access to private methods
@@ -164,8 +140,8 @@ private:
   void serialize(Archive & /* archive */, const unsigned int /* version */) {}
 };
 
-}  // namespace fuse_core
+} // namespace fuse_core
 
 #endif
 
-#endif  // FUSE_CORE_MANIFOLD_H
+#endif // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -48,7 +48,8 @@
 // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
 #include <ceres/manifold.h>
 
-namespace fuse_core {
+namespace fuse_core 
+{
 
 /**
  * @brief The Manifold interface definition.
@@ -59,7 +60,8 @@ namespace fuse_core {
  * See the Ceres documentation for more details.
  * http://ceres-solver.org/nnls_modeling.html#manifold
  */
-class Manifold : public ceres::Manifold {
+class Manifold : public ceres::Manifold 
+{
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
 
@@ -122,18 +124,26 @@ public:
   virtual int LocalSize() const = 0;
 
   /// Equivalent to \p GlobalSize()
-  int AmbientSize() const override { return GlobalSize(); }
+  int AmbientSize() const override 
+  { 
+    return GlobalSize(); 
+  }
 
   /// Equivalent to \p LocalSize()
-  int TangentSize() const override { return LocalSize(); }
+  int TangentSize() const override 
+  { 
+    return LocalSize(); 
+  }
 
   /// Equivalent to \p ComputeJacobian()
-  bool PlusJacobian(const double *x, double *jacobian) const override {
+  bool PlusJacobian(const double *x, double *jacobian) const override 
+  {
     return ComputeJacobian(x, jacobian);
   }
 
   /// Equivalent to \p ComputeMinusJacobian()
-  bool MinusJacobian(const double *x, double *jacobian) const override {
+  bool MinusJacobian(const double *x, double *jacobian) const override 
+  {
     return ComputeMinusJacobian(x, jacobian);
   }
 
@@ -154,8 +164,8 @@ private:
   void serialize(Archive & /* archive */, const unsigned int /* version */) {}
 };
 
-} // namespace fuse_core
+}  // namespace fuse_core
 
 #endif
 
-#endif // FUSE_CORE_MANIFOLD_H
+#endif  // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -103,6 +103,8 @@ public:
    *
    * Given two points on the manifold, Minus computes the change to x in the
    * tangent space at x, that will take it to y.
+   * 
+   * i.e. x + delta = y
    *
    * @param[in] y is a \p AmbientSize() vector.
    * @param[in] x is a \p AmbientSize() vector.
@@ -114,7 +116,7 @@ public:
   /**
    * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
    *
-   *      (D_1 Minus) (x, x)
+   *      (D_1 Minus) (y, y)
    *
    * @param[in] x is a \p AmbientSize() vector.
    * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -99,12 +99,13 @@ public:
   virtual bool PlusJacobian(const double* x, double* jacobian) const = 0;
 
   /**
-   * @brief y_minus_x = Minus(y, x)
+   * @brief Generalization of the subtraction operation
    *
-   * Given two points on the manifold, Minus computes the change to x in the
-   * tangent space at x, that will take it to y.
-   * 
-   * i.e. x + delta = y
+   * Minus(y, x) -> y_minus_x
+   *
+   * with the conditions that:
+   *  - Minus(x, x) -> 0
+   *  - if Plus(y, delta) -> x, then Minus(y, x) -> delta
    *
    * @param[in] y is a \p AmbientSize() vector.
    * @param[in] x is a \p AmbientSize() vector.

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -35,12 +35,13 @@
 #define FUSE_CORE_MANIFOLD_H
 
 #include <fuse_core/ceres_macros.h>
+
+#if CERES_SUPPORTS_MANIFOLDS
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
 // Local parameterizations got marked as deprecated in favour of Manifold in
 // version 2.1.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -48,8 +48,8 @@
 // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
 #include <ceres/manifold.h>
 
-namespace fuse_core {
-
+namespace fuse_core
+{
 /**
  * @brief The Manifold interface definition.
  *
@@ -59,7 +59,8 @@ namespace fuse_core {
  * See the Ceres documentation for more details.
  * http://ceres-solver.org/nnls_modeling.html#manifold
  */
-class Manifold : public ceres::Manifold {
+class Manifold : public ceres::Manifold
+{
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
 
@@ -81,8 +82,7 @@ public:
    * @param[out] x_plus_delta  is a \p AmbientSize() vector.
    * @return Return value indicates if the operation was successful or not.
    */
-  virtual bool Plus(const double *x, const double *delta,
-                    double *x_plus_delta) const = 0;
+  virtual bool Plus(const double* x, const double* delta, double* x_plus_delta) const = 0;
 
   /**
    * @brief Compute the derivative of Plus(x, delta) w.r.t delta at delta = 0,
@@ -95,33 +95,31 @@ public:
    * matrix.
    * @return
    */
-  virtual bool PlusJacobian(const double *x, double *jacobian) const = 0;
+  virtual bool PlusJacobian(const double* x, double* jacobian) const = 0;
 
   /**
    * @brief y_minus_x = Minus(y, x)
-   * 
+   *
    * Given two points on the manifold, Minus computes the change to x in the
    * tangent space at x, that will take it to y.
-   * 
+   *
    * @param[in] y is a \p AmbientSize() vector.
    * @param[in] x is a \p AmbientSize() vector.
    * @param[out] y_minus_x is a \p TangentSize() vector.
    * @return Return value indicates if the operation was successful or not.
    */
-  virtual bool Minus(const double *y, const double *x,
-                     double *y_minus_x) const = 0;
-
+  virtual bool Minus(const double* y, const double* x, double* y_minus_x) const = 0;
 
   /**
    * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
-   * 
+   *
    *      (D_1 Minus) (x, x)
-   * 
+   *
    * @param[in] x is a \p AmbientSize() vector.
    * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.
    * @return Return value indicates whether the operation was successful or not.
    */
-  virtual bool MinusJacobian(const double *x, double *jacobian) const = 0;
+  virtual bool MinusJacobian(const double* x, double* jacobian) const = 0;
 
 private:
   // Allow Boost Serialization access to private methods
@@ -137,11 +135,13 @@ private:
    * Generally unused.
    */
   template <class Archive>
-  void serialize(Archive & /* archive */, const unsigned int /* version */) {}
+  void serialize(Archive& /* archive */, const unsigned int /* version */)
+  {
+  }
 };
 
-} // namespace fuse_core
+}  // namespace fuse_core
 
 #endif
 
-#endif // FUSE_CORE_MANIFOLD_H
+#endif  // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -47,27 +47,80 @@ namespace fuse_core
 class ManifoldAdapter : public fuse_core::Manifold
 {
 public:
-  ManifoldAdapter(LocalParameterization* local_parameterization) : local_parameterization_(local_parameterization) {}
+  /**
+   * @brief Constructor to adapt a fuse::LocalParameterization into a fuse::Manifold
+   *
+   * @param[in] local_parameterization fuse::LocalParameterization
+   */
+  explicit ManifoldAdapter(LocalParameterization* local_parameterization) :
+    local_parameterization_(local_parameterization)
+  {
+  }
 
+  // Dimension of the ambient space in which the manifold is embedded.
   int AmbientSize() const override { return local_parameterization_->GlobalSize(); }
 
+  // Dimension of the manifold/tangent space.
   int TangentSize() const override { return local_parameterization_->LocalSize(); }
 
+  /**
+   * @brief  x_plus_delta = Plus(x, delta),
+   *
+   * A generalization of vector addition in Euclidean space, Plus computes the
+   * result of moving along delta in the tangent space at x, and then projecting
+   * back onto the manifold that x belongs to.
+   *
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[in] delta delta is a \p TangentSize() vector.
+   * @param[out] x_plus_delta  is a \p AmbientSize() vector.
+   * @return Return value indicates if the operation was successful or not.
+   */
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
     return local_parameterization_->Plus(x, delta, x_plus_delta);
   }
 
+  /**
+   * @brief Compute the derivative of Plus(x, delta) w.r.t delta at delta = 0,
+   * i.e.
+   *
+   * (D_2 Plus)(x, 0)
+   *
+   * @param[in] x is a \p AmbientSize() vector
+   * @param[out] jacobian is a row-major \p AmbientSize() x \p TangentSize()
+   * matrix.
+   * @return
+   */
   bool PlusJacobian(const double* x, double* jacobian) const override
   {
     return local_parameterization_->ComputeJacobian(x, jacobian);
   }
 
+  /**
+   * @brief y_minus_x = Minus(y, x)
+   *
+   * Given two points on the manifold, Minus computes the change to x in the
+   * tangent space at x, that will take it to y.
+   *
+   * @param[in] y is a \p AmbientSize() vector.
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] y_minus_x is a \p TangentSize() vector.
+   * @return Return value indicates if the operation was successful or not.
+   */
   bool Minus(const double* y, const double* x, double* y_minus_x) const override
   {
     return local_parameterization_->Minus(x, y, y_minus_x);
   }
 
+  /**
+   * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
+   *
+   *      (D_1 Minus) (x, x)
+   *
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.
+   * @return Return value indicates whether the operation was successful or not.
+   */
   bool MinusJacobian(const double* x, double* jacobian) const override
   {
     return local_parameterization_->ComputeMinusJacobian(x, jacobian);

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -42,46 +42,44 @@
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
 
-namespace fuse_core {
-
-class ManifoldAdapter : public fuse_core::Manifold {
+namespace fuse_core
+{
+class ManifoldAdapter : public fuse_core::Manifold
+{
 public:
-  ManifoldAdapter(LocalParameterization *local_parameterization)
-      : local_parameterization_(local_parameterization) {}
+  ManifoldAdapter(LocalParameterization* local_parameterization) : local_parameterization_(local_parameterization) {}
 
-  int AmbientSize() const override {
-    return local_parameterization_->GlobalSize();
-  }
+  int AmbientSize() const override { return local_parameterization_->GlobalSize(); }
 
-  int TangentSize() const override {
-    return local_parameterization_->LocalSize();
-  }
+  int TangentSize() const override { return local_parameterization_->LocalSize(); }
 
-  bool Plus(const double *x, const double *delta,
-            double *x_plus_delta) const override {
+  bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
+  {
     return local_parameterization_->Plus(x, delta, x_plus_delta);
   }
 
-  bool PlusJacobian(const double *x, double *jacobian) const override {
+  bool PlusJacobian(const double* x, double* jacobian) const override
+  {
     return local_parameterization_->ComputeJacobian(x, jacobian);
   }
-  
-  bool Minus(const double *y, const double *x,
-             double *y_minus_x) const override {
+
+  bool Minus(const double* y, const double* x, double* y_minus_x) const override
+  {
     return local_parameterization_->Minus(x, y, y_minus_x);
   }
 
-  bool MinusJacobian(const double *x, double *jacobian) const override {
+  bool MinusJacobian(const double* x, double* jacobian) const override
+  {
     return local_parameterization_->ComputeMinusJacobian(x, jacobian);
   }
 
 private:
-  fuse_core::LocalParameterization *local_parameterization_;
+  fuse_core::LocalParameterization* local_parameterization_;
 };
 
-} // namespace fuse_core
+}  // namespace fuse_core
 
 #endif
 #endif
 
-#endif // FUSE_CORE_MANIFOLD_ADAPTER_H
+#endif  // FUSE_CORE_MANIFOLD_ADAPTER_H

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -122,7 +122,13 @@ public:
    */
   bool MinusJacobian(const double* x, double* jacobian) const override
   {
-    return local_parameterization_->ComputeMinusJacobian(x, jacobian);
+    const auto success = local_parameterization_->ComputeMinusJacobian(x, jacobian);
+    const auto N = TangentSize() * AmbientSize();
+    for (int i = 0; i < N; i++)
+    {
+      jacobian[i] = -jacobian[i];
+    }
+    return success;
   }
 
 private:

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -35,12 +35,11 @@
 #ifndef FUSE_CORE_MANIFOLD_ADAPTER_H
 #define FUSE_CORE_MANIFOLD_ADAPTER_H
 
+#include <fuse_core/ceres_macros.h>
+
+#if CERES_SUPPORTS_MANIFOLDS
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/manifold.h>
-
-// This is only needed for exactly ceres == 2.1.x
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 
 namespace fuse_core
 {
@@ -52,9 +51,9 @@ public:
    *
    * @param[in] local_parameterization fuse::LocalParameterization
    */
-  explicit ManifoldAdapter(LocalParameterization* local_parameterization) :
-    local_parameterization_(local_parameterization)
+  explicit ManifoldAdapter(fuse_core::LocalParameterization* local_parameterization)
   {
+    *local_parameterization_ = *local_parameterization;
   }
 
   // Dimension of the ambient space in which the manifold is embedded.
@@ -127,12 +126,11 @@ public:
   }
 
 private:
-  fuse_core::LocalParameterization* local_parameterization_;
+  std::unique_ptr<fuse_core::LocalParameterization> local_parameterization_;
 };
 
 }  // namespace fuse_core
 
-#endif
 #endif
 
 #endif  // FUSE_CORE_MANIFOLD_ADAPTER_H

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -116,7 +116,7 @@ public:
   /**
    * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
    *
-   *      (D_1 Minus) (x, x)
+   *      (D_1 Minus) (y, y)
    *
    * @param[in] x is a \p AmbientSize() vector.
    * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.
@@ -124,13 +124,7 @@ public:
    */
   bool MinusJacobian(const double* x, double* jacobian) const override
   {
-    const auto success = local_parameterization_->ComputeMinusJacobian(x, jacobian);
-    const auto N = TangentSize() * AmbientSize();
-    for (int i = 0; i < N; i++)
-    {
-      jacobian[i] = -jacobian[i];
-    }
-    return success;
+    return local_parameterization_->ComputeMinusJacobian(x, jacobian);
   }
 
 private:

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -37,6 +37,8 @@
 
 #include <fuse_core/ceres_macros.h>
 
+#include <memory>
+
 #if CERES_SUPPORTS_MANIFOLDS
 #include <fuse_core/local_parameterization.h>
 #include <fuse_core/manifold.h>

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -61,10 +61,8 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_CLONE_DEFINITION(...)                                    \
-  fuse_core::Variable::UniquePtr clone() const override {                      \
-    return __VA_ARGS__::make_unique(*this);                                    \
-  }
+#define FUSE_VARIABLE_CLONE_DEFINITION(...) \
+  fuse_core::Variable::UniquePtr clone() const override { return __VA_ARGS__::make_unique(*this); }
 
 /**
  * @brief Implementation of the serialize() and deserialize() member functions
@@ -80,19 +78,11 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...)                                \
-  void serialize(fuse_core::BinaryOutputArchive &archive) const override {     \
-    archive << *this;                                                          \
-  } /* NOLINT */                                                               \
-  void serialize(fuse_core::TextOutputArchive &archive) const override {       \
-    archive << *this;                                                          \
-  } /* NOLINT */                                                               \
-  void deserialize(fuse_core::BinaryInputArchive &archive) override {          \
-    archive >> *this;                                                          \
-  } /* NOLINT */                                                               \
-  void deserialize(fuse_core::TextInputArchive &archive) override {            \
-    archive >> *this;                                                          \
-  }
+#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...)                                                             \
+  void serialize(fuse_core::BinaryOutputArchive& archive) const override { archive << *this; } /* NOLINT */ \
+  void serialize(fuse_core::TextOutputArchive& archive) const override { archive << *this; } /* NOLINT */   \
+  void deserialize(fuse_core::BinaryInputArchive& archive) override { archive >> *this; } /* NOLINT */      \
+  void deserialize(fuse_core::TextInputArchive& archive) override { archive >> *this; }
 
 /**
  * @brief Implements the type() member function using the suggested
@@ -111,13 +101,14 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_TYPE_DEFINITION(...)                                     \
-  struct detail {                                                              \
-    static std::string type() {                                                \
-      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>()          \
-          .pretty_name();                                                      \
-    } /* NOLINT */                                                             \
-  };  /* NOLINT */                                                             \
+#define FUSE_VARIABLE_TYPE_DEFINITION(...)                                           \
+  struct detail                                                                      \
+  {                                                                                  \
+    static std::string type()                                                        \
+    {                                                                                \
+      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>().pretty_name(); \
+    } /* NOLINT */                                                                   \
+  }; /* NOLINT */                                                                    \
   std::string type() const override { return detail::type(); }
 
 /**
@@ -134,10 +125,10 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS(...)                                         \
-  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__)                                      \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
+#define FUSE_VARIABLE_DEFINITIONS(...)        \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__)     \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)  \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 /**
@@ -155,14 +146,14 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...)                              \
-  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__)                           \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
+#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...)    \
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)         \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)        \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
-namespace fuse_core {
-
+namespace fuse_core
+{
 /**
  * @brief The Variable interface definition.
  *
@@ -186,7 +177,8 @@ namespace fuse_core {
  * for more details.
  * http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class Variable {
+class Variable
+{
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Variable);
 
@@ -216,7 +208,7 @@ public:
    *
    * @param[in] uuid The unique ID number for this variable
    */
-  explicit Variable(const UUID &uuid);
+  explicit Variable(const UUID& uuid);
 
   /**
    * @brief Destructor
@@ -226,7 +218,7 @@ public:
   /**
    * @brief Returns a UUID for this variable.
    */
-  const UUID &uuid() const { return uuid_; }
+  const UUID& uuid() const { return uuid_; }
 
   /**
    * @brief Returns a unique name for this variable type.
@@ -274,7 +266,7 @@ public:
    * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual const double *data() const = 0;
+  virtual const double* data() const = 0;
 
   /**
    * @brief Read-write access to the variable data
@@ -284,7 +276,7 @@ public:
    * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual double *data() = 0;
+  virtual double* data() = 0;
 
   /**
    * @brief Print a human-readable description of the variable to the provided
@@ -292,7 +284,7 @@ public:
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
-  virtual void print(std::ostream &stream = std::cout) const = 0;
+  virtual void print(std::ostream& stream = std::cout) const = 0;
 
   /**
    * @brief Perform a deep copy of the Variable and return a unique pointer to
@@ -332,9 +324,7 @@ public:
    *
    * @return A base pointer to an instance of a derived LocalParameterization
    */
-  virtual fuse_core::LocalParameterization *localParameterization() const {
-    return nullptr;
-  }
+  virtual fuse_core::LocalParameterization* localParameterization() const { return nullptr; }
 #endif
 
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
@@ -355,13 +345,15 @@ public:
    *
    * @return A base pointer to an instance of a derived Manifold
    */
-  virtual fuse_core::Manifold *manifold() const {
+  virtual fuse_core::Manifold* manifold() const
+  {
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
-    if (!localParameterization()) {
+    if (!localParameterization())
+    {
       return nullptr;
     }
     std::shared_ptr<fuse_core::Manifold> adapted_manifold =
-        std::make_shared<fuse_core::ManifoldAdapter>(localParameterization());
+      std::make_shared<fuse_core::ManifoldAdapter>(localParameterization());
     return adapted_manifold.get();
 #endif
 
@@ -377,9 +369,7 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The lower bound for the requested variable dimension
    */
-  virtual double lowerBound(size_t index) const {
-    return std::numeric_limits<double>::lowest();
-  }
+  virtual double lowerBound(size_t index) const { return std::numeric_limits<double>::lowest(); }
 
   /**
    * @brief Specifies the upper bound value of each variable dimension
@@ -389,9 +379,7 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The upper bound for the requested variable dimension
    */
-  virtual double upperBound(size_t index) const {
-    return std::numeric_limits<double>::max();
-  }
+  virtual double upperBound(size_t index) const { return std::numeric_limits<double>::max(); }
 
   /**
    * @brief Specifies if the value of the variable should not be changed during
@@ -409,8 +397,7 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void
-  serialize(fuse_core::BinaryOutputArchive & /* archive */) const = 0;
+  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
 
   /**
    * @brief Serialize this Variable into the provided text archive
@@ -422,8 +409,7 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void
-  serialize(fuse_core::TextOutputArchive & /* archive */) const = 0;
+  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
 
   /**
    * @brief Deserialize data from the provided binary archive into this Variable
@@ -435,7 +421,7 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::BinaryInputArchive & /* archive */) = 0;
+  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
 
   /**
    * @brief Deserialize data from the provided text archive into this Variable
@@ -447,10 +433,10 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::TextInputArchive & /* archive */) = 0;
+  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
 
 private:
-  fuse_core::UUID uuid_; //!< The unique ID number for this variable
+  fuse_core::UUID uuid_;  //!< The unique ID number for this variable
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;
@@ -470,16 +456,17 @@ private:
    * Generally unused.
    */
   template <class Archive>
-  void serialize(Archive &archive, const unsigned int /* version */) {
-    archive &uuid_;
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive& uuid_;
   }
 };
 
 /**
  * Stream operator implementation used for all derived Variable classes.
  */
-std::ostream &operator<<(std::ostream &stream, const Variable &variable);
+std::ostream& operator<<(std::ostream& stream, const Variable& variable);
 
-} // namespace fuse_core
+}  // namespace fuse_core
 
-#endif // FUSE_CORE_VARIABLE_H
+#endif  // FUSE_CORE_VARIABLE_H

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -47,6 +47,7 @@
 #include <limits>
 #include <ostream>
 #include <string>
+#include <memory>
 
 /**
  * @brief Implementation of the clone() member function for derived classes

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -306,7 +306,6 @@ public:
    */
   virtual Variable::UniquePtr clone() const = 0;
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Create a new Ceres local parameterization object to apply to updates
    * of this variable
@@ -326,9 +325,8 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   virtual fuse_core::LocalParameterization* localParameterization() const { return nullptr; }
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
   /**
    * @brief Create a new Ceres manifold object to apply to updates of this
    * variable
@@ -348,17 +346,15 @@ public:
    */
   virtual fuse_core::Manifold* manifold() const
   {
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
-    if (!localParameterization())
+    auto local_parameterization = localParameterization();
+    if (!local_parameterization)
     {
       return nullptr;
     }
-    std::shared_ptr<fuse_core::Manifold> adapted_manifold =
-      std::make_shared<fuse_core::ManifoldAdapter>(localParameterization());
-    return adapted_manifold.get();
-#endif
-
-    return nullptr;
+    else
+    {
+      return new fuse_core::ManifoldAdapter(local_parameterization);
+    }
   }
 #endif
 

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -34,8 +34,10 @@
 #ifndef FUSE_CORE_VARIABLE_H
 #define FUSE_CORE_VARIABLE_H
 
-#include <fuse_core/local_parameterization.h>
 #include <fuse_core/fuse_macros.h>
+#include <fuse_core/local_parameterization.h>
+#include <fuse_core/manifold.h>
+#include <fuse_core/manifold_adapter.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
@@ -45,7 +47,6 @@
 #include <limits>
 #include <ostream>
 #include <string>
-
 
 /**
  * @brief Implementation of the clone() member function for derived classes
@@ -60,14 +61,14 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_CLONE_DEFINITION(...) \
-  fuse_core::Variable::UniquePtr clone() const override \
-  { \
-    return __VA_ARGS__::make_unique(*this); \
+#define FUSE_VARIABLE_CLONE_DEFINITION(...)                                    \
+  fuse_core::Variable::UniquePtr clone() const override {                      \
+    return __VA_ARGS__::make_unique(*this);                                    \
   }
 
 /**
- * @brief Implementation of the serialize() and deserialize() member functions for derived classes
+ * @brief Implementation of the serialize() and deserialize() member functions
+ * for derived classes
  *
  * Usage:
  * @code{.cpp}
@@ -79,28 +80,26 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...) \
-  void serialize(fuse_core::BinaryOutputArchive& archive) const override \
-  { \
-    archive << *this; \
-  }  /* NOLINT */ \
-  void serialize(fuse_core::TextOutputArchive& archive) const override \
-  { \
-    archive << *this; \
-  }  /* NOLINT */ \
-  void deserialize(fuse_core::BinaryInputArchive& archive) override \
-  { \
-    archive >> *this; \
-  }  /* NOLINT */ \
-  void deserialize(fuse_core::TextInputArchive& archive) override \
-  { \
-    archive >> *this; \
+#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...)                                \
+  void serialize(fuse_core::BinaryOutputArchive &archive) const override {     \
+    archive << *this;                                                          \
+  } /* NOLINT */                                                               \
+  void serialize(fuse_core::TextOutputArchive &archive) const override {       \
+    archive << *this;                                                          \
+  } /* NOLINT */                                                               \
+  void deserialize(fuse_core::BinaryInputArchive &archive) override {          \
+    archive >> *this;                                                          \
+  } /* NOLINT */                                                               \
+  void deserialize(fuse_core::TextInputArchive &archive) override {            \
+    archive >> *this;                                                          \
   }
 
 /**
- * @brief Implements the type() member function using the suggested implementation
+ * @brief Implements the type() member function using the suggested
+ * implementation
  *
- * Also creates a static detail::type() function that may be used without an object instance
+ * Also creates a static detail::type() function that may be used without an
+ * object instance
  *
  * Usage:
  * @code{.cpp}
@@ -112,21 +111,18 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_TYPE_DEFINITION(...) \
-  struct detail \
-  { \
-    static std::string type() \
-    { \
-      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>().pretty_name(); \
-    }  /* NOLINT */ \
-  };  /* NOLINT */ \
-  std::string type() const override \
-  { \
-    return detail::type(); \
-  }
+#define FUSE_VARIABLE_TYPE_DEFINITION(...)                                     \
+  struct detail {                                                              \
+    static std::string type() {                                                \
+      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>()          \
+          .pretty_name();                                                      \
+    } /* NOLINT */                                                             \
+  };  /* NOLINT */                                                             \
+  std::string type() const override { return detail::type(); }
 
 /**
- * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
+ * @brief Convenience function that creates the required pointer aliases,
+ * clone() method, and type() method
  *
  * Usage:
  * @code{.cpp}
@@ -138,15 +134,16 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS(...) \
-  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+#define FUSE_VARIABLE_DEFINITIONS(...)                                         \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__)                                      \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 /**
- * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
- *        for derived Variable classes that have fixed-sized Eigen member objects.
+ * @brief Convenience function that creates the required pointer aliases,
+ * clone() method, and type() method for derived Variable classes that have
+ * fixed-sized Eigen member objects.
  *
  * Usage:
  * @code{.cpp}
@@ -158,35 +155,38 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...) \
-  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...)                              \
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__)                           \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
-
-namespace fuse_core
-{
+namespace fuse_core {
 
 /**
  * @brief The Variable interface definition.
  *
- * A Variable defines some semantically meaningful group of one or more individual scale values. Each variable is
- * treated as a block by the optimization engine, as the values of all of its dimensions are likely to be involved
- * in the same constraints. Some common examples of variable groupings are a 2D point (x, y), 3D point (x, y, z), or
- * camera calibration parameters (fx, fy, cx, cy).
+ * A Variable defines some semantically meaningful group of one or more
+ * individual scale values. Each variable is treated as a block by the
+ * optimization engine, as the values of all of its dimensions are likely to be
+ * involved in the same constraints. Some common examples of variable groupings
+ * are a 2D point (x, y), 3D point (x, y, z), or camera calibration parameters
+ * (fx, fy, cx, cy).
  *
- * To support the Ceres optimization engine, the Variable must hold the scalar values of each dimension in a
- * _contiguous_ memory space, and must provide access to that memory location via the Variable::data() methods.
+ * To support the Ceres optimization engine, the Variable must hold the scalar
+ * values of each dimension in a _contiguous_ memory space, and must provide
+ * access to that memory location via the Variable::data() methods.
  *
- * Some Variables may require special update rules, either because they are over-parameterized, as is the case with
- * 3D rotations represented as quaternions, or because the update of the individual dimensions exhibit some nonlinear
- * properties, as is the case with rotations in general (e.g. 2D rotations have a discontinuity around &pi;). To
- * support these situations, Ceres uses an optional "local parameterization". See the Ceres documentation for more
- * details. http://ceres-solver.org/nnls_modeling.html#localparameterization
+ * Some Variables may require special update rules, either because they are
+ * over-parameterized, as is the case with 3D rotations represented as
+ * quaternions, or because the update of the individual dimensions exhibit some
+ * nonlinear properties, as is the case with rotations in general (e.g. 2D
+ * rotations have a discontinuity around &pi;). To support these situations,
+ * Ceres uses an optional "local parameterization". See the Ceres documentation
+ * for more details.
+ * http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class Variable
-{
+class Variable {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Variable);
 
@@ -198,20 +198,25 @@ public:
   /**
    * @brief Constructor
    *
-   * The implemented UUID generation should be deterministic such that a variable with the same metadata will always
-   * return the same UUID. Identical UUIDs produced by sensors will be treated as the same variable by the optimizer,
-   * and different UUIDs will be treated as different variables. So, two derived variables representing robot poses with
-   * the same timestamp but different UUIDs will incorrectly be treated as different variables, and two robot poses with
-   * different timestamps but the same UUID will be incorrectly treated as the same variable.
+   * The implemented UUID generation should be deterministic such that a
+   * variable with the same metadata will always return the same UUID. Identical
+   * UUIDs produced by sensors will be treated as the same variable by the
+   * optimizer, and different UUIDs will be treated as different variables. So,
+   * two derived variables representing robot poses with the same timestamp but
+   * different UUIDs will incorrectly be treated as different variables, and two
+   * robot poses with different timestamps but the same UUID will be incorrectly
+   * treated as the same variable.
    *
-   * One method of producing UUIDs that adhere to this requirement is to use the boost::uuid::name_generator() function.
-   * The type() string can be used to generate a UUID namespace for all variables of a given derived type, and the
-   * variable metadata of consequence can be converted into a carefully-formatted string or byte array and provided to
-   * the generator to create the UUID for a specific variable instance.
+   * One method of producing UUIDs that adhere to this requirement is to use the
+   * boost::uuid::name_generator() function. The type() string can be used to
+   * generate a UUID namespace for all variables of a given derived type, and
+   * the variable metadata of consequence can be converted into a
+   * carefully-formatted string or byte array and provided to the generator to
+   * create the UUID for a specific variable instance.
    *
    * @param[in] uuid The unique ID number for this variable
    */
-  explicit Variable(const UUID& uuid);
+  explicit Variable(const UUID &uuid);
 
   /**
    * @brief Destructor
@@ -221,68 +226,77 @@ public:
   /**
    * @brief Returns a UUID for this variable.
    */
-  const UUID& uuid() const { return uuid_; }
+  const UUID &uuid() const { return uuid_; }
 
   /**
    * @brief Returns a unique name for this variable type.
    *
-   * The variable type string must be unique for each class. As such, the fully-qualified class name is an excellent
-   * choice for the type string.
+   * The variable type string must be unique for each class. As such, the
+   * fully-qualified class name is an excellent choice for the type string.
    *
    * The suggested implementation for all derived classes is:
    * @code{.cpp}
-   * return return boost::typeindex::stl_type_index::type_id<Derived>().pretty_name();
+   * return return
+   * boost::typeindex::stl_type_index::type_id<Derived>().pretty_name();
    * @endcode
    *
-   * To make this easy to implement in all derived classes, the FUSE_VARIABLE_TYPE_DEFINITION() and
-   * FUSE_VARIABLE_DEFINITIONS() macro functions have been provided.
+   * To make this easy to implement in all derived classes, the
+   * FUSE_VARIABLE_TYPE_DEFINITION() and FUSE_VARIABLE_DEFINITIONS() macro
+   * functions have been provided.
    */
   virtual std::string type() const = 0;
 
   /**
    * @brief Returns the number of elements of this variable.
    *
-   * In most cases, this will be the number of degrees of freedom this variable represents. For example, a 2D pose has
-   * an x, y, and theta value, so the size will be 3. A notable exception is a 3D rotation represented as a quaternion.
-   * It only has 3 degrees of freedom, but it is represented as four elements, (w, x, y, z), so it's size will be 4.
+   * In most cases, this will be the number of degrees of freedom this variable
+   * represents. For example, a 2D pose has an x, y, and theta value, so the
+   * size will be 3. A notable exception is a 3D rotation represented as a
+   * quaternion. It only has 3 degrees of freedom, but it is represented as four
+   * elements, (w, x, y, z), so it's size will be 4.
    */
   virtual size_t size() const = 0;
 
   /**
    * @brief Returns the number of elements of the local parameterization space.
    *
-   * If you override the \p localParameterization() method, it is good practice to also override the \p localSize()
-   * method. By default, the \p size() method is used for \p localSize() as well.
+   * If you override the \p localParameterization() method, it is good practice
+   * to also override the \p localSize() method. By default, the \p size()
+   * method is used for \p localSize() as well.
    */
   virtual size_t localSize() const { return size(); }
 
   /**
    * @brief Read-only access to the variable data
    *
-   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
-   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * The data elements must be contiguous (such as a C-style array double[3] or
+   * std::vector<double>), and it must contain at least Variable::size()
+   * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual const double* data() const = 0;
+  virtual const double *data() const = 0;
 
   /**
    * @brief Read-write access to the variable data
    *
-   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
-   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * The data elements must be contiguous (such as a C-style array double[3] or
+   * std::vector<double>), and it must contain at least Variable::size()
+   * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual double* data() = 0;
+  virtual double *data() = 0;
 
   /**
-   * @brief Print a human-readable description of the variable to the provided stream.
+   * @brief Print a human-readable description of the variable to the provided
+   * stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
-  virtual void print(std::ostream& stream = std::cout) const = 0;
+  virtual void print(std::ostream &stream = std::cout) const = 0;
 
   /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
+   * @brief Perform a deep copy of the Variable and return a unique pointer to
+   * the copy
    *
    * Unique pointers can be implicitly upgraded to shared pointers if needed.
    *
@@ -291,31 +305,69 @@ public:
    * return Derived::make_unique(*this);
    * @endcode
    *
-   * To make this easy to implement in all derived classes, the FUSE_VARIABLE_CLONE_DEFINITION() and
-   * FUSE_VARIABLE_DEFINITIONS() macros functions have been provided.
+   * To make this easy to implement in all derived classes, the
+   * FUSE_VARIABLE_CLONE_DEFINITION() and FUSE_VARIABLE_DEFINITIONS() macros
+   * functions have been provided.
    *
    * @return A unique pointer to a new instance of the most-derived Variable
    */
   virtual Variable::UniquePtr clone() const = 0;
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
-   * @brief Create a new Ceres local parameterization object to apply to updates of this variable
+   * @brief Create a new Ceres local parameterization object to apply to updates
+   * of this variable
    *
-   * If a local parameterization is not needed, a null pointer should be returned. If a local parameterization is
-   * needed, remember to also override the \p localSize() method to return the appropriate local parameterization
+   * If a local parameterization is not needed, a null pointer should be
+   * returned. If a local parameterization is needed, remember to also override
+   * the \p localSize() method to return the appropriate local parameterization
    * size.
    *
-   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
-   * delete the local parameterization when it is done. Additionally, fuse promises that the Variable object will
-   * outlive any generated local parameterization (i.e. the Ceres objects will be destroyed before the Variable
-   * objects). This guarantee may allow optimizations for the creation of the local parameterization objects.
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of
+   * the pointer and promises to properly delete the local parameterization when
+   * it is done. Additionally, fuse promises that the Variable object will
+   * outlive any generated local parameterization (i.e. the Ceres objects will
+   * be destroyed before the Variable objects). This guarantee may allow
+   * optimizations for the creation of the local parameterization objects.
    *
    * @return A base pointer to an instance of a derived LocalParameterization
    */
-  virtual fuse_core::LocalParameterization* localParameterization() const
-  {
+  virtual fuse_core::LocalParameterization *localParameterization() const {
     return nullptr;
   }
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  /**
+   * @brief Create a new Ceres manifold object to apply to updates of this
+   * variable
+   *
+   * If a manifold is not needed, a null pointer should be returned. If a local
+   * parameterization is needed, remember to also override the \p localSize()
+   * method to return the appropriate local parameterization size.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of
+   * the pointer and promises to properly delete the local parameterization when
+   * it is done. Additionally, fuse promises that the Variable object will
+   * outlive any generated local parameterization (i.e. the Ceres objects will
+   * be destroyed before the Variable objects). This guarantee may allow
+   * optimizations for the creation of the local parameterization objects.
+   *
+   * @return A base pointer to an instance of a derived Manifold
+   */
+  virtual fuse_core::Manifold *manifold() const {
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
+    if (!localParameterization()) {
+      return nullptr;
+    }
+    std::shared_ptr<fuse_core::Manifold> adapted_manifold =
+        std::make_shared<fuse_core::ManifoldAdapter>(localParameterization());
+    return adapted_manifold.get();
+#endif
+
+    return nullptr;
+  }
+#endif
 
   /**
    * @brief Specifies the lower bound value of each variable dimension
@@ -325,8 +377,7 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The lower bound for the requested variable dimension
    */
-  virtual double lowerBound(size_t index) const
-  {
+  virtual double lowerBound(size_t index) const {
     return std::numeric_limits<double>::lowest();
   }
 
@@ -338,18 +389,15 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The upper bound for the requested variable dimension
    */
-  virtual double upperBound(size_t index) const
-  {
+  virtual double upperBound(size_t index) const {
     return std::numeric_limits<double>::max();
   }
 
   /**
-   * @brief Specifies if the value of the variable should not be changed during optimization
+   * @brief Specifies if the value of the variable should not be changed during
+   * optimization
    */
-  virtual bool holdConstant() const
-  {
-    return false;
-  }
+  virtual bool holdConstant() const { return false; }
 
   /**
    * @brief Serialize this Variable into the provided binary archive
@@ -361,7 +409,8 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
+  virtual void
+  serialize(fuse_core::BinaryOutputArchive & /* archive */) const = 0;
 
   /**
    * @brief Serialize this Variable into the provided text archive
@@ -373,7 +422,8 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
+  virtual void
+  serialize(fuse_core::TextOutputArchive & /* archive */) const = 0;
 
   /**
    * @brief Deserialize data from the provided binary archive into this Variable
@@ -385,7 +435,7 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
+  virtual void deserialize(fuse_core::BinaryInputArchive & /* archive */) = 0;
 
   /**
    * @brief Deserialize data from the provided text archive into this Variable
@@ -397,36 +447,39 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
+  virtual void deserialize(fuse_core::TextInputArchive & /* archive */) = 0;
 
 private:
-  fuse_core::UUID uuid_;  //!< The unique ID number for this variable
+  fuse_core::UUID uuid_; //!< The unique ID number for this variable
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;
 
   /**
-   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
    *
-   * This method, or a combination of save() and load() methods, must be implemented by all derived classes. See
-   * documentation on Boost Serialization for information on how to implement the serialize() method.
+   * This method, or a combination of save() and load() methods, must be
+   * implemented by all derived classes. See documentation on Boost
+   * Serialization for information on how to implement the serialize() method.
    * https://www.boost.org/doc/libs/1_70_0/libs/serialization/doc/
    *
-   * @param[in/out] archive - The archive object that holds the serialized class members
-   * @param[in] version - The version of the archive being read/written. Generally unused.
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
    */
-  template<class Archive>
-  void serialize(Archive& archive, const unsigned int /* version */)
-  {
-    archive & uuid_;
+  template <class Archive>
+  void serialize(Archive &archive, const unsigned int /* version */) {
+    archive &uuid_;
   }
 };
 
 /**
  * Stream operator implementation used for all derived Variable classes.
  */
-std::ostream& operator <<(std::ostream& stream, const Variable& variable);
+std::ostream &operator<<(std::ostream &stream, const Variable &variable);
 
-}  // namespace fuse_core
+} // namespace fuse_core
 
-#endif  // FUSE_CORE_VARIABLE_H
+#endif // FUSE_CORE_VARIABLE_H

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -56,19 +56,19 @@ struct Plus
 struct Minus
 {
   template <typename T>
-  bool operator()(const T* y, const T* x, T* y_minus_x) const
+  bool operator()(const T* x, const T* y, T* y_minus_x) const
   {
-    y_minus_x[0] = (x[0] - y[0]) / 2.0;
-    y_minus_x[1] = (x[1] - y[1]) / 5.0;
+    y_minus_x[0] = (y[0] - x[0]) / 2.0;
+    y_minus_x[1] = (y[1] - x[1]) / 5.0;
     return true;
   }
 };
 
-using TestParameterization = fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
+using TestLocalParameterization = fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
 
 TEST(LocalParameterization, Plus)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   double x[3] = { 1.0, 2.0, 3.0 };
   double delta[2] = { 0.5, 1.0 };
@@ -83,7 +83,7 @@ TEST(LocalParameterization, Plus)
 
 TEST(LocalParameterization, PlusJacobian)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   double x[3] = { 1.0, 2.0, 3.0 };
   fuse_core::MatrixXd actual(3, 2);
@@ -98,7 +98,7 @@ TEST(LocalParameterization, PlusJacobian)
 
 TEST(LocalParameterization, Minus)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   double x1[3] = { 1.0, 2.0, 3.0 };
   double x2[3] = { 2.0, 7.0, 3.0 };
@@ -112,7 +112,7 @@ TEST(LocalParameterization, Minus)
 
 TEST(LocalParameterization, MinusJacobian)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   double x[3] = { 1.0, 2.0, 3.0 };
   fuse_core::MatrixXd actual(2, 3);
@@ -127,7 +127,7 @@ TEST(LocalParameterization, MinusJacobian)
 
 TEST(LocalParameterization, MinusSameVariablesIsZero)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   double x1[3] = { 1.0, 2.0, 3.0 };
   double actual[2] = { 0.0, 0.0 };
@@ -140,7 +140,7 @@ TEST(LocalParameterization, MinusSameVariablesIsZero)
 
 TEST(LocalParameterization, PlusMinus)
 {
-  TestParameterization parameterization;
+  TestLocalParameterization parameterization;
 
   const double x1[3] = { 1.0, 2.0, 3.0 };
   const double delta[2] = { 0.5, 1.0 };

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -119,7 +119,7 @@ TEST(LocalParameterization, MinusJacobian)
   bool success = parameterization.ComputeMinusJacobian(x, actual.data());
 
   fuse_core::MatrixXd expected(2, 3);
-  expected << -0.5, 0.0, 0.0, 0.0, -0.2, 0.0;
+  expected << 0.5, 0.0, 0.0, 0.0, 0.2, 0.0;
 
   EXPECT_TRUE(success);
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -64,7 +64,7 @@ struct Minus
   }
 };
 
-using TestAutoDiff = fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
+using TestParameterization = fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
 
 TEST(LocalParameterization, Plus)
 {

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -43,16 +43,15 @@
 
 #include <gtest/gtest.h>
 
-
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 struct TestFunctor
 {
-  template<typename T>
+  template <typename T>
   bool Plus(const T* x, const T* delta, T* x_plus_delta) const
 #else
 struct Plus
 {
-  template<typename T>
+  template <typename T>
   bool operator()(const T* x, const T* delta, T* x_plus_delta) const
 #endif
   {
@@ -63,14 +62,14 @@ struct Plus
   }
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 
-  template<typename T>
+  template <typename T>
   bool Minus(const T* y, const T* x, T* y_minus_x) const
 #else
 };
 
 struct Minus
 {
-  template<typename T>
+  template <typename T>
   bool operator()(const T* y, const T* x, T* y_minus_x) const
 #endif
   {
@@ -82,19 +81,18 @@ struct Minus
 
 using TestAutoDiff =
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-ceres::AutoDiffManifold<TestFunctor, 3, 2>;
+  ceres::AutoDiffManifold<TestFunctor, 3, 2>;
 #else
-fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
+  fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
 #endif
-
 
 TEST(LocalParameterization, Plus)
 {
   TestAutoDiff parameterization;
 
-  double x[3] = {1.0, 2.0, 3.0};
-  double delta[2] = {0.5, 1.0};
-  double actual[3] = {0.0, 0.0, 0.0};
+  double x[3] = { 1.0, 2.0, 3.0 };
+  double delta[2] = { 0.5, 1.0 };
+  double actual[3] = { 0.0, 0.0, 0.0 };
   bool success = parameterization.Plus(x, delta, actual);
 
   EXPECT_TRUE(success);
@@ -107,7 +105,7 @@ TEST(LocalParameterization, PlusJacobian)
 {
   TestAutoDiff parameterization;
 
-  double x[3] = {1.0, 2.0, 3.0};
+  double x[3] = { 1.0, 2.0, 3.0 };
   fuse_core::MatrixXd actual(3, 2);
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
   bool success = parameterization.PlusJacobian(x, actual.data());
@@ -116,9 +114,7 @@ TEST(LocalParameterization, PlusJacobian)
 #endif
 
   fuse_core::MatrixXd expected(3, 2);
-  expected << 2.0, 0.0,
-              0.0, 5.0,
-              0.0, 0.0;
+  expected << 2.0, 0.0, 0.0, 5.0, 0.0, 0.0;
 
   EXPECT_TRUE(success);
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);
@@ -131,11 +127,7 @@ TEST(LocalParameterization, Minus)
   double x1[3] = {1.0, 2.0, 3.0};
   double x2[3] = {2.0, 7.0, 3.0};
   double actual[2] = {0.0, 0.0};
-  #if CERES_VERSION_AT_LEAST(2, 1, 0)
-    bool success = parameterization.Minus(x1, x2, actual);
-  #else
-    bool success = parameterization.Minus(x2, x1, actual);
-  #endif
+  bool success = parameterization.Minus(x1, x2, actual);
 
   EXPECT_TRUE(success);
   EXPECT_NEAR(0.5, actual[0], 1.0e-5);
@@ -146,7 +138,7 @@ TEST(LocalParameterization, MinusJacobian)
 {
   TestAutoDiff parameterization;
 
-  double x[3] = {1.0, 2.0, 3.0};
+  double x[3] = { 1.0, 2.0, 3.0 };
   fuse_core::MatrixXd actual(2, 3);
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
   bool success = parameterization.MinusJacobian(x, actual.data());
@@ -155,8 +147,7 @@ TEST(LocalParameterization, MinusJacobian)
 #endif
 
   fuse_core::MatrixXd expected(2, 3);
-  expected << -0.5, 0.0, 0.0,
-              0.0, -0.2, 0.0;
+  expected << -0.5, 0.0, 0.0, 0.0, -0.2, 0.0;
 
   EXPECT_TRUE(success);
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);
@@ -166,8 +157,8 @@ TEST(LocalParameterization, MinusSameVariablesIsZero)
 {
   TestAutoDiff parameterization;
 
-  double x1[3] = {1.0, 2.0, 3.0};
-  double actual[2] = {0.0, 0.0};
+  double x1[3] = { 1.0, 2.0, 3.0 };
+  double actual[2] = { 0.0, 0.0 };
   bool success = parameterization.Minus(x1, x1, actual);
 
   EXPECT_TRUE(success);
@@ -179,26 +170,22 @@ TEST(LocalParameterization, PlusMinus)
 {
   TestAutoDiff parameterization;
 
-  const double x1[3] = {1.0, 2.0, 3.0};
-  const double delta[2] = {0.5, 1.0};
-  double x2[3] = {0.0, 0.0, 0.0};
+  const double x1[3] = { 1.0, 2.0, 3.0 };
+  const double delta[2] = { 0.5, 1.0 };
+  double x2[3] = { 0.0, 0.0, 0.0 };
   bool success = parameterization.Plus(x1, delta, x2);
 
   ASSERT_TRUE(success);
 
-  double actual[2] = {0.0, 0.0};
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-    success = parameterization.Minus(x1, x2, actual);
-#else
-    success = parameterization.Minus(x2, x1, actual);
-#endif
+  double actual[2] = { 0.0, 0.0 };
+  success = parameterization.Minus(x1, x2, actual);
 
   EXPECT_TRUE(success);
   EXPECT_NEAR(delta[0], actual[0], 1.0e-5);
   EXPECT_NEAR(delta[1], actual[1], 1.0e-5);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -151,8 +151,8 @@ TEST(LocalParameterization, MinusJacobian)
 #endif
 
   fuse_core::MatrixXd expected(2, 3);
-  expected << 0.5, 0.0, 0.0,
-              0.0, 0.2, 0.0;
+  expected << -0.5, 0.0, 0.0,
+              0.0, -0.2, 0.0;
 
   EXPECT_TRUE(success);
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -158,6 +158,38 @@ TEST(LocalParameterization, MinusJacobian)
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);
 }
 
+TEST(LocalParameterization, MinusSameVariablesIsZero)
+{
+  TestLocalParameterization parameterization;
+
+  double x1[3] = {1.0, 2.0, 3.0};
+  double actual[2] = {0.0, 0.0};
+  bool success = parameterization.Minus(x1, x1, actual);
+
+  EXPECT_TRUE(success);
+  EXPECT_NEAR(0.0, actual[0], 1.0e-5);
+  EXPECT_NEAR(0.0, actual[1], 1.0e-5);
+}
+
+TEST(LocalParameterization, PlusMinus)
+{
+  TestLocalParameterization parameterization;
+
+  const double x1[3] = {1.0, 2.0, 3.0};
+  const double delta[2] = {0.5, 1.0};
+  double x2[3] = {0.0, 0.0, 0.0};
+  bool success = parameterization.Plus(x1, delta, x2);
+
+  ASSERT_TRUE(success);
+
+  double actual[2] = {0.0, 0.0};
+  success = parameterization.Minus(x1, x2, actual);
+
+  EXPECT_TRUE(success);
+  EXPECT_NEAR(delta[0], actual[0], 1.0e-5);
+  EXPECT_NEAR(delta[1], actual[1], 1.0e-5);
+}
+
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -131,11 +131,11 @@ TEST(LocalParameterization, Minus)
   double x1[3] = {1.0, 2.0, 3.0};
   double x2[3] = {2.0, 7.0, 3.0};
   double actual[2] = {0.0, 0.0};
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  #if CERES_VERSION_AT_LEAST(2, 1, 0)
     bool success = parameterization.Minus(x1, x2, actual);
-#else
+  #else
     bool success = parameterization.Minus(x2, x1, actual);
-#endif
+  #endif
 
   EXPECT_TRUE(success);
   EXPECT_NEAR(0.5, actual[0], 1.0e-5);
@@ -188,9 +188,9 @@ TEST(LocalParameterization, PlusMinus)
 
   double actual[2] = {0.0, 0.0};
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-    bool success = parameterization.Minus(x1, x2, actual);
+    success = parameterization.Minus(x1, x2, actual);
 #else
-    bool success = parameterization.Minus(x2, x1, actual);
+    success = parameterization.Minus(x2, x1, actual);
 #endif
 
   EXPECT_TRUE(success);

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -80,7 +80,7 @@ struct Minus
   }
 };
 
-using TestLocalParameterization =
+using TestAutoDiff =
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 ceres::AutoDiffManifold<TestFunctor, 3, 2>;
 #else
@@ -90,7 +90,7 @@ fuse_core::AutoDiffLocalParameterization<Plus, Minus, 3, 2>;
 
 TEST(LocalParameterization, Plus)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   double x[3] = {1.0, 2.0, 3.0};
   double delta[2] = {0.5, 1.0};
@@ -105,7 +105,7 @@ TEST(LocalParameterization, Plus)
 
 TEST(LocalParameterization, PlusJacobian)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   double x[3] = {1.0, 2.0, 3.0};
   fuse_core::MatrixXd actual(3, 2);
@@ -126,12 +126,16 @@ TEST(LocalParameterization, PlusJacobian)
 
 TEST(LocalParameterization, Minus)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   double x1[3] = {1.0, 2.0, 3.0};
   double x2[3] = {2.0, 7.0, 3.0};
   double actual[2] = {0.0, 0.0};
-  bool success = parameterization.Minus(x1, x2, actual);
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+    bool success = parameterization.Minus(x1, x2, actual);
+#else
+    bool success = parameterization.Minus(x2, x1, actual);
+#endif
 
   EXPECT_TRUE(success);
   EXPECT_NEAR(0.5, actual[0], 1.0e-5);
@@ -140,7 +144,7 @@ TEST(LocalParameterization, Minus)
 
 TEST(LocalParameterization, MinusJacobian)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   double x[3] = {1.0, 2.0, 3.0};
   fuse_core::MatrixXd actual(2, 3);
@@ -160,7 +164,7 @@ TEST(LocalParameterization, MinusJacobian)
 
 TEST(LocalParameterization, MinusSameVariablesIsZero)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   double x1[3] = {1.0, 2.0, 3.0};
   double actual[2] = {0.0, 0.0};
@@ -173,7 +177,7 @@ TEST(LocalParameterization, MinusSameVariablesIsZero)
 
 TEST(LocalParameterization, PlusMinus)
 {
-  TestLocalParameterization parameterization;
+  TestAutoDiff parameterization;
 
   const double x1[3] = {1.0, 2.0, 3.0};
   const double delta[2] = {0.5, 1.0};
@@ -183,7 +187,11 @@ TEST(LocalParameterization, PlusMinus)
   ASSERT_TRUE(success);
 
   double actual[2] = {0.0, 0.0};
-  success = parameterization.Minus(x1, x2, actual);
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+    bool success = parameterization.Minus(x1, x2, actual);
+#else
+    bool success = parameterization.Minus(x2, x1, actual);
+#endif
 
   EXPECT_TRUE(success);
   EXPECT_NEAR(delta[0], actual[0], 1.0e-5);

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -28,7 +28,28 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror)
+
+# Disable warnings about maybe uninitialized variables with -Wno-maybe-uninitialized until we fix the following error:
+#
+# In file included from include/c++/12.2.0/functional:59,
+#                  from include/eigen3/Eigen/Core:85,
+#                  from include/fuse_core/fuse_macros.h:63,
+#                  from include/fuse_core/loss.h:37,
+#                  from include/fuse_core/constraint.h:37,
+#                  from src/fuse/fuse_graphs/include/fuse_graphs/hash_graph.h:38,
+#                  from src/fuse/fuse_graphs/src/hash_graph.cpp:34:
+# In copy constructor ‘std::function<_Res(_ArgTypes ...)>::function(const std::function<_Res(_ArgTypes ...)>&) [with _Res = const fuse_core::Variable&; _ArgTypes = {const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&}]’,
+#     inlined from ‘boost::iterators::transform_iterator<UnaryFunction, Iterator, Reference, Value>::transform_iterator(const Iterator&, UnaryFunc) [with UnaryFunc = std::function<const fuse_core::Variable&(const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&)>; Iterator = std::__detail::_Node_const_iterator<std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >, false, true>; Reference = boost::use_default; Value = boost::use_default]’ at include/boost/iterator/transform_iterator.hpp:96:21,
+#     inlined from ‘boost::iterators::transform_iterator<UnaryFunc, Iterator> boost::iterators::make_transform_iterator(Iterator, UnaryFunc) [with UnaryFunc = std::function<const fuse_core::Variable&(const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&)>; Iterator = std::__detail::_Node_const_iterator<std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >, false, true>]’ at include/boost/iterator/transform_iterator.hpp:141:61,
+#     inlined from ‘virtual fuse_core::Graph::const_variable_range fuse_graphs::HashGraph::getVariables() const’ at fuse/fuse_graphs/src/hash_graph.cpp:284:35:
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h:391:17: error: ‘<anonymous>’ may be used uninitialized [-Werror=maybe-uninitialized]
+#   391 |             __x._M_manager(_M_functor, __x._M_functor, __clone_functor);
+#       |             ~~~~^~~~~~~~~~
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h: In member function ‘virtual fuse_core::Graph::const_variable_range fuse_graphs::HashGraph::getVariables() const’:
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h:267:7: note: by argument 2 of type ‘const std::_Any_data&’ to ‘static bool std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_manager(std::_Any_data&, const std::_Any_data&, std::_Manager_operation) [with _Res = const fuse_core::Variable&; _Functor = fuse_graphs::HashGraph::getVariables() const::<lambda(const std::unordered_map<boost::uuids::uuid, std::shared_ptr<fuse_core::Variable>, boost::hash<boost::uuids::uuid> >::value_type&)>; _ArgTypes = {const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&}]’ declared here
+#   267 |       _M_manager(_Any_data& __dest, const _Any_data& __source,
+#       |       ^~~~~~~~~~
+add_compile_options(-Wall -Werror -Wno-maybe-uninitialized)
 
 ## fuse_graphs library
 add_library(${PROJECT_NAME}

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -61,6 +61,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
@@ -119,6 +122,9 @@ if(CATKIN_ENABLE_TESTING)
   target_include_directories(test_hash_graph
     PRIVATE
       include
+  )
+  target_include_directories(test_hash_graph
+    SYSTEM PRIVATE
       ${Boost_INCLUDE_DIRS}
       ${catkin_INCLUDE_DIRS}
       ${CERES_INCLUDE_DIRS}

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -34,6 +34,7 @@
 #ifndef FUSE_GRAPHS_HASH_GRAPH_H
 #define FUSE_GRAPHS_HASH_GRAPH_H
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/constraint.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/fuse_macros.h>
@@ -423,7 +424,15 @@ void serialize(Archive& archive, ceres::Problem::Options& options, const unsigne
   archive & options.cost_function_ownership;
   archive & options.disable_all_safety_checks;
   archive & options.enable_fast_removal;
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  // Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+  // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+  // and they got removed in 2.2.0, see
+  // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+  archive & options.manifold_ownership;
+#else
   archive & options.local_parameterization_ownership;
+#endif
   archive & options.loss_function_ownership;
 }
 

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -424,7 +424,7 @@ void serialize(Archive& archive, ceres::Problem::Options& options, const unsigne
   archive & options.cost_function_ownership;
   archive & options.disable_all_safety_checks;
   archive & options.enable_fast_removal;
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
   // Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
   // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
   // and they got removed in 2.2.0, see

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -49,6 +49,9 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
 )

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -31,6 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/ceres_macros.h>
+
 #include <fuse_models/unicycle_2d_state_cost_function.h>
 #include <fuse_models/unicycle_2d_state_cost_functor.h>
 
@@ -99,7 +101,13 @@ TEST(CostFunction, evaluateCostFunction)
 
   // Check jacobians are correct using a gradient checker
   ceres::NumericDiffOptions numeric_diff_options;
-  ceres::GradientChecker gradient_checker(&cost_function, NULL, numeric_diff_options);
+  ceres::GradientChecker gradient_checker(&cost_function,
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+      static_cast<const std::vector<const ceres::Manifold*>*>(nullptr),
+#else
+      static_cast<const std::vector<const ceres::LocalParameterization*>*>(nullptr),
+#endif
+      numeric_diff_options);
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -101,13 +101,7 @@ TEST(CostFunction, evaluateCostFunction)
 
   // Check jacobians are correct using a gradient checker
   ceres::NumericDiffOptions numeric_diff_options;
-  ceres::GradientChecker gradient_checker(&cost_function,
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-      static_cast<const std::vector<const ceres::Manifold*>*>(nullptr),
-#else
-      static_cast<const std::vector<const ceres::LocalParameterization*>*>(nullptr),
-#endif
-      numeric_diff_options);
+  ceres::GradientChecker gradient_checker(&cost_function, nullptr, numeric_diff_options);
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -54,6 +54,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
 )

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -53,6 +53,7 @@
 namespace fuse_variables
 {
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 2D Orientations.
  *
@@ -126,6 +127,85 @@ private:
   }
 };
 
+#endif
+
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+/**
+ * @brief A Manifold class for 2D Orientations.
+ *
+ * 2D orientations add and subtract in the "usual" way, except for the 2*pi rollover issue. This local parameterization
+ * handles the rollover. Because the Jacobians for this parameterization are always identity, we implement this
+ * parameterization with "analytic" derivatives, instead of using the Ceres's autodiff system.
+ */
+class Orientation2DManifold : public fuse_core::Manifold
+{
+public:
+  int AmbientSize() const override
+  {
+    return 1;
+  }
+
+  int TangentSize() const override
+  {
+    return 1;
+  }
+
+  bool Plus(
+    const double* x,
+    const double* delta,
+    double* x_plus_delta) const override
+  {
+    // Compute the angle increment as a linear update, and handle the 2*Pi rollover
+    x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
+    return true;
+  }
+
+  bool PlusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    jacobian[0] = 1.0;
+    return true;
+  }
+
+  bool Minus(
+    const double* y,
+    const double* x,
+    double* y_minus_x) const override
+  {
+    // Compute the difference from x2 to x1, and handle the 2*Pi rollover
+    y_minus_x[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
+    return true;
+  }
+
+  bool MinusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    jacobian[0] = -1.0;
+    return true;
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Manifold>(*this);
+  }
+};
+
+#endif
+
 /**
  * @brief Variable representing a 2D orientation (theta) at a specific time, with a specific piece of hardware.
  *
@@ -195,6 +275,7 @@ public:
    */
   size_t localSize() const override { return 1u; }
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Create a new Ceres local parameterization object to apply to updates of this variable
    *
@@ -204,6 +285,19 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   fuse_core::LocalParameterization* localParameterization() const override;
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  /**
+   * @brief Create a new Ceres manifold object to apply to updates of this variable
+   *
+   * A 2D rotation has a nonlinearity when the angle wraps around from -PI to PI. This is handled by a custom
+   * manifold to ensure smooth derivatives.
+   *
+   * @return A base pointer to an instance of a derived manifold
+   */
+  fuse_core::Manifold* manifold() const override;
+#endif
 
 private:
   // Allow Boost Serialization access to private methods
@@ -225,7 +319,14 @@ private:
 
 }  // namespace fuse_variables
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DManifold);
+#endif 
+
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DLocalParameterization);
+#endif
+
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -174,8 +174,8 @@ public:
     const double* x,
     double* y_minus_x) const override
   {
-    // Compute the difference from x2 to x1, and handle the 2*Pi rollover
-    y_minus_x[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
+    // Compute the difference from x to y, and handle the 2*Pi rollover
+    y_minus_x[0] = fuse_core::wrapAngle2D(x[0] - y[0]);
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -49,10 +49,8 @@
 
 #include <ostream>
 
-
 namespace fuse_variables
 {
-
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 2D Orientations.
@@ -64,47 +62,31 @@ namespace fuse_variables
 class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
-  int GlobalSize() const override
-  {
-    return 1;
-  }
+  int GlobalSize() const override { return 1; }
 
-  int LocalSize() const override
-  {
-    return 1;
-  }
+  int LocalSize() const override { return 1; }
 
-  bool Plus(
-    const double* x,
-    const double* delta,
-    double* x_plus_delta) const override
+  bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
     // Compute the angle increment as a linear update, and handle the 2*Pi rollover
     x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
     return true;
   }
 
-  bool ComputeJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
+  bool ComputeJacobian(const double* /*x*/, double* jacobian) const override
   {
     jacobian[0] = 1.0;
     return true;
   }
 
-  bool Minus(
-    const double* x1,
-    const double* x2,
-    double* delta) const override
+  bool Minus(const double* x1, const double* x2, double* delta) const override
   {
     // Compute the difference from x2 to x1, and handle the 2*Pi rollover
     delta[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
     return true;
   }
 
-  bool ComputeMinusJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
+  bool ComputeMinusJacobian(const double* /*x*/, double* jacobian) const override
   {
     jacobian[0] = -1.0;
     return true;
@@ -120,15 +102,14 @@ private:
    * @param[in/out] archive - The archive object that holds the serialized class members
    * @param[in] version - The version of the archive being read/written. Generally unused.
    */
-  template<class Archive>
+  template <class Archive>
   void serialize(Archive& archive, const unsigned int /* version */)
   {
-    archive & boost::serialization::base_object<fuse_core::LocalParameterization>(*this);
+    archive& boost::serialization::base_object<fuse_core::LocalParameterization>(*this);
   }
 };
 
 #endif
-
 
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 /**
@@ -141,47 +122,31 @@ private:
 class Orientation2DManifold : public fuse_core::Manifold
 {
 public:
-  int AmbientSize() const override
-  {
-    return 1;
-  }
+  int AmbientSize() const override { return 1; }
 
-  int TangentSize() const override
-  {
-    return 1;
-  }
+  int TangentSize() const override { return 1; }
 
-  bool Plus(
-    const double* x,
-    const double* delta,
-    double* x_plus_delta) const override
+  bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
     // Compute the angle increment as a linear update, and handle the 2*Pi rollover
     x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
     return true;
   }
 
-  bool PlusJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
+  bool PlusJacobian(const double* /*x*/, double* jacobian) const override
   {
     jacobian[0] = 1.0;
     return true;
   }
 
-  bool Minus(
-    const double* y,
-    const double* x,
-    double* y_minus_x) const override
+  bool Minus(const double* y, const double* x, double* y_minus_x) const override
   {
     // Compute the difference from x to y, and handle the 2*Pi rollover
     y_minus_x[0] = fuse_core::wrapAngle2D(x[0] - y[0]);
     return true;
   }
 
-  bool MinusJacobian(
-    const double* /*x*/,
-    double* jacobian) const override
+  bool MinusJacobian(const double* /*x*/, double* jacobian) const override
   {
     jacobian[0] = -1.0;
     return true;
@@ -197,10 +162,10 @@ private:
    * @param[in/out] archive - The archive object that holds the serialized class members
    * @param[in] version - The version of the archive being read/written. Generally unused.
    */
-  template<class Archive>
+  template <class Archive>
   void serialize(Archive& archive, const unsigned int /* version */)
   {
-    archive & boost::serialization::base_object<fuse_core::Manifold>(*this);
+    archive& boost::serialization::base_object<fuse_core::Manifold>(*this);
   }
 };
 
@@ -321,7 +286,7 @@ private:
 
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DManifold);
-#endif 
+#endif
 
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DLocalParameterization);

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -63,20 +63,12 @@ namespace fuse_variables
 class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int AmbientSize() const override
-#else
   int GlobalSize() const override
-#endif
   {
     return 1;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int TangentSize() const override
-#else
   int LocalSize() const override
-#endif
   {
     return 1;
   }
@@ -91,11 +83,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool PlusJacobian(
-#else
   bool ComputeJacobian(
-#endif
     const double* /*x*/,
     double* jacobian) const override
   {
@@ -113,11 +101,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool MinusJacobian(
-#else
   bool ComputeMinusJacobian(
-#endif
     const double* /*x*/,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -78,10 +78,10 @@ public:
     return true;
   }
 
-  bool Minus(const double* x1, const double* x2, double* delta) const override
+  bool Minus(const double* x, const double* y, double* y_minus_x) const override
   {
-    // Compute the difference from x2 to x1, and handle the 2*Pi rollover
-    delta[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
+    // Compute the difference from y to x, and handle the 2*Pi rollover
+    y_minus_x[0] = fuse_core::wrapAngle2D(y[0] - x[0]);
     return true;
   }
 
@@ -139,14 +139,14 @@ public:
 
   bool Minus(const double* y, const double* x, double* y_minus_x) const override
   {
-    // Compute the difference from x to y, and handle the 2*Pi rollover
+    // Compute the difference from y to x, and handle the 2*Pi rollover
     y_minus_x[0] = fuse_core::wrapAngle2D(y[0] - x[0]);
     return true;
   }
 
   bool MinusJacobian(const double* /*x*/, double* jacobian) const override
   {
-    jacobian[0] = -1.0;
+    jacobian[0] = 1.0;
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -63,12 +63,20 @@ namespace fuse_variables
 class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int AmbientSize() const override
+#else
   int GlobalSize() const override
+#endif
   {
     return 1;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int TangentSize() const override
+#else
   int LocalSize() const override
+#endif
   {
     return 1;
   }
@@ -83,7 +91,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool PlusJacobian(
+#else
   bool ComputeJacobian(
+#endif
     const double* /*x*/,
     double* jacobian) const override
   {
@@ -101,7 +113,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool MinusJacobian(
+#else
   bool ComputeMinusJacobian(
+#endif
     const double* /*x*/,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -51,7 +51,6 @@
 
 namespace fuse_variables
 {
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 2D Orientations.
  *
@@ -88,7 +87,7 @@ public:
 
   bool ComputeMinusJacobian(const double* /*x*/, double* jacobian) const override
   {
-    jacobian[0] = -1.0;
+    jacobian[0] = 1.0;
     return true;
   }
 
@@ -109,9 +108,8 @@ private:
   }
 };
 
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 /**
  * @brief A Manifold class for 2D Orientations.
  *
@@ -142,7 +140,7 @@ public:
   bool Minus(const double* y, const double* x, double* y_minus_x) const override
   {
     // Compute the difference from x to y, and handle the 2*Pi rollover
-    y_minus_x[0] = fuse_core::wrapAngle2D(x[0] - y[0]);
+    y_minus_x[0] = fuse_core::wrapAngle2D(y[0] - x[0]);
     return true;
   }
 
@@ -240,7 +238,6 @@ public:
    */
   size_t localSize() const override { return 1u; }
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Create a new Ceres local parameterization object to apply to updates of this variable
    *
@@ -250,9 +247,8 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   fuse_core::LocalParameterization* localParameterization() const override;
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
   /**
    * @brief Create a new Ceres manifold object to apply to updates of this variable
    *
@@ -284,14 +280,11 @@ private:
 
 }  // namespace fuse_variables
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DManifold);
 #endif
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DLocalParameterization);
-#endif
-
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -121,7 +121,7 @@ public:
     const double* /*x*/,
     double* jacobian) const override
   {
-    jacobian[0] = 1.0;
+    jacobian[0] = -1.0;
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -78,12 +78,20 @@ public:
     out[3] = -in[3];
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int AmbientSize() const override
+#else
   int GlobalSize() const override
+#endif
   {
     return 4;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int TangentSize() const override
+#else
   int LocalSize() const override
+#endif
   {
     return 3;
   }
@@ -99,7 +107,11 @@ public:
     return true;
 }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool PlusJacobian(
+#else
   bool ComputeJacobian(
+#endif
     const double* x,
     double* jacobian) const override
   {
@@ -127,7 +139,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool MinusJacobian(
+#else
   bool ComputeMinusJacobian(
+#endif
     const double* x,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -50,17 +50,15 @@
 
 #include <ostream>
 
-
 namespace fuse_variables
 {
-
 /**
  * @brief Create the inverse quaternion
  *
  * ceres/rotation.h is missing this function for some reason.
  */
-template<typename T> inline
-static void QuaternionInverse(const T in[4], T out[4])
+template <typename T>
+inline static void QuaternionInverse(const T in[4], T out[4])
 {
   out[0] = in[0];
   out[1] = -in[1];
@@ -79,21 +77,11 @@ static void QuaternionInverse(const T in[4], T out[4])
 class Orientation3DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
+  int GlobalSize() const override { return 4; }
 
-  int GlobalSize() const override
-  {
-    return 4;
-  }
+  int LocalSize() const override { return 3; }
 
-  int LocalSize() const override
-  {
-    return 3;
-  }
-
-  bool Plus(
-    const double* x,
-    const double* delta,
-    double* x_plus_delta) const override
+  bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
     double q_delta[4];
     ceres::AngleAxisToQuaternion(delta, q_delta);
@@ -101,9 +89,7 @@ public:
     return true;
   }
 
-  bool ComputeJacobian(
-    const double* x,
-    double* jacobian) const override
+  bool ComputeJacobian(const double* x, double* jacobian) const override
   {
     double x0 = x[0] / 2;
     double x1 = x[1] / 2;
@@ -116,10 +102,7 @@ public:
     return true;
   }
 
-  bool Minus(
-    const double* x1,
-    const double* x2,
-    double* delta) const override
+  bool Minus(const double* x1, const double* x2, double* delta) const override
   {
     double x1_inverse[4];
     QuaternionInverse(x1, x1_inverse);
@@ -129,9 +112,7 @@ public:
     return true;
   }
 
-  bool ComputeMinusJacobian(
-    const double* x,
-    double* jacobian) const override
+  bool ComputeMinusJacobian(const double* x, double* jacobian) const override
   {
     double x0 = x[0] * 2;
     double x1 = x[1] * 2;
@@ -172,20 +153,11 @@ private:
 class Orientation3DManifold : public fuse_core::Manifold
 {
 public:
-  int AmbientSize() const override
-  {
-    return 4;
-  }
+  int AmbientSize() const override { return 4; }
 
-  int TangentSize() const override
-  {
-    return 3;
-  }
+  int TangentSize() const override { return 3; }
 
-  bool Plus(
-    const double* x,
-    const double* delta,
-    double* x_plus_delta) const override
+  bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
     double q_delta[4];
     ceres::AngleAxisToQuaternion(delta, q_delta);
@@ -193,9 +165,7 @@ public:
     return true;
   }
 
-  bool PlusJacobian(
-    const double* x,
-    double* jacobian) const override
+  bool PlusJacobian(const double* x, double* jacobian) const override
   {
     double x0 = x[0] / 2;
     double x1 = x[1] / 2;
@@ -208,10 +178,7 @@ public:
     return true;
   }
 
-  bool Minus(
-    const double* y,
-    const double* x,
-    double* y_minus_x) const override
+  bool Minus(const double* y, const double* x, double* y_minus_x) const override
   {
     double x_inverse[4];
     QuaternionInverse(x, x_inverse);
@@ -221,9 +188,7 @@ public:
     return true;
   }
 
-  bool MinusJacobian(
-    const double* x,
-    double* jacobian) const override
+  bool MinusJacobian(const double* x, double* jacobian) const override
   {
     double x0 = x[0] * 2;
     double x1 = x[1] * 2;
@@ -261,7 +226,7 @@ private:
  * This is commonly used to represent a robot orientation in single or multi-robot systems. The UUID of this class is
  * static after construction. As such, the timestamp and device ID cannot be modified. The value of the orientation
  * can be modified.
- * 
+ *
  * The internal representation for this is different from the typical ROS representation, as w is the first component.
  * This is necessary to use the Ceres local parameterization for quaternions.
  */
@@ -382,7 +347,6 @@ public:
    */
   fuse_core::LocalParameterization* localParameterization() const override;
 #endif
-
 
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
   /**

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -78,20 +78,12 @@ public:
     out[3] = -in[3];
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int AmbientSize() const override
-#else
   int GlobalSize() const override
-#endif
   {
     return 4;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int TangentSize() const override
-#else
   int LocalSize() const override
-#endif
   {
     return 3;
   }
@@ -105,13 +97,9 @@ public:
     ceres::AngleAxisToQuaternion(delta, q_delta);
     ceres::QuaternionProduct(x, q_delta, x_plus_delta);
     return true;
-}
+  }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool PlusJacobian(
-#else
   bool ComputeJacobian(
-#endif
     const double* x,
     double* jacobian) const override
   {
@@ -139,11 +127,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool MinusJacobian(
-#else
   bool ComputeMinusJacobian(
-#endif
     const double* x,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -66,7 +66,6 @@ inline static void QuaternionInverse(const T in[4], T out[4])
   out[3] = -in[3];
 }
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 3D Orientations.
  *
@@ -118,9 +117,9 @@ public:
     double x1 = x[1] * 2;
     double x2 = x[2] * 2;
     double x3 = x[3] * 2;
-    jacobian[0] = x1; jacobian[1]  = -x0; jacobian[2]  = -x3;  jacobian[3]  =  x2;  // NOLINT
-    jacobian[4] = x2; jacobian[5]  =  x3; jacobian[6]  = -x0;  jacobian[7]  = -x1;  // NOLINT
-    jacobian[8] = x3; jacobian[9]  = -x2; jacobian[10] =  x1;  jacobian[11] = -x0;  // NOLINT
+    jacobian[0] = -x1; jacobian[1]  =  x0; jacobian[2]  =  x3;  jacobian[3]  = -x2;  // NOLINT
+    jacobian[4] = -x2; jacobian[5]  = -x3; jacobian[6]  =  x0;  jacobian[7]  =  x1;  // NOLINT
+    jacobian[8] = -x3; jacobian[9]  =  x2; jacobian[10] = -x1;  jacobian[11] =  x0;  // NOLINT
     return true;
   }
 
@@ -140,9 +139,8 @@ private:
     archive & boost::serialization::base_object<fuse_core::LocalParameterization>(*this);
   }
 };
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 /**
  * @brief A Manifold class for 2D Orientations.
  *
@@ -339,16 +337,14 @@ public:
    */
   size_t localSize() const override { return 3u; }
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Provides a Ceres local parameterization for the quaternion
    *
    * @return A pointer to a local parameterization object that indicates how to "add" increments to the quaternion
    */
   fuse_core::LocalParameterization* localParameterization() const override;
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
   /**
    * @brief Provides a Ceres manifold for the quaternion
    *
@@ -377,14 +373,11 @@ private:
 
 }  // namespace fuse_variables
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DManifold);
 #endif
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DLocalParameterization);
-#endif
-
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -54,6 +54,20 @@
 namespace fuse_variables
 {
 
+/**
+ * @brief Create the inverse quaternion
+ *
+ * ceres/rotation.h is missing this function for some reason.
+ */
+template<typename T> inline
+static void QuaternionInverse(const T in[4], T out[4])
+{
+  out[0] = in[0];
+  out[1] = -in[1];
+  out[2] = -in[2];
+  out[3] = -in[3];
+}
+
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 3D Orientations.
@@ -65,19 +79,6 @@ namespace fuse_variables
 class Orientation3DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
-  /**
-   * @brief Create the inverse quaternion
-   *
-   * ceres/rotation.h is missing this function for some reason.
-   */
-  template<typename T> inline
-  static void QuaternionInverse(const T in[4], T out[4])
-  {
-    out[0] = in[0];
-    out[1] = -in[1];
-    out[2] = -in[2];
-    out[3] = -in[3];
-  }
 
   int GlobalSize() const override
   {
@@ -193,7 +194,7 @@ public:
   }
 
   bool PlusJacobian(
-    const double* /*x*/,
+    const double* x,
     double* jacobian) const override
   {
     double x0 = x[0] / 2;
@@ -221,7 +222,7 @@ public:
   }
 
   bool MinusJacobian(
-    const double* /*x*/,
+    const double* x,
     double* jacobian) const override
   {
     double x0 = x[0] * 2;

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -151,9 +151,9 @@ public:
     double x1 = x[1] * 2;
     double x2 = x[2] * 2;
     double x3 = x[3] * 2;
-    jacobian[0] = -x1; jacobian[1]  =  x0; jacobian[2]  =  x3;  jacobian[3]  = -x2;  // NOLINT
-    jacobian[4] = -x2; jacobian[5]  = -x3; jacobian[6]  =  x0;  jacobian[7]  =  x1;  // NOLINT
-    jacobian[8] = -x3; jacobian[9]  =  x2; jacobian[10] = -x1;  jacobian[11] =  x0;  // NOLINT
+    jacobian[0] = x1; jacobian[1]  = -x0; jacobian[2]  = -x3;  jacobian[3]  =  x2;  // NOLINT
+    jacobian[4] = x2; jacobian[5]  =  x3; jacobian[6]  = -x0;  jacobian[7]  = -x1;  // NOLINT
+    jacobian[8] = x3; jacobian[9]  = -x2; jacobian[10] =  x1;  jacobian[11] = -x0;  // NOLINT
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -101,13 +101,13 @@ public:
     return true;
   }
 
-  bool Minus(const double* x1, const double* x2, double* delta) const override
+  bool Minus(const double* x, const double* y, double* y_minus_x) const override
   {
-    double x1_inverse[4];
-    QuaternionInverse(x1, x1_inverse);
+    double x_inverse[4];
+    QuaternionInverse(x, x_inverse);
     double q_delta[4];
-    ceres::QuaternionProduct(x1_inverse, x2, q_delta);
-    ceres::QuaternionToAngleAxis(q_delta, delta);
+    ceres::QuaternionProduct(x_inverse, y, q_delta);
+    ceres::QuaternionToAngleAxis(q_delta, y_minus_x);
     return true;
   }
 
@@ -192,9 +192,9 @@ public:
     double x1 = x[1] * 2;
     double x2 = x[2] * 2;
     double x3 = x[3] * 2;
-    jacobian[0] = x1; jacobian[1]  = -x0; jacobian[2]  = -x3;  jacobian[3]  =  x2;  // NOLINT
-    jacobian[4] = x2; jacobian[5]  =  x3; jacobian[6]  = -x0;  jacobian[7]  = -x1;  // NOLINT
-    jacobian[8] = x3; jacobian[9]  = -x2; jacobian[10] =  x1;  jacobian[11] = -x0;  // NOLINT
+    jacobian[0] = -x1; jacobian[1]  =  x0; jacobian[2]  =  x3;  jacobian[3]  = -x2;  // NOLINT
+    jacobian[4] = -x2; jacobian[5]  = -x3; jacobian[6]  =  x0;  jacobian[7]  =  x1;  // NOLINT
+    jacobian[8] = -x3; jacobian[9]  =  x2; jacobian[10] = -x1;  jacobian[11] =  x0;  // NOLINT
     return true;
   }
 

--- a/fuse_variables/src/orientation_2d_stamped.cpp
+++ b/fuse_variables/src/orientation_2d_stamped.cpp
@@ -65,14 +65,12 @@ void Orientation2DStamped::print(std::ostream& stream) const
          << "  - yaw: " << getYaw() << "\n";
 }
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() const
 {
   return new Orientation2DLocalParameterization();
 }
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 fuse_core::Manifold* Orientation2DStamped::manifold() const
 {
   return new Orientation2DManifold();
@@ -81,13 +79,10 @@ fuse_core::Manifold* Orientation2DStamped::manifold() const
 
 }  // namespace fuse_variables
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DManifold);
 #endif
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DLocalParameterization);
-#endif
-
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DStamped);
 PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation2DStamped, fuse_core::Variable);

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -69,13 +69,29 @@ void Orientation3DStamped::print(std::ostream& stream) const
          << "  - z: " << z() << "\n";
 }
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const
 {
   return new Orientation3DLocalParameterization();
 }
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+fuse_core::Manifold* Orientation3DStamped::manifold() const
+{
+  return new Orientation3DManifold();
+}
+#endif
 
 }  // namespace fuse_variables
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DManifold);
+#endif
+
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
+#endif
+
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
 PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation3DStamped, fuse_core::Variable);

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -69,14 +69,12 @@ void Orientation3DStamped::print(std::ostream& stream) const
          << "  - z: " << z() << "\n";
 }
 
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const
 {
   return new Orientation3DLocalParameterization();
 }
-#endif
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 fuse_core::Manifold* Orientation3DStamped::manifold() const
 {
   return new Orientation3DManifold();
@@ -85,13 +83,9 @@ fuse_core::Manifold* Orientation3DStamped::manifold() const
 
 }  // namespace fuse_variables
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DManifold);
 #endif
-
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
-#endif
-
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
 PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation3DStamped, fuse_core::Variable);

--- a/fuse_variables/test/test_acceleration_angular_2d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_angular_2d_stamped.cpp
@@ -123,8 +123,7 @@ TEST(AccelerationAngular2DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     acceleration.data(),
-    acceleration.size(),
-    acceleration.localParameterization());
+    acceleration.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(acceleration.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_acceleration_angular_3d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_angular_3d_stamped.cpp
@@ -127,8 +127,7 @@ TEST(AccelerationAngular3DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     acceleration.data(),
-    acceleration.size(),
-    acceleration.localParameterization());
+    acceleration.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(acceleration.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_acceleration_linear_2d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_linear_2d_stamped.cpp
@@ -125,8 +125,7 @@ TEST(AccelerationLinear2DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     acceleration.data(),
-    acceleration.size(),
-    acceleration.localParameterization());
+    acceleration.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(acceleration.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_acceleration_linear_3d_stamped.cpp
+++ b/fuse_variables/test/test_acceleration_linear_3d_stamped.cpp
@@ -127,8 +127,7 @@ TEST(AccelerationLinear3DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     acceleration.data(),
-    acceleration.size(),
-    acceleration.localParameterization());
+    acceleration.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(acceleration.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -33,7 +33,7 @@
  */
 #include <fuse_core/ceres_macros.h>
 #include <fuse_core/serialization.h>
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 #include <ceres/autodiff_manifold.h>
 #else
 #include <fuse_core/autodiff_local_parameterization.h>
@@ -107,7 +107,7 @@ TEST(Orientation2DStamped, Stamped)
   EXPECT_EQ(fuse_core::uuid::generate("mo"), stamped->deviceId());
 }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 struct Orientation2DFunctor
 {
   template<typename T>
@@ -122,7 +122,7 @@ struct Orientation2DPlus
     x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
     return true;
   }
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 
   template<typename T>
   bool Minus(const T* y, const T* x, T* y_minus_x) const
@@ -141,7 +141,7 @@ struct Orientation2DMinus
 };
 
 using Orientation2DAutoDiff =
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
+#if CERES_SUPPORTS_MANIFOLDS
 ceres::AutoDiffManifold<Orientation2DFunctor, 1, 1>;
 #else
 fuse_core::AutoDiffLocalParameterization<Orientation2DPlus, Orientation2DMinus, 1, 1>;
@@ -178,7 +178,7 @@ TEST(Orientation2DStamped, Plus)
 
 TEST(Orientation2DStamped, PlusJacobian)
 {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).localParameterization();
 #else
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).manifold();
@@ -190,14 +190,14 @@ TEST(Orientation2DStamped, PlusJacobian)
   {
     double x[1] = {test_value};
     double actual[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     bool success = parameterization->ComputeJacobian(x, actual);
 #else
     bool success = parameterization->PlusJacobian(x, actual);
 #endif
 
     double expected[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     reference.ComputeJacobian(x, expected);
 #else
     reference.PlusJacobian(x, expected);
@@ -212,7 +212,7 @@ TEST(Orientation2DStamped, PlusJacobian)
 
 TEST(Orientation2DStamped, Minus)
 {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).localParameterization();
 #else
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).manifold();
@@ -223,7 +223,7 @@ TEST(Orientation2DStamped, Minus)
     double x1[1] = {1.0};
     double x2[1] = {1.5};
     double actual[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     bool success = parameterization->Minus(x1, x2, actual);
 #else
     bool success = parameterization->Minus(x2, x1, actual);
@@ -238,7 +238,7 @@ TEST(Orientation2DStamped, Minus)
     double x1[1] = {2.0};
     double x2[1] = {5 - 2*M_PI};
     double actual[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     bool success = parameterization->Minus(x1, x2, actual);
 #else
     bool success = parameterization->Minus(x2, x1, actual);
@@ -251,7 +251,7 @@ TEST(Orientation2DStamped, Minus)
 
 TEST(Orientation2DStamped, MinusJacobian)
 {
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).localParameterization();
 #else
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).manifold();
@@ -263,14 +263,14 @@ TEST(Orientation2DStamped, MinusJacobian)
   {
     double x[1] = {test_value};
     double actual[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     bool success = parameterization->ComputeMinusJacobian(x, actual);
 #else
     bool success = parameterization->MinusJacobian(x, actual);
 #endif
 
     double expected[1] = {0.0};
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
     reference.ComputeMinusJacobian(x, expected);
 #else
     reference.MinusJacobian(x, expected);
@@ -305,7 +305,7 @@ TEST(Orientation2DStamped, Optimization)
 
   // Build the problem.
   ceres::Problem problem;
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
+#if !CERES_SUPPORTS_MANIFOLDS
   problem.AddParameterBlock(
     orientation.data(),
     orientation.size(),

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -137,7 +137,7 @@ struct Orientation2DPlus
 struct Orientation2DMinus
 {
   template <typename T>
-  bool operator()(const double* x, const double* y, double* y_minus_x) const
+  bool operator()(const T* x, const T* y, T* y_minus_x) const
   {
     y_minus_x[0] = fuse_core::wrapAngle2D(y[0] - x[0]);
     return true;

--- a/fuse_variables/test/test_orientation_2d_stamped.cpp
+++ b/fuse_variables/test/test_orientation_2d_stamped.cpp
@@ -177,7 +177,7 @@ TEST(Orientation2DStamped, Plus)
 }
 
 TEST(Orientation2DStamped, PlusJacobian)
-{ 
+{
 #if !CERES_VERSION_AT_LEAST(2, 1, 0)
   auto parameterization = Orientation2DStamped(ros::Time(0, 0)).localParameterization();
 #else
@@ -264,7 +264,7 @@ TEST(Orientation2DStamped, MinusJacobian)
     double x[1] = {test_value};
     double actual[1] = {0.0};
 #if !CERES_VERSION_AT_LEAST(2, 1, 0)
-    bool success = parameterization->ComputeMinusJacobian(x, actual);  
+    bool success = parameterization->ComputeMinusJacobian(x, actual);
 #else
     bool success = parameterization->MinusJacobian(x, actual);
 #endif

--- a/fuse_variables/test/test_point_2d_fixed_landmark.cpp
+++ b/fuse_variables/test/test_point_2d_fixed_landmark.cpp
@@ -78,7 +78,6 @@ struct CostFunctor
   {
     residual[0] = x[0] - T(3.0);
     residual[1] = x[1] + T(8.0);
-    residual[2] = x[2] - T(3.1);
     return true;
   }
 };

--- a/fuse_variables/test/test_position_2d_stamped.cpp
+++ b/fuse_variables/test/test_position_2d_stamped.cpp
@@ -125,8 +125,7 @@ TEST(Position2DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     position.data(),
-    position.size(),
-    position.localParameterization());
+    position.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(position.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_velocity_angular_2d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_angular_2d_stamped.cpp
@@ -123,8 +123,7 @@ TEST(VelocityAngular2DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     velocity.data(),
-    velocity.size(),
-    velocity.localParameterization());
+    velocity.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(velocity.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_velocity_angular_3d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_angular_3d_stamped.cpp
@@ -127,8 +127,7 @@ TEST(VelocityAngular3DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     velocity.data(),
-    velocity.size(),
-    velocity.localParameterization());
+    velocity.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(velocity.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_velocity_linear_2d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_linear_2d_stamped.cpp
@@ -125,8 +125,7 @@ TEST(VelocityLinear2DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     velocity.data(),
-    velocity.size(),
-    velocity.localParameterization());
+    velocity.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(velocity.data());
   problem.AddResidualBlock(

--- a/fuse_variables/test/test_velocity_linear_3d_stamped.cpp
+++ b/fuse_variables/test/test_velocity_linear_3d_stamped.cpp
@@ -127,8 +127,7 @@ TEST(VelocityLinear3DStamped, Optimization)
   ceres::Problem problem;
   problem.AddParameterBlock(
     velocity.data(),
-    velocity.size(),
-    velocity.localParameterization());
+    velocity.size());
   std::vector<double*> parameter_blocks;
   parameter_blocks.push_back(velocity.data());
   problem.AddResidualBlock(


### PR DESCRIPTION
This MR has all the changes required to support `gcc12` and Ceres `2.1.0`.

```bash
$ g++ --version
g++ (GCC) 12.2.0
```

With Ceres `2.1.0` the `ceres::LocalParameterization` was [marked as deprecated](https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc) in favour of the new `ceres::Manifold` that implements the `Plus` and `Minus` methods; in Ceres `2.2.0` the `ceres::LocalParameterization` is [already removed](https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3).

`gcc12` spotted some issues:
* An out of bounds access in the `CostFunctor` defined for the `Poin2DFixedLandmark` unit test
* A `maybe-unitialized` warning in `fuse_graphs` related to `boost::make_transform_iterator` and a lambda that takes a reference from constraints or variables. I simply added `-Wno-maybe-uninitialized` for now
* A `array-bounds` warning due to [this `gcc12` bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247), also mentioned in [Eigen issue](https://gitlab.com/libeigen/eigen/-/issues/2506). I simply added `-Wno-array-bounds`, conditional on the compiler being `gcc` and `>=12.0`.

I also added `SYSTEM` to 3rd party headers to ignore warnings from those libraries.

The `Minus` **Jacobian** implementation of `ceres::Manifold` only [computes the jacobian wrt the 1st argument](https://github.com/ceres-solver/ceres-solver/blob/77497373193a6304a67d0/include/ceres/autodiff_manifold.h#L244-L246), which differs from the `fuse_core::LocalParameterization` implementation, that [computes it wrt the 2nd argument](https://github.com/locusrobotics/fuse/blob/c8ab2f6e971a21ecf74e9debeef0d74d1c24655d/fuse_core/include/fuse_core/autodiff_local_parameterization.h#L214-L215), which seems to be wrong. For that reason, I fixed the following bugs:
* Fixed the `fuse_core::AutoDiffLocalParameterization`
* Used `ceres::AutoDiffManifold` instead of `fuse_core::AutoDiffLocalParameterization` for Ceres `>=2.1.0`
* Updated the unit tests that had hard-coded expected Jacobians. They basically changed in signed. This only impacted the orientation 2D and 3D local parameterizations, which are the only ones provided.
* Fixed the analytic `Minus` Jacobians for the `Orientation2DLocalParameterization` and `Orientation3DLocalParameterization`, since they had the wrong sign. This bug was hiden by the bug in `fuse_core::AutoDiffParameterization`, which in a way was cancelling it out.
