### PR TITLE
Fixing issue with Eigen in Ubuntu Jammy on ARM

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -81,8 +81,8 @@ endif()
 # the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
 # for ARM builds here.
 if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
-CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
-CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+   CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
     add_compile_options(-Wno-class-memaccess)
 endif()
 

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -77,6 +77,15 @@ else()
   add_compile_options(-Wall -Werror)
 endif()
 
+# On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
+# the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
+# for ARM builds here.
+if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
+CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+    add_compile_options(-Wno-class-memaccess)
+endif()
+
 # fuse_constraints library
 add_library(${PROJECT_NAME}
   src/absolute_constraint.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -35,6 +35,15 @@ catkin_package(
 ###########
 add_compile_options(-Wall -Werror)
 
+# On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
+# the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
+# for ARM builds here.
+if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
+CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+    add_compile_options(-Wno-class-memaccess)
+endif()
+
 ## fuse_core library
 add_library(${PROJECT_NAME}
   src/async_motion_model.cpp

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -39,8 +39,8 @@ add_compile_options(-Wall -Werror)
 # the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
 # for ARM builds here.
 if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
-CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
-CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+   CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
     add_compile_options(-Wno-class-memaccess)
 endif()
 

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -81,6 +81,15 @@ roslint_cpp()
 ###########
 add_compile_options(-Wall -Werror)
 
+# On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
+# the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
+# for ARM builds here.
+if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
+CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+    add_compile_options(-Wno-class-memaccess)
+endif()
+
 ## Declare a C++ library
 add_library(${PROJECT_NAME}
   src/acceleration_2d.cpp

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -85,8 +85,8 @@ add_compile_options(-Wall -Werror)
 # the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
 # for ARM builds here.
 if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
-CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
-CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+   CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
     add_compile_options(-Wno-class-memaccess)
 endif()
 

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -31,6 +31,15 @@ catkin_package(
 ###########
 add_compile_options(-Wall -Werror)
 
+# On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
+# the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
+# for ARM builds here.
+if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
+CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+    add_compile_options(-Wno-class-memaccess)
+endif()
+
 # fuse_publishers library
 add_library(${PROJECT_NAME}
   src/path_2d_publisher.cpp

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -33,11 +33,16 @@ add_compile_options(-Wall -Werror)
 
 # On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
 # the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
-# for ARM builds here.
-if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
-CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
-CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
-    add_compile_options(-Wno-class-memaccess)
+# for ARM builds here. However, this package does not depend directly upon Eigen, but includes headers from other
+# packages that do. So to prevent the error, we need to find Eigen and then check the version.
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+   CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+
+   find_package(Eigen3)
+
+   if(Eigen3_FOUND AND Eigen3_VERSION VERSION_EQUAL 3.4)
+      add_compile_options(-Wno-class-memaccess)
+   endif()
 endif()
 
 # fuse_publishers library

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -37,11 +37,16 @@ add_compile_options(-Wall -Werror)
 
 # On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
 # the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
-# for ARM builds here.
-if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
-CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
-CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
-    add_compile_options(-Wno-class-memaccess)
+# for ARM builds here. However, this package does not depend directly upon Eigen, but includes headers from other
+# packages that do. So to prevent the error, we need to find Eigen and then check the version.
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+   CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+
+   find_package(Eigen3)
+
+   if(Eigen3_FOUND AND Eigen3_VERSION VERSION_EQUAL 3.4)
+      add_compile_options(-Wno-class-memaccess)
+   endif()
 endif()
 
 catkin_package(

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -35,6 +35,15 @@ add_definitions(-DQT_NO_KEYWORDS)
 ###########
 add_compile_options(-Wall -Werror)
 
+# On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes
+# the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning
+# for ARM builds here.
+if(Eigen3_VERSION VERSION_EQUAL 3.4 AND
+CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0 AND
+CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
+    add_compile_options(-Wno-class-memaccess)
+endif()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}


### PR DESCRIPTION
On ARM, the use of Eigen 3.4 with g++11 (both the versions in Jammy) causes a warning, which in turn causes the build to fail. Details are here: https://gitlab.com/libeigen/eigen/-/issues/2326. We can suppress the warning for ARM builds by checking for the specific versions of the affected packages and architecture.

If anyone has a more reliable (yet equally succinct) way of testing for ARM, please fill me in.