### PR TITLE
Adding stop and start functionality to the fixed lag smoother

### DIFF
--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -162,6 +162,8 @@ protected:
   ros::Time start_time_;  //!< The timestamp of the first ignition sensor transaction
   bool started_;  //!< Flag indicating the optimizer is ready/has received a transaction from an ignition sensor
   ros::ServiceServer reset_service_server_;  //!< Service that resets the optimizer to its initial state
+  ros::ServiceServer stop_service_server_;  //!< Service that stops and clears the optimizer
+  ros::ServiceServer start_service_server_;  //!< Service that restarts the optimizer
 
   /**
    * @brief Generate motion model constraints for pending transactions
@@ -217,6 +219,26 @@ protected:
    * @brief Service callback that resets the optimizer to its original state
    */
   bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+  /**
+   * @brief Service callback that stops the optimizer plugins and clears the existing graph. Essentially performs a reset,
+   * but doesn't immediately restart optimization.
+   */
+  bool stopServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+
+  /**
+   * @brief Service callback that starts the optimizer plugins after they have been stopped.
+   */
+  bool startServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+
+  /**
+   * @brief Start the optimizer
+   */
+  void start();
+
+  /**
+   * @brief Stop the optimizer
+   */
+  void stop();
 };
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -68,6 +68,16 @@ public:
   std::string reset_service { "~reset" };
 
   /**
+   * @brief The topic name of the advertised stop service
+   */
+  std::string stop_service { "~stop" };
+
+  /**
+   * @brief The topic name of the advertised restart service
+   */
+  std::string start_service { "~start" };
+
+  /**
    * @brief The maximum time to wait for motion models to be generated for a received transaction.
    *
    * Transactions are processed sequentially, so no new transactions will be added to the graph while waiting for
@@ -100,6 +110,8 @@ public:
     }
 
     nh.getParam("reset_service", reset_service);
+    nh.getParam("stop_service", stop_service);
+    nh.getParam("start_service", start_service);
 
     fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -284,6 +284,16 @@ protected:
   bool startServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 
   /**
+   * @brief Start the optimizer
+   */
+  void start();
+
+  /**
+   * @brief Stop the optimizer
+   */
+  void stop();
+  
+  /**
    * @brief Thread-safe read-only access to the optimizer start time
    */
   ros::Time getStartTime() const

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -190,6 +190,8 @@ protected:
   // Ordering ROS objects with callbacks last
   ros::Timer optimize_timer_;  //!< Trigger an optimization operation at a fixed frequency
   ros::ServiceServer reset_service_server_;  //!< Service that resets the optimizer to its initial state
+  ros::ServiceServer stop_service_server_;  //!< Service that stops and clears the optimizer
+  ros::ServiceServer start_service_server_;  //!< Service that restarts the optimizer
 
   /**
    * @brief Automatically start the smoother if no ignition sensors are specified
@@ -269,6 +271,17 @@ protected:
    * @brief Service callback that resets the optimizer to its original state
    */
   bool resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+
+  /**
+   * @brief Service callback that stops the optimizer plugins and clears the existing graph. Essentially performs a reset,
+   * but doesn't immediately restart optimization.
+   */
+  bool stopServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+
+  /**
+   * @brief Service callback that starts the optimizer plugins after they have been stopped.
+   */
+  bool startServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
 
   /**
    * @brief Thread-safe read-only access to the optimizer start time

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -292,7 +292,7 @@ protected:
    * @brief Stop the optimizer
    */
   void stop();
-  
+
   /**
    * @brief Thread-safe read-only access to the optimizer start time
    */

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -75,6 +75,16 @@ public:
   std::string reset_service { "~reset" };
 
   /**
+   * @brief The topic name of the advertised stop service
+   */
+  std::string stop_service { "~stop" };
+
+  /**
+   * @brief The topic name of the advertised restart service
+   */
+  std::string start_service { "~start" };
+
+  /**
    * @brief The maximum time to wait for motion models to be generated for a received transaction.
    *
    * Transactions are processed sequentially, so no new transactions will be added to the graph while waiting for
@@ -109,6 +119,8 @@ public:
     }
 
     nh.getParam("reset_service", reset_service);
+    nh.getParam("stop_service", stop_service);
+    nh.getParam("start_service", start_service);
 
     fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -72,6 +72,16 @@ BatchOptimizer::BatchOptimizer(
     ros::names::resolve(params_.reset_service),
     &BatchOptimizer::resetServiceCallback,
     this);
+
+  stop_service_server_ = node_handle_.advertiseService(
+    ros::names::resolve(params_.stop_service),
+    &BatchOptimizer::stopServiceCallback,
+    this);
+
+  start_service_server_ = node_handle_.advertiseService(
+    ros::names::resolve(params_.start_service),
+    &BatchOptimizer::startServiceCallback,
+    this);
 }
 
 BatchOptimizer::~BatchOptimizer()
@@ -249,6 +259,31 @@ void BatchOptimizer::setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper&
 
 bool BatchOptimizer::resetServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
 {
+  stop();
+  start();
+  return true;
+}
+
+bool BatchOptimizer::stopServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+{
+  stop();
+  return true;
+}
+
+bool BatchOptimizer::startServiceCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+{
+  start();
+  return true;
+}
+
+void BatchOptimizer::start()
+{
+  // Tell all the plugins to start
+  startPlugins();
+}
+
+void BatchOptimizer::stop()
+{
   // Tell all the plugins to stop
   stopPlugins();
   // Reset the optimizer state
@@ -280,10 +315,6 @@ bool BatchOptimizer::resetServiceCallback(std_srvs::Empty::Request&, std_srvs::E
     std::lock_guard<std::mutex> lock(pending_transactions_mutex_);
     pending_transactions_.clear();
   }
-  // Tell all the plugins to start
-  startPlugins();
-
-  return true;
 }
 
 }  // namespace fuse_optimizers

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -529,7 +529,6 @@ void FixedLagSmoother::transactionCallback(
       // ...check if we should
       if (sensor_models_.at(sensor_name).ignition)
       {
-        ROS_INFO_STREAM("Ignition occured");
         started_ = true;
         ignited_ = true;
         start_time = position->minStamp();


### PR DESCRIPTION
This PR adds the ability to stop the fixed lag smoother and restart it at a later time, to keep it from consuming CPU when it's not needed.

This PR makes the assumption that whenever you restart the optimizer, any data that was previously held in the optimizer is no longer valid, and should be removed.