### PR TITLE
Fix Qwt deprecated declarations

### DIFF
--- a/fuse_loss/include/fuse_loss/qwt_loss_plot.h
+++ b/fuse_loss/include/fuse_loss/qwt_loss_plot.h
@@ -218,7 +218,7 @@ class QwtLossPlot
 {
 public:
   QwtLossPlot(const std::vector<double>& residuals, const HSVColormap& colormap)
-    : residuals_(QVector<double>::fromStdVector(residuals))
+    : residuals_(residuals.cbegin(), residuals.cend())
     , loss_evaluator_(residuals)
     , colormap_(colormap)
     , magnifier_(plot_.canvas())
@@ -251,7 +251,7 @@ public:
   {
     QwtPlotCurve* curve = new QwtPlotCurve(name.c_str());
 
-    curve->setSamples(residuals_, QVector<double>::fromStdVector(values));
+    curve->setSamples(residuals_, QVector<double>(values.cbegin(), values.cend()));
 
     curve->setPen(colormap_[curves_.size()]);
     curve->attach(&plot_);


### PR DESCRIPTION
This fixes `-Werror=deprecated-declarations` errors in a unit test that is built with `--cmake-args BUILD_WITH_PLOT_TESTS=ON` (only one error shown):
```bash
fuse/fuse_loss/include/fuse_loss/qwt_loss_plot.h:254:65: error: ‘static QVector<T> QVector<T>::fromStdVector(const std::vector<T>&) [with T = double]’ is deprecated: Use QVector<T>(vector.begin(), vector.end()) instead. [-Werror=deprecated-declarations]
  254 |     curve->setSamples(residuals_, QVector<double>::fromStdVector(values));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```