### PR TITLE
[RST-12952] Modified the loadDeviceId() function to accept optional parameters

### DIFF
--- a/fuse_variables/include/fuse_variables/stamped.hpp
+++ b/fuse_variables/include/fuse_variables/stamped.hpp
@@ -131,14 +131,17 @@ private:
  *
  * Will throw if the device_id parameter is not in an expected format.
  *
- * @param[in] interfaces  The node interfaces used to load parameters
+ * @param[in] interfaces  The node interfaces used to load parameters and write log messages
  * @param[in] uuid_parameter The parameter name that holds the device uuid to be loaded
  * @param[in] name_parameter The parameter name that holds the device name. The uuid will be generated from the name.
  * @param[in] silent If true, no ROS log warnings are generated
  * @return A device UUID
  */
 fuse_core::UUID loadDeviceId(
-  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces,
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Parameters,
+    fuse_core::node_interfaces::Logging
+  > interfaces,
   const std::string & uuid_parameter = "device_id",
   const std::string & name_parameter = "device_name",
   bool silent = true);

--- a/fuse_variables/include/fuse_variables/stamped.hpp
+++ b/fuse_variables/include/fuse_variables/stamped.hpp
@@ -34,13 +34,14 @@
 #ifndef FUSE_VARIABLES__STAMPED_HPP_
 #define FUSE_VARIABLES__STAMPED_HPP_
 
+#include <string>
+
+#include <boost/serialization/access.hpp>
+
 #include <fuse_core/fuse_macros.hpp>
 #include <fuse_core/serialization.hpp>
 #include <fuse_core/uuid.hpp>
 #include <fuse_core/node_interfaces/node_interfaces.hpp>
-
-#include <boost/serialization/access.hpp>
-
 #include <rclcpp/time.hpp>
 
 namespace fuse_variables
@@ -131,10 +132,16 @@ private:
  * Will throw if the device_id parameter is not in an expected format.
  *
  * @param[in] interfaces  The node interfaces used to load parameters
- * @return                A device UUID
+ * @param[in] uuid_parameter The parameter name that holds the device uuid to be loaded
+ * @param[in] name_parameter The parameter name that holds the device name. The uuid will be generated from the name.
+ * @param[in] silent If true, no ROS log warnings are generated
+ * @return A device UUID
  */
 fuse_core::UUID loadDeviceId(
-  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces);
+  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces,
+  const std::string & uuid_parameter = "device_id",
+  const std::string & name_parameter = "device_name",
+  bool silent = true);
 
 }  // namespace fuse_variables
 

--- a/fuse_variables/src/stamped.cpp
+++ b/fuse_variables/src/stamped.cpp
@@ -43,7 +43,10 @@ namespace fuse_variables
 {
 
 fuse_core::UUID loadDeviceId(
-  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces,
+  fuse_core::node_interfaces::NodeInterfaces<
+    fuse_core::node_interfaces::Parameters,
+    fuse_core::node_interfaces::Logging
+  > interfaces,
   const std::string & uuid_parameter,
   const std::string & name_parameter,
   bool silent)
@@ -62,7 +65,7 @@ fuse_core::UUID loadDeviceId(
 
   if (!silent) {
     RCLCPP_WARN_STREAM(
-      rclcpp::get_logger("fuse"),
+      interfaces.get_node_logging_interface()->get_logger(),
       "No " << uuid_parameter << " or " << name_parameter <<
         " parameter was provided on the parameter server.");
   }

--- a/fuse_variables/src/stamped.cpp
+++ b/fuse_variables/src/stamped.cpp
@@ -37,25 +37,35 @@
 #include <fuse_core/parameter.hpp>
 #include <fuse_core/uuid.hpp>
 #include <fuse_variables/stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace fuse_variables
 {
 
 fuse_core::UUID loadDeviceId(
-  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces)
+  fuse_core::node_interfaces::NodeInterfaces<fuse_core::node_interfaces::Parameters> interfaces,
+  const std::string & uuid_parameter,
+  const std::string & name_parameter,
+  bool silent)
 {
   std::string device_str;
 
-  device_str = fuse_core::getParam(interfaces, "device_id", std::string());
+  device_str = fuse_core::getParam(interfaces, uuid_parameter, std::string());
   if (!device_str.empty()) {
     return fuse_core::uuid::from_string(device_str);
   }
 
-  device_str = fuse_core::getParam(interfaces, "device_name", std::string());
+  device_str = fuse_core::getParam(interfaces, name_parameter, std::string());
   if (!device_str.empty()) {
     return fuse_core::uuid::generate(device_str);
   }
 
+  if (!silent) {
+    RCLCPP_WARN_STREAM(
+      rclcpp::get_logger("fuse"),
+      "No " << uuid_parameter << " or " << name_parameter <<
+        " parameter was provided on the parameter server.");
+  }
   return fuse_core::uuid::NIL;
 }
 


### PR DESCRIPTION
Modified the loadDeviceId() function to accept optional parameter names for the device UUID and device name