### PR TITLE
Fixing CI tests

### DIFF
--- a/fuse_constraints/test/cost_function_gtest.h
+++ b/fuse_constraints/test/cost_function_gtest.h
@@ -48,10 +48,9 @@
  *
  * @param[in] cost_function The expected cost function
  * @param[in] actual_cost_function The actual cost function
- * @param[in] tolerance The tolerance to use when comparing the cost functions are equal. Defaults to 1e-18
  */
 static void ExpectCostFunctionsAreEqual(const ceres::CostFunction& cost_function,
-                                        const ceres::CostFunction& actual_cost_function, double tolerance = 1e-18)
+                                        const ceres::CostFunction& actual_cost_function)
 {
   EXPECT_EQ(cost_function.num_residuals(), actual_cost_function.num_residuals());
   const size_t num_residuals = cost_function.num_residuals();
@@ -95,7 +94,7 @@ static void ExpectCostFunctionsAreEqual(const ceres::CostFunction& cost_function
   EXPECT_TRUE(actual_cost_function.Evaluate(parameter_blocks.get(), actual_residuals.get(), nullptr));
   for (size_t i = 0; i < num_residuals; ++i)
   {
-    EXPECT_NEAR(residuals[i], actual_residuals[i], tolerance) << "residual id: " << i;
+    EXPECT_DOUBLE_EQ(residuals[i], actual_residuals[i]) << "residual id: " << i;
   }
 
   EXPECT_TRUE(cost_function.Evaluate(parameter_blocks.get(), residuals.get(), jacobian_blocks.get()));
@@ -103,12 +102,12 @@ static void ExpectCostFunctionsAreEqual(const ceres::CostFunction& cost_function
       actual_cost_function.Evaluate(parameter_blocks.get(), actual_residuals.get(), actual_jacobian_blocks.get()));
   for (size_t i = 0; i < num_residuals; ++i)
   {
-    EXPECT_NEAR(residuals[i], actual_residuals[i], tolerance) << "residual : " << i;
+    EXPECT_DOUBLE_EQ(residuals[i], actual_residuals[i]) << "residual : " << i;
   }
 
   for (size_t i = 0; i < num_residuals * num_parameters; ++i)
   {
-    EXPECT_NEAR(jacobians[i], actual_jacobians[i], tolerance)
+    EXPECT_DOUBLE_EQ(jacobians[i], actual_jacobians[i])
         << "jacobian : " << i << " " << jacobians[i] << " " << actual_jacobians[i];
   }
 }


### PR DESCRIPTION
Removed the unused tolerance parameter from ExpectCostFunctionsAreEqual, and replaced EXPECT_NEAR with EXPECT_DOUBLE_EQ to prevent jenkins error.