### PR TITLE
[RST-10642] Allow the optimizer to remain disabled at startup

### DIFF
--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -56,6 +56,11 @@ struct FixedLagSmootherParams
 {
 public:
   /**
+   * @brief If true, the state estimator will not start until the start or reset service is called
+   */
+  bool disabled_at_startup { false };
+
+  /**
    * @brief The duration of the smoothing window in seconds
    */
   ros::Duration lag_duration { 5.0 };
@@ -105,6 +110,8 @@ public:
   void loadFromROS(const ros::NodeHandle& nh)
   {
     // Read settings from the parameter server
+    nh.getParam("disabled_at_startup", disabled_at_startup);
+
     fuse_core::getPositiveParam(nh, "lag_duration", lag_duration);
 
     if (nh.hasParam("optimization_frequency"))

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -82,6 +82,8 @@ BatchOptimizer::BatchOptimizer(
     ros::names::resolve(params_.start_service),
     &BatchOptimizer::startServiceCallback,
     this);
+
+  startPlugins();
 }
 
 BatchOptimizer::~BatchOptimizer()

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -90,9 +90,6 @@ FixedLagSmoother::FixedLagSmoother(
 {
   params_.loadFromROS(private_node_handle);
 
-  // Test for auto-start
-  autostart();
-
   // Start the optimization thread
   optimization_thread_ = std::thread(&FixedLagSmoother::optimizationLoop, this);
 
@@ -117,6 +114,11 @@ FixedLagSmoother::FixedLagSmoother(
     ros::names::resolve(params_.start_service),
     &FixedLagSmoother::startServiceCallback,
     this);
+
+  if (!params_.disabled_at_startup)
+  {
+    start();
+  }
 }
 
 FixedLagSmoother::~FixedLagSmoother()

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -458,6 +458,12 @@ bool FixedLagSmoother::startServiceCallback(std_srvs::Empty::Request&, std_srvs:
 
 void FixedLagSmoother::start()
 {
+  if (started_)
+  {
+    ROS_WARN_STREAM("Requested to start the optimizer while it is already running. Ignoring request.");
+    return;
+  }
+
   ROS_INFO_STREAM("Starting optimizer.");
   // Tell all the plugins to start
   startPlugins();

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -109,9 +109,6 @@ Optimizer::Optimizer(
   loadMotionModels();
   loadSensorModels();
   loadPublishers();
-
-  // Start all the plugins
-  startPlugins();
 }
 
 Optimizer::~Optimizer()


### PR DESCRIPTION
Instead of automatically starting all of the plugins during construction, we should allow the optimizer to remain in the offline state until someone calls `start()`. The `robot_localization` package supported this feature with a `disabled_at_startup` flag. This PR only affects the operation of the fixed-lag smoother. The batch optimizer is missing most of this functionality.

Note: There is a subtle API change here. The base Optimizer class no longer starts the plugins during construction. This PR patches the BatchOptimizer is start the plugins during its constructor instead. But if there exists a 3rd party optimizer derived from the base Optimizer class, that 3rd party class will potentially break. I considered placing the plugin startup check inside the base Optimizer class. That would prevent this breakage and it would mean both the Fixed-lag Smoother and Batch Optimizer would benefit from the `disabled_at_startup` flag. However, I feel this reduces the flexibility of the derived Optimizer classes. Allowing the derived classes to have control over when the plugins are started and stopped feels better. Derived classes can implement additional logic and bookkeeping, handle any locks required, etc at the same time the plugins change state.

But feel free to disagree with me.