### PR TITLE
Removed deprecations warnings

### DIFF
--- a/fuse_models/include/fuse_models/common/sensor_proc.hpp
+++ b/fuse_models/include/fuse_models/common/sensor_proc.hpp
@@ -34,8 +34,8 @@
 #ifndef FUSE_MODELS__COMMON__SENSOR_PROC_HPP_
 #define FUSE_MODELS__COMMON__SENSOR_PROC_HPP_
 
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/fuse_models/src/unicycle_2d.cpp
+++ b/fuse_models/src/unicycle_2d.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <Eigen/Dense>
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <stdexcept>
 #include <string>

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <Eigen/Dense>
-#include <tf2/convert.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/convert.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <exception>
 #include <stdexcept>

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.hpp
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.hpp
@@ -34,7 +34,7 @@
 #ifndef FUSE_PUBLISHERS__POSE_2D_PUBLISHER_HPP_
 #define FUSE_PUBLISHERS__POSE_2D_PUBLISHER_HPP_
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <utility>

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <chrono>
 #include <exception>

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -38,7 +38,7 @@
 
 // Workaround ros2/geometry2#242
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/utils.h>  // NOLINT(build/include_order)
+#include <tf2/utils.hpp>  // NOLINT(build/include_order)
 
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.hpp>
 #include <fuse_core/eigen.hpp>

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -39,7 +39,7 @@
 
 // Workaround ros2/geometry2#242
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/utils.h>  // NOLINT(build/include_order)
+#include <tf2/utils.hpp>  // NOLINT(build/include_order)
 
 #include <fuse_constraints/absolute_pose_2d_stamped_constraint.hpp>
 #include <fuse_core/eigen.hpp>

--- a/fuse_viz/include/fuse_viz/conversions.hpp
+++ b/fuse_viz/include/fuse_viz/conversions.hpp
@@ -35,9 +35,9 @@
 #ifndef FUSE_VIZ__CONVERSIONS_HPP_
 #define FUSE_VIZ__CONVERSIONS_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <OgreColourValue.h>
 #include <OgreQuaternion.h>

--- a/fuse_viz/include/fuse_viz/pose_2d_stamped_visual.hpp
+++ b/fuse_viz/include/fuse_viz/pose_2d_stamped_visual.hpp
@@ -35,7 +35,7 @@
 #ifndef FUSE_VIZ__POSE_2D_STAMPED_VISUAL_HPP_
 #define FUSE_VIZ__POSE_2D_STAMPED_VISUAL_HPP_
 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 #include <Ogre.h>
 
 #include <memory>

--- a/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
+++ b/fuse_viz/src/relative_pose_2d_stamped_constraint_visual.cpp
@@ -42,7 +42,7 @@
 
 // Workaround ros2/geometry2#242
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/utils.h>  // NOLINT(build/include_order)
+#include <tf2/utils.hpp>  // NOLINT(build/include_order)
 
 #include <fuse_constraints/relative_pose_2d_stamped_constraint.hpp>
 #include <fuse_core/graph.hpp>


### PR DESCRIPTION
This headers were deprecated long time ago, and now are removed from `rolling`

Debs are broken 

 - https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__fuse_publishers__ubuntu_noble_amd64__binary/81/console
  - https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__fuse_viz__ubuntu_noble_amd64__binary/98/console

It will require a new release when this PR is merged