### PR TITLE
Port patch #394 (imu2d-twist-transform-devel) into ROS2 Rolling

### DIFF
--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -289,7 +289,7 @@ void Imu2D::processDifferential(
         device_id_,
         *previous_pose_,
         *transformed_pose,
-        twist,
+        transformed_twist,
         params_.minimum_pose_relative_covariance,
         params_.twist_covariance_offset,
         params_.pose_loss,


### PR DESCRIPTION
Fix an error where we do not use the transformed_twist after computing it.