### PR TITLE
Only instantiate tf_listeners if needed

### DIFF
--- a/fuse_models/include/fuse_models/acceleration_2d.h
+++ b/fuse_models/include/fuse_models/acceleration_2d.h
@@ -44,6 +44,8 @@
 #include <ros/ros.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <memory>
+
 
 namespace fuse_models
 {
@@ -113,7 +115,7 @@ protected:
 
   tf2_ros::Buffer tf_buffer_;
 
-  tf2_ros::TransformListener tf_listener_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   ros::Subscriber subscriber_;
 

--- a/fuse_models/include/fuse_models/imu_2d.h
+++ b/fuse_models/include/fuse_models/imu_2d.h
@@ -146,7 +146,7 @@ protected:
 
   tf2_ros::Buffer tf_buffer_;
 
-  tf2_ros::TransformListener tf_listener_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   ros::Subscriber subscriber_;
 

--- a/fuse_models/include/fuse_models/odometry_2d.h
+++ b/fuse_models/include/fuse_models/odometry_2d.h
@@ -141,7 +141,7 @@ protected:
 
   tf2_ros::Buffer tf_buffer_;
 
-  tf2_ros::TransformListener tf_listener_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   ros::Subscriber subscriber_;
 

--- a/fuse_models/include/fuse_models/pose_2d.h
+++ b/fuse_models/include/fuse_models/pose_2d.h
@@ -44,6 +44,8 @@
 #include <ros/ros.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <memory>
+
 
 namespace fuse_models
 {
@@ -128,7 +130,7 @@ protected:
 
   tf2_ros::Buffer tf_buffer_;
 
-  tf2_ros::TransformListener tf_listener_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   ros::Subscriber subscriber_;
 

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -41,6 +41,8 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
+#include <memory>
+
 
 // Register this sensor model with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(fuse_models::Acceleration2D, fuse_core::SensorModel)
@@ -51,7 +53,6 @@ namespace fuse_models
 Acceleration2D::Acceleration2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_),
   throttled_callback_(std::bind(&Acceleration2D::process, this, std::placeholders::_1))
 {
 }
@@ -70,6 +71,11 @@ void Acceleration2D::onInit()
   {
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
+  }
+
+  if (!params_.target_frame.empty())
+  {
+    tf_listener_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_);
   }
 }
 

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -57,7 +57,6 @@ namespace fuse_models
 Imu2D::Imu2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_),
   throttled_callback_(std::bind(&Imu2D::process, this, std::placeholders::_1))
 {
 }
@@ -78,6 +77,13 @@ void Imu2D::onInit()
   {
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
+  }
+
+  if (!params_.acceleration_target_frame.empty() ||
+      !params_.twist_target_frame.empty() ||
+      !params_.orientation_target_frame.empty())
+  {
+      tf_listener_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_);
   }
 }
 

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -56,7 +56,6 @@ namespace fuse_models
 Odometry2D::Odometry2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_),
   throttled_callback_(std::bind(&Odometry2D::process, this, std::placeholders::_1))
 {
 }
@@ -78,6 +77,11 @@ void Odometry2D::onInit()
   {
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
+  }
+
+  if (!params_.pose_target_frame.empty() || !params_.twist_target_frame.empty())
+  {
+    tf_listener_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_);
   }
 }
 

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -54,7 +54,6 @@ namespace fuse_models
 Pose2D::Pose2D() :
   fuse_core::AsyncSensorModel(1),
   device_id_(fuse_core::uuid::NIL),
-  tf_listener_(tf_buffer_),
   throttled_callback_(std::bind(&Pose2D::process, this, std::placeholders::_1))
 {
 }
@@ -74,6 +73,11 @@ void Pose2D::onInit()
   {
     ROS_WARN_STREAM("No dimensions were specified. Data from topic " << ros::names::resolve(params_.topic) <<
                     " will be ignored.");
+  }
+
+  if (!params_.target_frame.empty())
+  {
+    tf_listener_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_);
   }
 }
 


### PR DESCRIPTION
- We find that the transform listeners in sensor models are negatively impacting performance
- Do not instantiate transform listeners if target frames are empty
- Target frames are empty by default
- Existing logic already does not do the transforms when target frames are empty