### PR TITLE
Add tf2_geometry_msgs as a target_link_libraries

### DIFF
--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   rviz_common::rviz_common
   rviz_rendering::rviz_rendering
   tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
This is directly included by the package, so must be listed as part of target_link_libraries.

This should fix the failing build on Rolling: https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__fuse_viz__ubuntu_jammy_amd64__binary/41/