### PR TITLE
Fix rolling build

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -66,7 +66,7 @@ include(suitesparse-extras.cmake)
 #   850 |   typename plain_matrix_type<Src>::type tmp(src);
 #       |                                         ^~~
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
-  add_compile_options(-Wall -Werror -Wno-array-bounds -Wno-stringop-overread)
+  add_compile_options(-Wall -Werror -Wno-array-bounds)
 else()
   add_compile_options(-Wall -Werror)
 endif()

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -66,7 +66,7 @@ include(suitesparse-extras.cmake)
 #   850 |   typename plain_matrix_type<Src>::type tmp(src);
 #       |                                         ^~~
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
-  add_compile_options(-Wall -Werror -Wno-array-bounds)
+  add_compile_options(-Wall -Werror -Wno-array-bounds -Wno-stringop-overread)
 else()
   add_compile_options(-Wall -Werror)
 endif()

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -166,7 +166,7 @@ public:
   /**
    * @brief tell the CallbackGroup that this waitable is ready to execute anything
    */
-  bool is_ready(rcl_wait_set_t const& wait_set) override;
+  bool is_ready(rcl_wait_set_t const & wait_set) override;
 
 
   /**
@@ -179,7 +179,7 @@ public:
 
   std::shared_ptr<void> take_data() override;
 
-  void execute(std::shared_ptr<void> const& data) override;
+  void execute(std::shared_ptr<void> const & data) override;
 
   void addCallback(const std::shared_ptr<CallbackWrapperBase> & callback);
 

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -187,6 +187,12 @@ public:
 
   void removeAllCallbacks();
 
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {
+    return nullptr;
+  }
+
 private:
   rcl_guard_condition_t gc_;  //!< guard condition to drive the waitable
 

--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -166,7 +166,7 @@ public:
   /**
    * @brief tell the CallbackGroup that this waitable is ready to execute anything
    */
-  bool is_ready(rcl_wait_set_t * wait_set) override;
+  bool is_ready(rcl_wait_set_t const& wait_set) override;
 
 
   /**
@@ -175,11 +175,11 @@ public:
     waitable_ptr = std::make_shared<CallbackWrapper>();
     node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
    */
-  void add_to_wait_set(rcl_wait_set_t * wait_set) override;
+  void add_to_wait_set(rcl_wait_set_t & wait_set) override;
 
   std::shared_ptr<void> take_data() override;
 
-  void execute(std::shared_ptr<void> & data) override;
+  void execute(std::shared_ptr<void> const& data) override;
 
   void addCallback(const std::shared_ptr<CallbackWrapperBase> & callback);
 

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -59,7 +59,7 @@ size_t CallbackAdapter::get_number_of_ready_guard_conditions() {return 1;}
 /**
    * @brief tell the CallbackGroup that this waitable is ready to execute anything
    */
-bool CallbackAdapter::is_ready(rcl_wait_set_t const& wait_set)
+bool CallbackAdapter::is_ready(rcl_wait_set_t const & wait_set)
 {
   (void) wait_set;
   return !callback_queue_.empty();
@@ -107,7 +107,7 @@ std::shared_ptr<void> CallbackAdapter::take_data()
    * @brief hook that allows the rclcpp::waitables interface to run the next callback
    *
    */
-void CallbackAdapter::execute(std::shared_ptr<void> const& data)
+void CallbackAdapter::execute(std::shared_ptr<void> const & data)
 {
   if (!data) {
     throw std::runtime_error("'data' is empty");

--- a/fuse_core/src/callback_wrapper.cpp
+++ b/fuse_core/src/callback_wrapper.cpp
@@ -59,7 +59,7 @@ size_t CallbackAdapter::get_number_of_ready_guard_conditions() {return 1;}
 /**
    * @brief tell the CallbackGroup that this waitable is ready to execute anything
    */
-bool CallbackAdapter::is_ready(rcl_wait_set_t * wait_set)
+bool CallbackAdapter::is_ready(rcl_wait_set_t const& wait_set)
 {
   (void) wait_set;
   return !callback_queue_.empty();
@@ -71,9 +71,9 @@ bool CallbackAdapter::is_ready(rcl_wait_set_t * wait_set)
     waitable_ptr = std::make_shared<CallbackAdapter>();
     node->get_node_waitables_interface()->add_waitable(waitable_ptr, (rclcpp::CallbackGroup::SharedPtr) nullptr);
    */
-void CallbackAdapter::add_to_wait_set(rcl_wait_set_t * wait_set)
+void CallbackAdapter::add_to_wait_set(rcl_wait_set_t & wait_set)
 {
-  if (RCL_RET_OK != rcl_wait_set_add_guard_condition(wait_set, &gc_, NULL)) {
+  if (RCL_RET_OK != rcl_wait_set_add_guard_condition(&wait_set, &gc_, NULL)) {
     RCLCPP_WARN(rclcpp::get_logger("fuse"), "Could not add callback waitable to wait set.");
   }
 }
@@ -107,7 +107,7 @@ std::shared_ptr<void> CallbackAdapter::take_data()
    * @brief hook that allows the rclcpp::waitables interface to run the next callback
    *
    */
-void CallbackAdapter::execute(std::shared_ptr<void> & data)
+void CallbackAdapter::execute(std::shared_ptr<void> const& data)
 {
   if (!data) {
     throw std::runtime_error("'data' is empty");


### PR DESCRIPTION
Some changes in `rclcpp::Waitable` (see [here](https://github.com/ros2/rclcpp/pull/2467)) cause the `CallbackAdapter` to fail to build. This PR fixes that