### PR TITLE
Work-around for a bug in Boost 1.90 any_range included in Ubuntu Resolute

### DIFF
--- a/fuse_core/include/fuse_core/graph.hpp
+++ b/fuse_core/include/fuse_core/graph.hpp
@@ -48,7 +48,10 @@
 #include <boost/core/demangle.hpp>
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
 // As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
-#include <boost/type_traits/add_const.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800 && BOOST_VERSION < 109000
+  #include <boost/type_traits/add_const.hpp>
+#endif
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/type_index/stl_type_index.hpp>

--- a/fuse_core/include/fuse_core/graph.hpp
+++ b/fuse_core/include/fuse_core/graph.hpp
@@ -47,7 +47,7 @@
 
 #include <boost/core/demangle.hpp>
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
-// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+// As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
 #include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>

--- a/fuse_core/include/fuse_core/graph.hpp
+++ b/fuse_core/include/fuse_core/graph.hpp
@@ -46,6 +46,9 @@
 #include <vector>
 
 #include <boost/core/demangle.hpp>
+// Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
+// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+#include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/type_index/stl_type_index.hpp>

--- a/fuse_core/include/fuse_core/message_buffer.hpp
+++ b/fuse_core/include/fuse_core/message_buffer.hpp
@@ -39,7 +39,10 @@
 
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
 // As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
-#include <boost/type_traits/add_const.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800 && BOOST_VERSION < 109000
+  #include <boost/type_traits/add_const.hpp>
+#endif
 #include <boost/range/any_range.hpp>
 #include <fuse_core/fuse_macros.hpp>
 #include <rclcpp/duration.hpp>

--- a/fuse_core/include/fuse_core/message_buffer.hpp
+++ b/fuse_core/include/fuse_core/message_buffer.hpp
@@ -37,6 +37,9 @@
 #include <deque>
 #include <utility>
 
+// Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
+// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+#include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <fuse_core/fuse_macros.hpp>
 #include <rclcpp/duration.hpp>

--- a/fuse_core/include/fuse_core/message_buffer.hpp
+++ b/fuse_core/include/fuse_core/message_buffer.hpp
@@ -38,7 +38,7 @@
 #include <utility>
 
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
-// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+// As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
 #include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <fuse_core/fuse_macros.hpp>

--- a/fuse_core/include/fuse_core/timestamp_manager.hpp
+++ b/fuse_core/include/fuse_core/timestamp_manager.hpp
@@ -39,7 +39,7 @@
 #include <vector>
 
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
-// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+// As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
 #include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <fuse_core/constraint.hpp>

--- a/fuse_core/include/fuse_core/timestamp_manager.hpp
+++ b/fuse_core/include/fuse_core/timestamp_manager.hpp
@@ -40,7 +40,10 @@
 
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
 // As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
-#include <boost/type_traits/add_const.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800 && BOOST_VERSION < 109000
+  #include <boost/type_traits/add_const.hpp>
+#endif
 #include <boost/range/any_range.hpp>
 #include <fuse_core/constraint.hpp>
 #include <fuse_core/fuse_macros.hpp>

--- a/fuse_core/include/fuse_core/timestamp_manager.hpp
+++ b/fuse_core/include/fuse_core/timestamp_manager.hpp
@@ -38,6 +38,9 @@
 #include <map>
 #include <vector>
 
+// Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
+// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+#include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <fuse_core/constraint.hpp>
 #include <fuse_core/fuse_macros.hpp>

--- a/fuse_core/include/fuse_core/transaction.hpp
+++ b/fuse_core/include/fuse_core/transaction.hpp
@@ -42,7 +42,10 @@
 #include <boost/archive/binary_oarchive.hpp>
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
 // As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
-#include <boost/type_traits/add_const.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800 && BOOST_VERSION < 109000
+  #include <boost/type_traits/add_const.hpp>
+#endif
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/set.hpp>

--- a/fuse_core/include/fuse_core/transaction.hpp
+++ b/fuse_core/include/fuse_core/transaction.hpp
@@ -41,7 +41,7 @@
 
 #include <boost/archive/binary_oarchive.hpp>
 // Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
-// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+// As a workaround, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
 #include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>

--- a/fuse_core/include/fuse_core/transaction.hpp
+++ b/fuse_core/include/fuse_core/transaction.hpp
@@ -40,6 +40,9 @@
 #include <vector>
 
 #include <boost/archive/binary_oarchive.hpp>
+// Bugfix for Boost 1.88 - 1.90. See https://github.com/boostorg/range/pull/157.
+// As a work around, include the add_const.hpp header before any_range.hpp or any_iterator.hpp
+#include <boost/type_traits/add_const.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/set.hpp>


### PR DESCRIPTION
Work-around for a bug in Boost 1.88 - 1.90. Ubuntu Resolute uses Boost 1.90, which affects ROS 2 Lyrical and ROS 2 Rolling.
See https://github.com/boostorg/range/pull/157 for details of the bug.
Basically Boost is missing a header include.
The work-around is to include that header before including `any_range.hpp` or `any_iterator.hpp`.
Aside from being ugly and a nuisance, it does not harm anything on earlier version of Boost. That header was being included anyway.

I could do something like this, if that feels better:
```
#include <boost/version.hpp>
#if BOOST_VERSION >= 108800 && BOOST_VERSION < 109000
  #include <boost/type_traits/add_const.hpp>
#endif
```