### PR TITLE
Cast nullptr to type for manifold support

### DIFF
--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -99,7 +99,17 @@ TEST(CostFunction, evaluateCostFunction)
 
   // Check jacobians are correct using a gradient checker
   ceres::NumericDiffOptions numeric_diff_options;
-  ceres::GradientChecker gradient_checker(&cost_function, nullptr, numeric_diff_options);
+#if !CERES_SUPPORTS_MANIFOLDS
+  ceres::GradientChecker gradient_checker(
+    &cost_function,
+    static_cast<std::vector<const ceres::LocalParameterization*>*>(nullptr),
+    numeric_diff_options);
+#else
+  ceres::GradientChecker gradient_checker(
+    &cost_function,
+    static_cast<std::vector<const ceres::Manifold*>*>(nullptr),
+    numeric_diff_options);
+#endif
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;


### PR DESCRIPTION
Without this when ceres version == 2.1.0 we get:
`/home/jmclaughlin/colcon_ws/src/perception/fuse/fuse_models/test/test_unicycle_2d_state_cost_function.cpp:102:88: error: call of overloaded ‘GradientChecker(const fuse_models::Unicycle2DStateCostFunction*, std::nullptr_t, ceres::NumericDiffOptions&)’ is ambiguous
  102 |   ceres::GradientChecker gradient_checker(&cost_function, nullptr, numeric_diff_options);
`