### PR TITLE
Use CXX_STANDARD 20 in all packages

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -131,7 +131,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -188,7 +188,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -214,7 +214,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_orientation_2d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -240,7 +240,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_orientation_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -266,7 +266,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_orientation_3d_stamped_euler_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -290,7 +290,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_pose_2d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -314,7 +314,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_fixed_3d_landmark_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -338,7 +338,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_absolute_pose_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -361,7 +361,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_marginal_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -384,7 +384,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_marginalize_variables
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -408,7 +408,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_normal_delta_pose_2d
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -432,7 +432,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_normal_prior_pose_2d
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -456,7 +456,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -480,7 +480,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_pose_2d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -504,7 +504,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_relative_pose_3d_stamped_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -523,7 +523,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_uuid_ordering
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -540,7 +540,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable_constraints
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -562,7 +562,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_normal_delta_pose_2d
         PROPERTIES
-          CXX_STANDARD 17
+          CXX_STANDARD 20
           CXX_STANDARD_REQUIRED YES
       )
     endif()
@@ -581,7 +581,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_normal_prior_pose_2d
         PROPERTIES
-          CXX_STANDARD 17
+          CXX_STANDARD 20
           CXX_STANDARD_REQUIRED YES
       )
     endif()

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -110,7 +110,7 @@ target_link_libraries(fuse_echo
 )
 set_target_properties(fuse_echo
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -171,7 +171,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_motion_model
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -197,7 +197,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_publisher
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -223,7 +223,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_async_sensor_model
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -248,7 +248,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_callback_wrapper
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -273,7 +273,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_constraint
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -298,7 +298,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_eigen
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -315,7 +315,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_local_parameterization
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -340,7 +340,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_loss
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -364,7 +364,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_message_buffer
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -389,7 +389,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_timestamp_manager
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -415,7 +415,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_transaction
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -440,7 +440,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_parameter
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -462,7 +462,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_throttled_callback
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -486,7 +486,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_util
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -511,7 +511,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_uuid
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -537,7 +537,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_core/test/test_variable.cpp
+++ b/fuse_core/test/test_variable.cpp
@@ -193,7 +193,7 @@ TEST(LegacyVariable, Deserialization)
   EXPECT_EQ(expected.data()[3], actual.data()[3]);
 
   // Test the manifold interface, and that the Legacy LocalParameterization is wrapped in a ManifoldAdapter
-  fuse_core::Manifold* actual_manifold;
+  fuse_core::Manifold* actual_manifold = nullptr;
   ASSERT_NO_THROW(actual_manifold = actual.manifold());
   ASSERT_NE(actual_manifold, nullptr);
   auto actual_manifold_adapter = dynamic_cast<fuse_core::ManifoldAdapter*>(actual_manifold);

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -136,7 +136,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_hash_graph
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -162,7 +162,7 @@ if(CATKIN_ENABLE_TESTING)
     )
     set_target_properties(benchmark_create_problem
       PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
     )
   endif()

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -126,7 +126,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_loss_function
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -150,7 +150,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_composed_loss
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -174,7 +174,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_huber_loss
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -198,7 +198,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_tukey_loss
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -230,7 +230,7 @@ if(CATKIN_ENABLE_TESTING)
     )
     set_target_properties(test_qwt_loss_plot
       PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
     )
 
@@ -260,7 +260,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_scaled_loss
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_models/CMakeLists.txt
+++ b/fuse_models/CMakeLists.txt
@@ -122,7 +122,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -173,7 +173,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -189,7 +189,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_predict
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -206,7 +206,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_state_cost_function
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -232,7 +232,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_graph_ignition
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -248,7 +248,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_unicycle_2d_ignition
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -263,7 +263,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_sensor_proc
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -284,7 +284,7 @@ if(CATKIN_ENABLE_TESTING)
       )
       set_target_properties(benchmark_unicycle_2d_state_cost_function
         PROPERTIES
-          CXX_STANDARD 17
+          CXX_STANDARD 20
           CXX_STANDARD_REQUIRED YES
       )
     endif()

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 #include <fuse_core/eigen_gtest.h>
+#include <fuse_core/ceres_macros.h>
 
 #include <ceres/autodiff_cost_function.h>
 #include <ceres/gradient_checker.h>
@@ -99,7 +100,15 @@ TEST(CostFunction, evaluateCostFunction)
 
   // Check jacobians are correct using a gradient checker
   ceres::NumericDiffOptions numeric_diff_options;
+#if !CERES_SUPPORTS_MANIFOLDS
   ceres::GradientChecker gradient_checker(&cost_function, nullptr, numeric_diff_options);
+#else
+  // ceres::GradientChecker is overloaded for ceres::LocalParameterization and ceres::Manifold before
+  // ceres::LocalParameterization support is deprecated. For that reason we cannot use nullptr. Otherwise the compiler
+  // cannot figure out which overloaded implementation to use
+  std::vector<const ceres::Manifold*>* manifolds = nullptr;
+  ceres::GradientChecker gradient_checker(&cost_function, manifolds, numeric_diff_options);
+#endif
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -79,7 +79,7 @@ target_link_libraries(batch_optimizer_node
 )
 set_target_properties(batch_optimizer_node
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -104,7 +104,7 @@ target_link_libraries(fixed_lag_smoother_node
 )
 set_target_properties(fixed_lag_smoother_node
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -166,7 +166,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_variable_stamp_index
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -193,7 +193,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_optimizer
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -228,7 +228,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_fixed_lag_ignition
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_publishers/CMakeLists.txt
+++ b/fuse_publishers/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -135,7 +135,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_path_2d_publisher
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -161,7 +161,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_pose_2d_publisher
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -185,7 +185,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_stamped_variable_synchronizer
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_tutorials/CMakeLists.txt
+++ b/fuse_tutorials/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -78,7 +78,7 @@ target_link_libraries(range_sensor_simulator
 )
 set_target_properties(range_sensor_simulator
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 
@@ -125,7 +125,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_angular_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -149,7 +149,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_angular_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -173,7 +173,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_linear_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -197,7 +197,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_acceleration_linear_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -221,7 +221,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_pinhole_camera
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -245,7 +245,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_pinhole_camera_fixed
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
   )
 
@@ -268,7 +268,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_fixed_size_variable
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -292,7 +292,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_load_device_id
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -316,7 +316,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_orientation_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -340,7 +340,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_orientation_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -364,7 +364,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_2d_fixed_landmark
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -388,7 +388,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_2d_landmark
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -412,7 +412,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_3d_fixed_landmark
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -436,7 +436,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_point_3d_landmark
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -460,7 +460,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_position_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -484,7 +484,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_position_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -508,7 +508,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_angular_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -532,7 +532,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_angular_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -556,7 +556,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_linear_2d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 
@@ -580,7 +580,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   set_target_properties(test_velocity_linear_3d_stamped
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
   )
 endif()

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -100,9 +100,14 @@ target_link_libraries(${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${QT_LIBRARIES}
 )
+# CXX_STANDARD 20 fails if rviz uses OGRE 1.10.11
+# ogre-1.10.11/include/OGRE/OgreMemorySTLAllocator.h:126:44:i
+# error: ‘const_pointer’ in ‘class std::allocator<void>’ does not name a type
+#   126 |             typename std::allocator<void>::const_pointer ptr = 0 )
+#       |                                            ^~~~~~~~~~~~~
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 20
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 

--- a/fuse_viz/CMakeLists.txt
+++ b/fuse_viz/CMakeLists.txt
@@ -102,7 +102,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
 


### PR DESCRIPTION
* Use `CXX_STANDARD 20` in all packages
* Fix `maybe-uninitialized`
* Use `CXX_STANDARD 17` for fuse_viz - `CXX_STANDARD 20` fails if `rviz` uses OGRE 1.10.11
    ```bash
    ogre-1.10.11/include/OGRE/OgreMemorySTLAllocator.h:126:44: error: ‘const_pointer’ in ‘class std::allocator<void>’ does not name a type
      126 |             typename std::allocator<void>::const_pointer ptr = 0 )
          |                                            ^~~~~~~~~~~~~
    ```
* Disambiguate GradientChecker overloaded ctor call

We've bumped to C++20 standard in our fork https://github.com/clearpathrobotics/fuse/pull/36

Sending this upstream in case you want to consider bumping to C++20 as well. Otherwise, feel free to close this PR.

I'm just trying to minimize the changes in our fork wrt upstream.