### PR TITLE
[RST-10727] Publish the start/stop status of the fixed-lag smoother

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -9,6 +9,7 @@ set(build_depends
   fuse_variables
   pluginlib
   roscpp
+  std_msgs
   std_srvs
 )
 

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -192,6 +192,7 @@ protected:
   ros::ServiceServer reset_service_server_;  //!< Service that resets the optimizer to its initial state
   ros::ServiceServer stop_service_server_;  //!< Service that stops and clears the optimizer
   ros::ServiceServer start_service_server_;  //!< Service that restarts the optimizer
+  ros::Publisher status_publisher_;  //!< Publishing the started/stopped status of the optimizer
 
   /**
    * @brief Automatically start the smoother if no ignition sensors are specified

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -200,6 +200,13 @@ protected:
   void autostart();
 
   /**
+   * @brief Publish the optimizer status message
+   *
+   * @param[in] running Flag indicating if the optimizer is running
+   */
+  void publishStatus(const bool running);
+
+  /**
    * @brief Perform any required preprocessing steps before \p computeVariablesToMarginalize() is called
    *
    * All new transactions that will be applied to the graph are provided. This does not include the marginal

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -90,6 +90,11 @@ public:
   std::string start_service { "~start" };
 
   /**
+   * @brief The topic name of the started/stopped status topic
+   */
+  std::string status_topic { "~running" };
+
+  /**
    * @brief The maximum time to wait for motion models to be generated for a received transaction.
    *
    * Transactions are processed sequentially, so no new transactions will be added to the graph while waiting for
@@ -128,6 +133,7 @@ public:
     nh.getParam("reset_service", reset_service);
     nh.getParam("stop_service", stop_service);
     nh.getParam("start_service", start_service);
+    nh.getParam("status_topic", status_topic);
 
     fuse_core::getPositiveParam(nh, "transaction_timeout", transaction_timeout);
 

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -21,6 +21,7 @@
   <depend>fuse_variables</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <test_depend>fuse_models</test_depend>
   <test_depend>geometry_msgs</test_depend>

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -120,9 +120,7 @@ FixedLagSmoother::FixedLagSmoother(
     ros::names::resolve(params_.status_topic),
     1,
     true);
-  auto status = std_msgs::Bool();
-  status.data = false;
-  status_publisher_.publish(status);
+  publishStatus(false);
 
   if (!params_.disabled_at_startup)
   {
@@ -152,6 +150,13 @@ void FixedLagSmoother::autostart()
     setStartTime(ros::Time(0, 0));
     ROS_INFO_STREAM("No ignition sensors were specified. Optimization will begin immediately.");
   }
+}
+
+void FixedLagSmoother::publishStatus(const bool running)
+{
+  auto status = std_msgs::Bool();
+  status.data = running;
+  status_publisher_.publish(status);
 }
 
 void FixedLagSmoother::preprocessMarginalization(const fuse_core::Transaction& new_transaction)
@@ -479,9 +484,7 @@ void FixedLagSmoother::start()
   // Test for auto-start
   autostart();
   // Update status topic
-  auto status = std_msgs::Bool();
-  status.data = true;
-  status_publisher_.publish(status);
+  publishStatus(true);
 
   ROS_INFO_STREAM("Started optimizer.");
 }
@@ -516,9 +519,7 @@ void FixedLagSmoother::stop()
     lag_expiration_ = ros::Time(0, 0);
   }
   // Update status topic
-  auto status = std_msgs::Bool();
-  status.data = false;
-  status_publisher_.publish(status);
+  publishStatus(false);
 
   ROS_INFO_STREAM("Stopped Optimizer.");
 }


### PR DESCRIPTION
Now that it is possible to construct a fixed-lag smoother without immediately starting it, knowing the running state of the optimizer may be important for coordination with other nodes. Publish the start/stop state of the optimizer as a latched topic.

The status is currently being published as a `std_msgs/Bool`. I do wonder if I should add a dedicated message type to `fuse_msgs` and publish that instead? If we ever want to expand the status information in the future, having our own message type could make that easier. We would simply add new fields to the message, but we would continue to publish the same message type. Any thoughts?