### PR TITLE
Add reset to batch opt

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror)
+add_compile_options(-Wall -Werror -Wno-deprecated-declarations)
 
 ## fuse_optimizers library
 add_library(${PROJECT_NAME}

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror -Wno-deprecated-declarations)
+add_compile_options(-Wall -Werror)
 
 ## fuse_optimizers library
 add_library(${PROJECT_NAME}

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -40,6 +40,7 @@
 #include <fuse_optimizers/batch_optimizer_params.h>
 #include <fuse_optimizers/optimizer.h>
 #include <ros/ros.h>
+#include <std_srvs/Empty.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -159,6 +160,7 @@ protected:
   std::mutex pending_transactions_mutex_;  //!< Synchronize modification of the pending_transactions_ container
   ros::Time start_time_;  //!< The timestamp of the first ignition sensor transaction
   bool started_;  //!< Flag indicating the optimizer is ready/has received a transaction from an ignition sensor
+  ros::ServiceServer reset_service_server_;  //!< Service that resets the optimizer to its initial state
 
   /**
    * @brief Generate motion model constraints for pending transactions
@@ -209,6 +211,11 @@ protected:
    * @param[in] status The diagnostic status
    */
   void setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& status) override;
+
+  /**
+   * @brief Service callback that resets the optimizer to its original state
+   */
+  bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -143,6 +143,7 @@ protected:
    */
   using TransactionQueue = std::multimap<ros::Time, TransactionQueueElement>;
 
+  std::mutex optimization_mutex_;  //!< Mutex held while the graph is begin optimized
   fuse_core::Transaction::SharedPtr combined_transaction_;  //!< Transaction used aggregate constraints and variables
                                                             //!< from multiple sensors and motions models before being
                                                             //!< applied to the graph.

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -45,10 +45,8 @@
 #include <string>
 #include <vector>
 
-
 namespace fuse_optimizers
 {
-
 /**
  * @brief Defines the set of parameters required by the fuse_optimizers::FixedLagSmoother class
  */
@@ -102,7 +100,7 @@ public:
     }
 
     nh.getParam("reset_service", reset_service);
-    
+
     fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -65,6 +65,11 @@ public:
   ros::Duration optimization_period { 0.1 };
 
   /**
+   * @brief The topic name of the advertised reset service
+   */
+  std::string reset_service { "~reset" };
+
+  /**
    * @brief The maximum time to wait for motion models to be generated for a received transaction.
    *
    * Transactions are processed sequentially, so no new transactions will be added to the graph while waiting for
@@ -96,6 +101,8 @@ public:
       fuse_core::getPositiveParam(nh, "optimization_period", optimization_period);
     }
 
+    nh.getParam("reset_service", reset_service);
+    
     fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 
     fuse_core::loadSolverOptionsFromROS(ros::NodeHandle(nh, "solver_options"), solver_options);

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -72,6 +72,7 @@ BatchOptimizer::BatchOptimizer(
     ros::names::resolve(params_.reset_service),
     &BatchOptimizer::resetServiceCallback,
     this);
+  std::cout << ros::this_node::getNamespace() << std::endl;
 }
 
 BatchOptimizer::~BatchOptimizer()

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -66,6 +66,12 @@ BatchOptimizer::BatchOptimizer(
 
   // Start the optimization thread
   optimization_thread_ = std::thread(&BatchOptimizer::optimizationLoop, this);
+
+  // Advertise a service that resets the optimizer to its initial state
+  reset_service_server_ = node_handle_.advertiseService(
+    ros::names::resolve(params_.reset_service),
+    &FixedLagSmoother::resetServiceCallback,
+    this);
 }
 
 BatchOptimizer::~BatchOptimizer()
@@ -236,6 +242,41 @@ void BatchOptimizer::setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper&
     std::lock_guard<std::mutex> lock(pending_transactions_mutex_);
     status.add("Pending Transactions", pending_transactions_.size());
   }
+}
+
+bool BatchOptimizer::resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+{
+  // Tell all the plugins to stop
+  stopPlugins();
+  // Reset the optimizer state
+  {
+    std::lock_guard<std::mutex> lock(optimization_requested_mutex_);
+    optimization_request_ = false;
+  }
+  started_ = false;
+  ignited_ = false;
+  setStartTime(ros::Time(0, 0));
+  // DANGER: The optimizationLoop() function obtains the lock optimization_mutex_ lock and the
+  //         pending_transactions_mutex_ lock at the same time. We perform a parallel locking scheme here to
+  //         prevent the possibility of deadlocks.
+  {
+    std::lock_guard<std::mutex> lock(optimization_mutex_);
+    // Clear all pending transactions
+    {
+      std::lock_guard<std::mutex> lock(pending_transactions_mutex_);
+      pending_transactions_.clear();
+    }
+    // Clear the graph and marginal tracking states
+    graph_->clear();
+    marginal_transaction_ = fuse_core::Transaction();
+    timestamp_tracking_.clear();
+  }
+  // Tell all the plugins to start
+  startPlugins();
+  // Test for auto-start
+  autostart();
+
+  return true;
 }
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -72,7 +72,6 @@ BatchOptimizer::BatchOptimizer(
     ros::names::resolve(params_.reset_service),
     &BatchOptimizer::resetServiceCallback,
     this);
-  std::cout << ros::this_node::getNamespace() << std::endl;
 }
 
 BatchOptimizer::~BatchOptimizer()

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -143,13 +143,6 @@ void BatchOptimizer::optimizationLoop()
     {
       break;
     }
-    // Copy the combined transaction so it can be shared with all the plugins
-    fuse_core::Transaction::ConstSharedPtr const_transaction;
-    {
-      std::lock_guard<std::mutex> lock(combined_transaction_mutex_);
-      const_transaction = std::move(combined_transaction_);
-      combined_transaction_ = fuse_core::Transaction::make_shared();
-    }
     {
       std::lock_guard<std::mutex> lock(optimization_mutex_);
       // Copy the combined transaction so it can be shared with all the plugins


### PR DESCRIPTION
Adding the same reset service from the fixed lag smoother to the batch optimizer. This also adds a mutex for the optimization which is performing fine in my experiments, this is to make sure on reset we have sole access to the graph.